### PR TITLE
Feature/testresult refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     * [global options](#global-options)
       * [-f gossfile](#-f-gossfile)
     * [validate, v - Validate the system](#validate-v---validate-the-system)
+      * [Flags](#flags)
     * [add, a - Add system resource to test suite](#add-a---add-system-resource-to-test-suite)
       * [package - Add a package](#package---add-a-package)
         * [Attributes](#attributes)
@@ -160,6 +161,10 @@ $ cat goss.json | goss validate
 $ goss render | ssh remote-host 'goss validate'
 $ curl -s https://static/or/dynamic/goss.json | goss validate
 ```
+
+#### Flags
+* --format (output format)
+* --no-color (disable color)
 
 ### autoadd, aa - Auto add all matching resources to test suite
 automatically adds all **existing** resources matching the provided argument.

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aelsabbahy/goss"
+	"github.com/aelsabbahy/goss/outputs"
 	"github.com/codegangsta/cli"
 	//"time"
 )
@@ -34,6 +35,19 @@ func main() {
 			Name:    "validate",
 			Aliases: []string{"v"},
 			Usage:   "Validate system",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:   "format, f",
+					Value:  "rspecish",
+					Usage:  fmt.Sprintf("Format to output in, valid options: %s", outputs.Outputers()),
+					EnvVar: "GOSS_FMT",
+				},
+				cli.BoolFlag{
+					Name:   "no-color",
+					Usage:  "Force color off",
+					EnvVar: "GOSS_COLOR",
+				},
+			},
 			Action: func(c *cli.Context) {
 				goss.Run(c.GlobalString("gossfile"), c)
 			},

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -45,7 +45,7 @@ func main() {
 				cli.BoolFlag{
 					Name:   "no-color",
 					Usage:  "Force color off",
-					EnvVar: "GOSS_COLOR",
+					EnvVar: "GOSS_NOCOLOR",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,5 +12,3 @@ import:
     ref:     9bb9dbf0e53309fa81d26e7230cbb6cff9373cad
   - package: github.com/fatih/color
     ref:     76d423163af754ff6423d2d9be0057fbf03c57c2
-  - package: github.com/mattn/go-isatty
-    ref:     7fcbc72f853b92b5720db4a6b8482be612daef24

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,3 +14,5 @@ import:
     ref:     76d423163af754ff6423d2d9be0057fbf03c57c2
   - package: github.com/mattn/go-isatty
     ref:     7fcbc72f853b92b5720db4a6b8482be612daef24
+  - package: github.com/shiena/ansicolor
+    ref:     d445752f6f66f9cd987722f109149f6799cdf1de

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,3 +10,7 @@ import:
     ref:     a65b733b303f0055f8d324d805f393cd3e7a7904
   - package: github.com/godbus/dbus
     ref:     9bb9dbf0e53309fa81d26e7230cbb6cff9373cad
+  - package: github.com/fatih/color
+    ref:     76d423163af754ff6423d2d9be0057fbf03c57c2
+  - package: github.com/mattn/go-isatty
+    ref:     7fcbc72f853b92b5720db4a6b8482be612daef24

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,5 +12,5 @@ import:
     ref:     9bb9dbf0e53309fa81d26e7230cbb6cff9373cad
   - package: github.com/fatih/color
     ref:     76d423163af754ff6423d2d9be0057fbf03c57c2
--  - package: github.com/mattn/go-isatty
--    ref:     7fcbc72f853b92b5720db4a6b8482be612daef24
+  - package: github.com/mattn/go-isatty
+    ref:     7fcbc72f853b92b5720db4a6b8482be612daef24

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,3 +12,5 @@ import:
     ref:     9bb9dbf0e53309fa81d26e7230cbb6cff9373cad
   - package: github.com/fatih/color
     ref:     76d423163af754ff6423d2d9be0057fbf03c57c2
+-  - package: github.com/mattn/go-isatty
+-    ref:     7fcbc72f853b92b5720db4a6b8482be612daef24

--- a/json.go
+++ b/json.go
@@ -310,15 +310,11 @@ func AutoAppendResource(fileName, key string, c *cli.Context) error {
 	return nil
 }
 
-type IDer interface {
-	ID() string
-}
+func resourcePrint(fileName string, res resource.IDer) {
+	resMap := map[string]resource.IDer{res.ID(): res}
 
-func resourcePrint(fileName string, resource IDer) {
-	res := map[string]IDer{resource.ID(): resource}
-
-	oj, _ := json.MarshalIndent(res, "", "    ")
-	typ := reflect.TypeOf(resource)
+	oj, _ := json.MarshalIndent(resMap, "", "    ")
+	typ := reflect.TypeOf(res)
 	typs := strings.Split(typ.String(), ".")[1]
 
 	fmt.Printf("Adding %s to '%s':\n\n%s\n\n", typs, fileName, string(oj))

--- a/outputs/documentation.go
+++ b/outputs/documentation.go
@@ -34,10 +34,10 @@ func (r Documentation) Output(results <-chan []resource.TestResult) (hasFail boo
 	}
 
 	if len(failed) > 0 {
-		color.Red("\n\nCount: %d failed: %d\n", testCount, len(failed))
+		color.Red("\nCount: %d failed: %d\n", testCount, len(failed))
 		return true
 	}
-	color.Green("\n\nCount: %d failed: %d\n", testCount, len(failed))
+	color.Green("\nCount: %d failed: %d\n", testCount, len(failed))
 	return false
 }
 

--- a/outputs/documentation.go
+++ b/outputs/documentation.go
@@ -7,13 +7,7 @@ import (
 	"github.com/fatih/color"
 )
 
-type Documentation struct {
-	color bool
-}
-
-func (d *Documentation) SetColor(t bool) {
-	d.color = t
-}
+type Documentation struct{}
 
 func (r Documentation) Output(results <-chan []resource.TestResult) (hasFail bool) {
 	testCount := 0
@@ -21,10 +15,10 @@ func (r Documentation) Output(results <-chan []resource.TestResult) (hasFail boo
 	for resultGroup := range results {
 		for _, testResult := range resultGroup {
 			if testResult.Result {
-				color.Green(humanizeResult(testResult))
+				fmt.Println(humanizeResult(testResult))
 				testCount++
 			} else {
-				color.Red(humanizeResult(testResult))
+				fmt.Println(humanizeResult(testResult))
 				failed = append(failed, testResult)
 				testCount++
 			}
@@ -35,7 +29,7 @@ func (r Documentation) Output(results <-chan []resource.TestResult) (hasFail boo
 	if len(failed) > 0 {
 		color.Red("\nFailures:")
 		for _, testResult := range failed {
-			color.Red(humanizeResult(testResult))
+			fmt.Println(humanizeResult(testResult))
 		}
 	}
 

--- a/outputs/documentation.go
+++ b/outputs/documentation.go
@@ -1,6 +1,8 @@
 package outputs
 
 import (
+	"fmt"
+
 	"github.com/aelsabbahy/goss/resource"
 	"github.com/fatih/color"
 )
@@ -13,34 +15,27 @@ func (d *Documentation) SetColor(t bool) {
 	d.color = t
 }
 
-func (r Documentation) Output(results <-chan resource.TestResult) (hasFail bool) {
+func (r Documentation) Output(results <-chan []resource.TestResult) (hasFail bool) {
 	testCount := 0
 	var failed []resource.TestResult
-	//var lastSeen string
-	for testResult := range results {
-		// Not sure if I want this or not
-		//seenKey := fmt.Sprintf("%s-%s", testResult.ResourceType, testResult.Title)
-		//if lastSeen != seenKey {
-		//	fmt.Println("")
-		//}
-		//lastSeen = seenKey
-
-		//fmt.Printf("%v: %s.\n", testResult.Duration, testResult.Desc)
-		if testResult.Result {
-			color.Green(humanizeResult(testResult))
-			testCount++
-		} else {
-			color.Red(humanizeResult(testResult))
-			failed = append(failed, testResult)
-			testCount++
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			if testResult.Result {
+				color.Green(humanizeResult(testResult))
+				testCount++
+			} else {
+				color.Red(humanizeResult(testResult))
+				failed = append(failed, testResult)
+				testCount++
+			}
 		}
+		fmt.Println("")
 	}
 
 	if len(failed) > 0 {
-		color.Red("\n\nFailures:")
+		color.Red("\nFailures:")
 		for _, testResult := range failed {
 			color.Red(humanizeResult(testResult))
-			//fmt.Printf("\n%s\n", testResult.Desc)
 		}
 	}
 

--- a/outputs/documentation.go
+++ b/outputs/documentation.go
@@ -5,25 +5,32 @@ import (
 	"github.com/fatih/color"
 )
 
-type Rspecish struct {
+type Documentation struct {
 	color bool
 }
 
-func (r *Rspecish) SetColor(t bool) {
-	r.color = t
+func (d *Documentation) SetColor(t bool) {
+	d.color = t
 }
 
-func (r Rspecish) Output(results <-chan resource.TestResult) (hasFail bool) {
-	green := color.New(color.FgGreen).PrintfFunc()
-	red := color.New(color.FgRed).PrintfFunc()
+func (r Documentation) Output(results <-chan resource.TestResult) (hasFail bool) {
 	testCount := 0
 	var failed []resource.TestResult
+	//var lastSeen string
 	for testResult := range results {
+		// Not sure if I want this or not
+		//seenKey := fmt.Sprintf("%s-%s", testResult.ResourceType, testResult.Title)
+		//if lastSeen != seenKey {
+		//	fmt.Println("")
+		//}
+		//lastSeen = seenKey
+
+		//fmt.Printf("%v: %s.\n", testResult.Duration, testResult.Desc)
 		if testResult.Result {
-			green(".")
+			color.Green(humanizeResult(testResult))
 			testCount++
 		} else {
-			red("F")
+			color.Red(humanizeResult(testResult))
 			failed = append(failed, testResult)
 			testCount++
 		}
@@ -33,6 +40,7 @@ func (r Rspecish) Output(results <-chan resource.TestResult) (hasFail bool) {
 		color.Red("\n\nFailures:")
 		for _, testResult := range failed {
 			color.Red(humanizeResult(testResult))
+			//fmt.Printf("\n%s\n", testResult.Desc)
 		}
 	}
 
@@ -45,5 +53,5 @@ func (r Rspecish) Output(results <-chan resource.TestResult) (hasFail bool) {
 }
 
 func init() {
-	RegisterOutputer("rspecish", &Rspecish{})
+	RegisterOutputer("documentation", &Documentation{})
 }

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Outputer interface {
-	Output(<-chan resource.TestResult) bool
+	Output(<-chan []resource.TestResult) bool
 	SetColor(bool)
 }
 

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -1,0 +1,83 @@
+package outputs
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/aelsabbahy/goss/resource"
+)
+
+type Outputer interface {
+	Output(<-chan resource.TestResult) bool
+	SetColor(bool)
+}
+
+func humanizeResult(r resource.TestResult) string {
+	if r.Err != nil {
+		return fmt.Sprintf("%s: %s: Error: %s", r.Title, r.Property, r.Err)
+	}
+	switch r.TestType {
+	case resource.Values:
+		if r.Result {
+			return fmt.Sprintf("%s: %s: %s: matches", r.ResourceType, r.Title, r.Property)
+		} else {
+			return fmt.Sprintf("%s: %s: %s: [%s] not in: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "), strings.Join(r.Found, ", "))
+		}
+	case resource.Value:
+		if r.Result {
+			return fmt.Sprintf("%s: %s: %s: matches expectation: %s", r.ResourceType, r.Title, r.Property, r.Expected)
+		} else {
+			return fmt.Sprintf("%s: %s: %s: doesn't match, expect: %s found: %s", r.ResourceType, r.Title, r.Property, r.Expected, r.Found)
+		}
+	case resource.Contains:
+		if r.Result {
+			return fmt.Sprintf("%s: %s: %s: all patterns found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+		} else {
+			return fmt.Sprintf("%s: %s: %s: patterns not found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+		}
+	default:
+		return fmt.Sprintf("Unexpected type %d", r.TestType)
+	}
+}
+
+// Copied from database/sql
+var (
+	outputersMu sync.Mutex
+	outputers   = make(map[string]Outputer)
+)
+
+func RegisterOutputer(name string, outputer Outputer) {
+	outputersMu.Lock()
+	defer outputersMu.Unlock()
+
+	if outputer == nil {
+		panic("goss: Register outputer is nil")
+	}
+	if _, dup := outputers[name]; dup {
+		panic("goss: Register called twice for ouputer " + name)
+	}
+	outputers[name] = outputer
+}
+
+// Outputers returns a sorted list of the names of the registered outputers.
+func Outputers() []string {
+	outputersMu.Lock()
+	defer outputersMu.Unlock()
+	var list []string
+	for name := range outputers {
+		list = append(list, name)
+	}
+	sort.Strings(list)
+	return list
+}
+
+func GetOutputer(name string) Outputer {
+	if _, ok := outputers[name]; !ok {
+		fmt.Println("goss: Bad output format: " + name)
+		os.Exit(1)
+	}
+	return outputers[name]
+}

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -8,38 +8,42 @@ import (
 	"sync"
 
 	"github.com/aelsabbahy/goss/resource"
+	"github.com/fatih/color"
 )
 
 type Outputer interface {
 	Output(<-chan []resource.TestResult) bool
-	SetColor(bool)
 }
+
+var green = color.New(color.FgGreen).SprintfFunc()
+var red = color.New(color.FgRed).SprintfFunc()
 
 func humanizeResult(r resource.TestResult) string {
 	if r.Err != nil {
 		return fmt.Sprintf("%s: %s: Error: %s", r.Title, r.Property, r.Err)
 	}
+
 	switch r.TestType {
 	case resource.Value:
 		if r.Result {
-			return fmt.Sprintf("%s: %s: %s: matches expectation: %s", r.ResourceType, r.Title, r.Property, r.Expected)
+			return green("%s: %s: %s: matches expectation: %s", r.ResourceType, r.Title, r.Property, r.Expected)
 		} else {
-			return fmt.Sprintf("%s: %s: %s: doesn't match, expect: %s found: %s", r.ResourceType, r.Title, r.Property, r.Expected, r.Found)
+			return red("%s: %s: %s: doesn't match, expect: %s found: %s", r.ResourceType, r.Title, r.Property, r.Expected, r.Found)
 		}
 	case resource.Values:
 		if r.Result {
-			return fmt.Sprintf("%s: %s: %s: all expectations found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+			return green("%s: %s: %s: all expectations found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
 		} else {
-			return fmt.Sprintf("%s: %s: %s: expectations not found [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+			return red("%s: %s: %s: expectations not found [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
 		}
 	case resource.Contains:
 		if r.Result {
-			return fmt.Sprintf("%s: %s: %s: all patterns found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+			return green("%s: %s: %s: all patterns found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
 		} else {
-			return fmt.Sprintf("%s: %s: %s: patterns not found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+			return red("%s: %s: %s: patterns not found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
 		}
 	default:
-		return fmt.Sprintf("Unexpected type %d", r.TestType)
+		return red("Unexpected type %d", r.TestType)
 	}
 }
 

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -20,17 +20,17 @@ func humanizeResult(r resource.TestResult) string {
 		return fmt.Sprintf("%s: %s: Error: %s", r.Title, r.Property, r.Err)
 	}
 	switch r.TestType {
-	case resource.Values:
-		if r.Result {
-			return fmt.Sprintf("%s: %s: %s: matches", r.ResourceType, r.Title, r.Property)
-		} else {
-			return fmt.Sprintf("%s: %s: %s: [%s] not in: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "), strings.Join(r.Found, ", "))
-		}
 	case resource.Value:
 		if r.Result {
 			return fmt.Sprintf("%s: %s: %s: matches expectation: %s", r.ResourceType, r.Title, r.Property, r.Expected)
 		} else {
 			return fmt.Sprintf("%s: %s: %s: doesn't match, expect: %s found: %s", r.ResourceType, r.Title, r.Property, r.Expected, r.Found)
+		}
+	case resource.Values:
+		if r.Result {
+			return fmt.Sprintf("%s: %s: %s: all expectations found: [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
+		} else {
+			return fmt.Sprintf("%s: %s: %s: expectations not found [%s]", r.ResourceType, r.Title, r.Property, strings.Join(r.Expected, ", "))
 		}
 	case resource.Contains:
 		if r.Result {

--- a/outputs/rspecish.go
+++ b/outputs/rspecish.go
@@ -2,33 +2,43 @@ package outputs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aelsabbahy/goss/resource"
+	"github.com/codegangsta/cli"
 )
 
 type Outputer interface {
-	Output(<-chan resource.TestResult) bool
+	Output(<-chan resource.TestResult, *cli.Context) bool
 }
 
 type Rspecish struct{}
 
-func (r Rspecish) Output(results <-chan resource.TestResult) (hasFail bool) {
+func (r Rspecish) Output(results <-chan resource.TestResult, c *cli.Context) (hasFail bool) {
 	testCount := 0
 	var failed []resource.TestResult
 	for testResult := range results {
 		//fmt.Printf("%v: %s.\n", testResult.Duration, testResult.Desc)
 		if testResult.Result {
-			fmt.Printf(".")
+			//fmt.Printf(".")
+			fmt.Println(rspecishFmtResult(testResult))
+			//fmt.Printf("\n%s\n", testResult.Desc)
 			testCount++
 		} else {
-			fmt.Printf("F")
+			//fmt.Printf("F")
+			fmt.Println(rspecishFmtResult(testResult))
+			//fmt.Printf("\n%s\n", testResult.Desc)
 			failed = append(failed, testResult)
 			testCount++
 		}
 	}
 
-	for _, testResult := range failed {
-		fmt.Printf("\n%s\n", testResult.Desc)
+	if len(failed) > 0 {
+		fmt.Println("\n\nFailures:")
+		for _, testResult := range failed {
+			fmt.Println(rspecishFmtResult(testResult))
+			//fmt.Printf("\n%s\n", testResult.Desc)
+		}
 	}
 
 	fmt.Printf("\n\nCount: %d failed: %d\n", testCount, len(failed))
@@ -36,4 +46,32 @@ func (r Rspecish) Output(results <-chan resource.TestResult) (hasFail bool) {
 		return true
 	}
 	return false
+}
+
+func rspecishFmtResult(r resource.TestResult) string {
+	if r.Err != nil {
+		return fmt.Sprintf("%s: %s: Error: %s", r.Title, r.Property, r.Err)
+	}
+	switch r.Type {
+	case resource.Values:
+		if r.Result {
+			return fmt.Sprintf("%s: %s matches", r.Title, r.Property)
+		} else {
+			return fmt.Sprintf("%s: %s: [%s] not in: [%s]", r.Title, r.Property, strings.Join(r.Expected, ", "), strings.Join(r.Found, ", "))
+		}
+	case resource.Value:
+		if r.Result {
+			return fmt.Sprintf("%s: %s matches", r.Title, r.Property)
+		} else {
+			return fmt.Sprintf("%s: %s: [%s] not in: [%s]", r.Title, r.Property, strings.Join(r.Expected, ", "), strings.Join(r.Found, ", "))
+		}
+	case resource.Contains:
+		if r.Result {
+			return fmt.Sprintf("%s: %s matches", r.Title, r.Property)
+		} else {
+			return fmt.Sprintf("%s: %s: doesn't match, expect: [%s] found: [%s]", r.Title, r.Property, strings.Join(r.Expected, ", "), strings.Join(r.Found, ", "))
+		}
+	default:
+		return fmt.Sprintf("Unexpected type %d", r.Type)
+	}
 }

--- a/outputs/rspecish.go
+++ b/outputs/rspecish.go
@@ -13,19 +13,21 @@ func (r *Rspecish) SetColor(t bool) {
 	r.color = t
 }
 
-func (r Rspecish) Output(results <-chan resource.TestResult) (hasFail bool) {
+func (r Rspecish) Output(results <-chan []resource.TestResult) (hasFail bool) {
 	green := color.New(color.FgGreen).PrintfFunc()
 	red := color.New(color.FgRed).PrintfFunc()
 	testCount := 0
 	var failed []resource.TestResult
-	for testResult := range results {
-		if testResult.Result {
-			green(".")
-			testCount++
-		} else {
-			red("F")
-			failed = append(failed, testResult)
-			testCount++
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			if testResult.Result {
+				green(".")
+				testCount++
+			} else {
+				red("F")
+				failed = append(failed, testResult)
+				testCount++
+			}
 		}
 	}
 

--- a/outputs/rspecish.go
+++ b/outputs/rspecish.go
@@ -1,30 +1,24 @@
 package outputs
 
 import (
+	"fmt"
+
 	"github.com/aelsabbahy/goss/resource"
 	"github.com/fatih/color"
 )
 
-type Rspecish struct {
-	color bool
-}
-
-func (r *Rspecish) SetColor(t bool) {
-	r.color = t
-}
+type Rspecish struct{}
 
 func (r Rspecish) Output(results <-chan []resource.TestResult) (hasFail bool) {
-	green := color.New(color.FgGreen).PrintfFunc()
-	red := color.New(color.FgRed).PrintfFunc()
 	testCount := 0
 	var failed []resource.TestResult
 	for resultGroup := range results {
 		for _, testResult := range resultGroup {
 			if testResult.Result {
-				green(".")
+				fmt.Printf(green("."))
 				testCount++
 			} else {
-				red("F")
+				fmt.Printf(red("F"))
 				failed = append(failed, testResult)
 				testCount++
 			}
@@ -34,7 +28,7 @@ func (r Rspecish) Output(results <-chan []resource.TestResult) (hasFail bool) {
 	if len(failed) > 0 {
 		color.Red("\n\nFailures:")
 		for _, testResult := range failed {
-			color.Red(humanizeResult(testResult))
+			humanizeResult(testResult)
 		}
 	}
 

--- a/resource/addr.go
+++ b/resource/addr.go
@@ -17,7 +17,7 @@ func (h *Addr) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(h.ID(), "reachable", h.Reachable, sysAddr.Reachable))
+	results = append(results, ValidateValue(h, "reachable", h.Reachable, sysAddr.Reachable))
 
 	return results
 }

--- a/resource/command.go
+++ b/resource/command.go
@@ -23,12 +23,12 @@ func (c *Command) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(c.ID(), "exit-status", c.ExitStatus, syscommand.ExitStatus))
+	results = append(results, ValidateValue(c, "exit-status", c.ExitStatus, syscommand.ExitStatus))
 	if len(c.Stdout) > 0 {
-		results = append(results, ValidateContains(c.ID(), "stdout", c.Stdout, syscommand.Stdout))
+		results = append(results, ValidateContains(c, "stdout", c.Stdout, syscommand.Stdout))
 	}
 	if len(c.Stderr) > 0 {
-		results = append(results, ValidateContains(c.ID(), "stderr", c.Stderr, syscommand.Stderr))
+		results = append(results, ValidateContains(c, "stderr", c.Stderr, syscommand.Stderr))
 	}
 
 	return results

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -18,11 +18,11 @@ func (d *DNS) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(d.ID(), "resolveable", d.Resolveable, sysDNS.Resolveable))
+	results = append(results, ValidateValue(d, "resolveable", d.Resolveable, sysDNS.Resolveable))
 	if !d.Resolveable {
 		return results
 	}
-	results = append(results, ValidateValues(d.ID(), "addrs", d.Addrs, sysDNS.Addrs))
+	results = append(results, ValidateValues(d, "addrs", d.Addrs, sysDNS.Addrs))
 
 	return results
 }

--- a/resource/file.go
+++ b/resource/file.go
@@ -21,33 +21,33 @@ func (f *File) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(f.ID(), "exists", f.Exists, sysFile.Exists))
+	results = append(results, ValidateValue(f, "exists", f.Exists, sysFile.Exists))
 	if !f.Exists {
 		return results
 	}
 
 	if f.Mode != "" {
-		results = append(results, ValidateValue(f.ID(), "mode", f.Mode, sysFile.Mode))
+		results = append(results, ValidateValue(f, "mode", f.Mode, sysFile.Mode))
 	}
 
 	if f.Owner != "" {
-		results = append(results, ValidateValue(f.ID(), "owner", f.Owner, sysFile.Owner))
+		results = append(results, ValidateValue(f, "owner", f.Owner, sysFile.Owner))
 	}
 
 	if f.Group != "" {
-		results = append(results, ValidateValue(f.ID(), "group", f.Group, sysFile.Group))
+		results = append(results, ValidateValue(f, "group", f.Group, sysFile.Group))
 	}
 
 	if f.LinkedTo != "" {
-		results = append(results, ValidateValue(f.ID(), "linkedto", f.LinkedTo, sysFile.LinkedTo))
+		results = append(results, ValidateValue(f, "linkedto", f.LinkedTo, sysFile.LinkedTo))
 	}
 
 	if f.Filetype != "" {
-		results = append(results, ValidateValue(f.ID(), "filetype", f.Filetype, sysFile.Filetype))
+		results = append(results, ValidateValue(f, "filetype", f.Filetype, sysFile.Filetype))
 	}
 
 	if len(f.Contains) != 0 {
-		results = append(results, ValidateContains(f.ID(), "contains", f.Contains, sysFile.Contains))
+		results = append(results, ValidateContains(f, "contains", f.Contains, sysFile.Contains))
 	}
 
 	return results

--- a/resource/group.go
+++ b/resource/group.go
@@ -16,11 +16,11 @@ func (g *Group) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(g.ID(), "exists", g.Exists, sysgroup.Exists))
+	results = append(results, ValidateValue(g, "exists", g.Exists, sysgroup.Exists))
 	if !g.Exists {
 		return results
 	}
-	results = append(results, ValidateValue(g.ID(), "gid", g.Gid, sysgroup.Gid))
+	results = append(results, ValidateValue(g, "gid", g.Gid, sysgroup.Gid))
 
 	return results
 }

--- a/resource/package.go
+++ b/resource/package.go
@@ -16,11 +16,11 @@ func (p *Package) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(p.ID(), "installed", p.Installed, sysPkg.Installed))
+	results = append(results, ValidateValue(p, "installed", p.Installed, sysPkg.Installed))
 	if !p.Installed {
 		return results
 	}
-	results = append(results, ValidateValues(p.ID(), "version", p.Versions, sysPkg.Versions))
+	results = append(results, ValidateValues(p, "version", p.Versions, sysPkg.Versions))
 
 	return results
 }

--- a/resource/port.go
+++ b/resource/port.go
@@ -16,11 +16,11 @@ func (p *Port) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(p.ID(), "listening", p.Listening, sysPort.Listening))
+	results = append(results, ValidateValue(p, "listening", p.Listening, sysPort.Listening))
 	if !p.Listening {
 		return results
 	}
-	results = append(results, ValidateValue(p.ID(), "ip", p.IP, sysPort.IP))
+	results = append(results, ValidateValue(p, "ip", p.IP, sysPort.IP))
 
 	return results
 }

--- a/resource/process.go
+++ b/resource/process.go
@@ -15,7 +15,7 @@ func (p *Process) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(p.ID(), "running", p.Running, sysProcess.Running))
+	results = append(results, ValidateValue(p, "running", p.Running, sysProcess.Running))
 
 	return results
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -6,3 +6,7 @@ type Resource interface {
 	Validate(*system.System) []TestResult
 	SetID(string)
 }
+
+type IDer interface {
+	ID() string
+}

--- a/resource/service.go
+++ b/resource/service.go
@@ -16,8 +16,8 @@ func (s *Service) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(s.ID(), "enabled", s.Enabled, sysservice.Enabled))
-	results = append(results, ValidateValue(s.ID(), "running", s.Running, sysservice.Running))
+	results = append(results, ValidateValue(s, "enabled", s.Enabled, sysservice.Enabled))
+	results = append(results, ValidateValue(s, "running", s.Running, sysservice.Running))
 
 	return results
 }

--- a/resource/user.go
+++ b/resource/user.go
@@ -19,14 +19,14 @@ func (u *User) Validate(sys *system.System) []TestResult {
 
 	var results []TestResult
 
-	results = append(results, ValidateValue(u.ID(), "exists", u.Exists, sysuser.Exists))
+	results = append(results, ValidateValue(u, "exists", u.Exists, sysuser.Exists))
 	if !u.Exists {
 		return results
 	}
-	results = append(results, ValidateValue(u.ID(), "uid", u.UID, sysuser.UID))
-	results = append(results, ValidateValue(u.ID(), "gid", u.GID, sysuser.GID))
-	results = append(results, ValidateValue(u.ID(), "home", u.Home, sysuser.Home))
-	results = append(results, ValidateValues(u.ID(), "groups", u.Groups, sysuser.Groups))
+	results = append(results, ValidateValue(u, "uid", u.UID, sysuser.UID))
+	results = append(results, ValidateValue(u, "gid", u.GID, sysuser.GID))
+	results = append(results, ValidateValue(u, "home", u.Home, sysuser.Home))
+	results = append(results, ValidateValues(u, "groups", u.Groups, sysuser.Groups))
 
 	return results
 }

--- a/resource/validate.go
+++ b/resource/validate.go
@@ -42,8 +42,7 @@ func ValidateValues(res IDer, property string, expectedValues []string, method f
 			Title:        title,
 			Property:     property,
 			Err:          err,
-			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 	set := make(map[string]bool)
@@ -67,8 +66,7 @@ func ValidateValues(res IDer, property string, expectedValues []string, method f
 			Property:     property,
 			Expected:     bad,
 			Found:        foundValues,
-			//Desc:     fmt.Sprintf("%s: %s: [%s] not in: [%s]", title, property, strings.Join(bad, ", "), strings.Join(foundValues, ", ")),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 	return TestResult{
@@ -79,8 +77,7 @@ func ValidateValues(res IDer, property string, expectedValues []string, method f
 		Property:     property,
 		Expected:     expectedValues,
 		Found:        foundValues,
-		//Desc:     fmt.Sprintf("%s: %s matches", title, property),
-		Duration: time.Now().Sub(startTime),
+		Duration:     time.Now().Sub(startTime),
 	}
 
 }
@@ -99,8 +96,7 @@ func ValidateValue(res IDer, property string, expectedValue interface{}, method 
 			Title:        title,
 			Property:     property,
 			Err:          err,
-			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 
@@ -113,8 +109,7 @@ func ValidateValue(res IDer, property string, expectedValue interface{}, method 
 			Property:     property,
 			Expected:     []string{interfaceToString(expectedValue)},
 			Found:        []string{interfaceToString(foundValue)},
-			//Desc:     fmt.Sprintf("%s: %s matches", title, property),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 
@@ -126,8 +121,7 @@ func ValidateValue(res IDer, property string, expectedValue interface{}, method 
 		Property:     property,
 		Expected:     []string{interfaceToString(expectedValue)},
 		Found:        []string{interfaceToString(foundValue)},
-		//Desc:     fmt.Sprintf("%s: %s doesn't match, expect: %v found: %v", title, property, expectedValue, foundValue),
-		Duration: time.Now().Sub(startTime),
+		Duration:     time.Now().Sub(startTime),
 	}
 }
 
@@ -240,8 +234,7 @@ func ValidateContains(res IDer, property string, expectedValues []string, method
 			Title:        title,
 			Property:     property,
 			Err:          err,
-			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 	scanner := bufio.NewScanner(fh)
@@ -272,8 +265,7 @@ func ValidateContains(res IDer, property string, expectedValues []string, method
 			Title:        title,
 			Property:     property,
 			Err:          err,
-			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 
@@ -293,7 +285,6 @@ func ValidateContains(res IDer, property string, expectedValues []string, method
 	}
 
 	if len(bad) > 0 {
-		//badPatterns := strings.Join(patternsToSlice(bad), ", ")
 		return TestResult{
 			Result:       false,
 			ResourceType: typs,
@@ -301,8 +292,7 @@ func ValidateContains(res IDer, property string, expectedValues []string, method
 			Title:        title,
 			Property:     property,
 			Expected:     patternsToSlice(bad),
-			//Desc:     fmt.Sprintf("%s: %s: patterns not found: [%s]", title, property, badPatterns),
-			Duration: time.Now().Sub(startTime),
+			Duration:     time.Now().Sub(startTime),
 		}
 	}
 	return TestResult{
@@ -312,8 +302,7 @@ func ValidateContains(res IDer, property string, expectedValues []string, method
 		Title:        title,
 		Property:     property,
 		Expected:     expectedValues,
-		//Desc:     fmt.Sprintf("%s: %s matches", title, property),
-		Duration: time.Now().Sub(startTime),
+		Duration:     time.Now().Sub(startTime),
 	}
 
 }

--- a/resource/validate.go
+++ b/resource/validate.go
@@ -77,7 +77,7 @@ func ValidateValues(res IDer, property string, expectedValues []string, method f
 		TestType:     Values,
 		Title:        title,
 		Property:     property,
-		Expected:     bad,
+		Expected:     expectedValues,
 		Found:        foundValues,
 		//Desc:     fmt.Sprintf("%s: %s matches", title, property),
 		Duration: time.Now().Sub(startTime),

--- a/resource/validate.go
+++ b/resource/validate.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -16,26 +17,31 @@ const (
 )
 
 type TestResult struct {
-	Result   bool
-	Title    string
-	Type     int
-	Property string
-	Err      error
-	Expected []string
-	Found    []string
-	Duration time.Duration
+	Result       bool
+	Title        string
+	ResourceType string
+	TestType     int
+	Property     string
+	Err          error
+	Expected     []string
+	Found        []string
+	Duration     time.Duration
 }
 
-func ValidateValues(title, property string, expectedValues []string, method func() ([]string, error)) TestResult {
+func ValidateValues(res IDer, property string, expectedValues []string, method func() ([]string, error)) TestResult {
+	title := res.ID()
+	typ := reflect.TypeOf(res)
+	typs := strings.Split(typ.String(), ".")[1]
 	startTime := time.Now()
 	foundValues, err := method()
 	if err != nil {
 		return TestResult{
-			Result:   false,
-			Type:     Values,
-			Title:    title,
-			Property: property,
-			Err:      err,
+			Result:       false,
+			ResourceType: typs,
+			TestType:     Values,
+			Title:        title,
+			Property:     property,
+			Err:          err,
 			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
 			Duration: time.Now().Sub(startTime),
 		}
@@ -54,39 +60,45 @@ func ValidateValues(title, property string, expectedValues []string, method func
 
 	if len(bad) > 0 {
 		return TestResult{
-			Result:   false,
-			Type:     Values,
-			Title:    title,
-			Property: property,
-			Expected: bad,
-			Found:    foundValues,
+			Result:       false,
+			ResourceType: typs,
+			TestType:     Values,
+			Title:        title,
+			Property:     property,
+			Expected:     bad,
+			Found:        foundValues,
 			//Desc:     fmt.Sprintf("%s: %s: [%s] not in: [%s]", title, property, strings.Join(bad, ", "), strings.Join(foundValues, ", ")),
 			Duration: time.Now().Sub(startTime),
 		}
 	}
 	return TestResult{
-		Result:   true,
-		Type:     Values,
-		Title:    title,
-		Property: property,
-		Expected: bad,
-		Found:    foundValues,
+		Result:       true,
+		ResourceType: typs,
+		TestType:     Values,
+		Title:        title,
+		Property:     property,
+		Expected:     bad,
+		Found:        foundValues,
 		//Desc:     fmt.Sprintf("%s: %s matches", title, property),
 		Duration: time.Now().Sub(startTime),
 	}
 
 }
 
-func ValidateValue(title, property string, expectedValue interface{}, method func() (interface{}, error)) TestResult {
+func ValidateValue(res IDer, property string, expectedValue interface{}, method func() (interface{}, error)) TestResult {
+	title := res.ID()
+	typ := reflect.TypeOf(res)
+	typs := strings.Split(typ.String(), ".")[1]
 	startTime := time.Now()
 	foundValue, err := method()
 	if err != nil {
 		return TestResult{
-			Result:   false,
-			Type:     Value,
-			Title:    title,
-			Property: property,
-			Err:      err,
+			Result:       false,
+			ResourceType: typs,
+			TestType:     Value,
+			Title:        title,
+			Property:     property,
+			Err:          err,
 			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
 			Duration: time.Now().Sub(startTime),
 		}
@@ -94,24 +106,26 @@ func ValidateValue(title, property string, expectedValue interface{}, method fun
 
 	if expectedValue == foundValue {
 		return TestResult{
-			Result:   true,
-			Type:     Value,
-			Title:    title,
-			Property: property,
-			Expected: []string{interfaceToString(expectedValue)},
-			Found:    []string{interfaceToString(foundValue)},
+			Result:       true,
+			ResourceType: typs,
+			TestType:     Value,
+			Title:        title,
+			Property:     property,
+			Expected:     []string{interfaceToString(expectedValue)},
+			Found:        []string{interfaceToString(foundValue)},
 			//Desc:     fmt.Sprintf("%s: %s matches", title, property),
 			Duration: time.Now().Sub(startTime),
 		}
 	}
 
 	return TestResult{
-		Result:   false,
-		Type:     Value,
-		Title:    title,
-		Property: property,
-		Expected: []string{interfaceToString(expectedValue)},
-		Found:    []string{interfaceToString(foundValue)},
+		Result:       false,
+		ResourceType: typs,
+		TestType:     Value,
+		Title:        title,
+		Property:     property,
+		Expected:     []string{interfaceToString(expectedValue)},
+		Found:        []string{interfaceToString(foundValue)},
 		//Desc:     fmt.Sprintf("%s: %s doesn't match, expect: %v found: %v", title, property, expectedValue, foundValue),
 		Duration: time.Now().Sub(startTime),
 	}
@@ -212,16 +226,20 @@ func patternsToSlice(patterns []patternMatcher) []string {
 	return slice
 }
 
-func ValidateContains(title, property string, expectedValues []string, method func() (io.Reader, error)) TestResult {
+func ValidateContains(res IDer, property string, expectedValues []string, method func() (io.Reader, error)) TestResult {
+	title := res.ID()
+	typ := reflect.TypeOf(res)
+	typs := strings.Split(typ.String(), ".")[1]
 	startTime := time.Now()
 	fh, err := method()
 	if err != nil {
 		return TestResult{
-			Result:   false,
-			Type:     Contains,
-			Title:    title,
-			Property: property,
-			Err:      err,
+			Result:       false,
+			ResourceType: typs,
+			TestType:     Contains,
+			Title:        title,
+			Property:     property,
+			Err:          err,
 			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
 			Duration: time.Now().Sub(startTime),
 		}
@@ -248,11 +266,12 @@ func ValidateContains(title, property string, expectedValues []string, method fu
 	}
 	if err := scanner.Err(); err != nil {
 		return TestResult{
-			Result:   false,
-			Type:     Contains,
-			Title:    title,
-			Property: property,
-			Err:      err,
+			Result:       false,
+			ResourceType: typs,
+			TestType:     Contains,
+			Title:        title,
+			Property:     property,
+			Err:          err,
 			//Desc:     fmt.Sprintf("%s: %s: Error: %s", title, property, err),
 			Duration: time.Now().Sub(startTime),
 		}
@@ -276,21 +295,23 @@ func ValidateContains(title, property string, expectedValues []string, method fu
 	if len(bad) > 0 {
 		//badPatterns := strings.Join(patternsToSlice(bad), ", ")
 		return TestResult{
-			Result:   false,
-			Type:     Contains,
-			Title:    title,
-			Property: property,
-			Expected: patternsToSlice(bad),
+			Result:       false,
+			ResourceType: typs,
+			TestType:     Contains,
+			Title:        title,
+			Property:     property,
+			Expected:     patternsToSlice(bad),
 			//Desc:     fmt.Sprintf("%s: %s: patterns not found: [%s]", title, property, badPatterns),
 			Duration: time.Now().Sub(startTime),
 		}
 	}
 	return TestResult{
-		Result:   true,
-		Type:     Contains,
-		Title:    title,
-		Property: property,
-		Found:    patternsToSlice(found),
+		Result:       true,
+		ResourceType: typs,
+		TestType:     Contains,
+		Title:        title,
+		Property:     property,
+		Expected:     expectedValues,
 		//Desc:     fmt.Sprintf("%s: %s matches", title, property),
 		Duration: time.Now().Sub(startTime),
 	}

--- a/resource/validate.go
+++ b/resource/validate.go
@@ -125,6 +125,7 @@ func ValidateValue(res IDer, property string, expectedValue interface{}, method 
 	}
 }
 
+// FIXME: Not sure I like this, perhaps move to more statically typed validations..
 func interfaceToString(i interface{}) string {
 	switch t := i.(type) {
 	case string:

--- a/resource/validate_test.go
+++ b/resource/validate_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+type FakeIDer struct {
+	id string
+}
+
+func (f *FakeIDer) ID() string {
+	return f.id
+}
+
 var stringTests = []struct {
 	in, in2 interface{}
 	want    bool
@@ -23,7 +31,7 @@ func TestValidateValue(t *testing.T) {
 		inFunc := func() (interface{}, error) {
 			return c.in2, nil
 		}
-		got := ValidateValue("", "", c.in, inFunc)
+		got := ValidateValue(&FakeIDer{""}, "", c.in, inFunc)
 		if got.Result != c.want {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, c.want)
 		}
@@ -35,7 +43,7 @@ func TestValidateValueErr(t *testing.T) {
 		inFunc := func() (interface{}, error) {
 			return c.in2, fmt.Errorf("some err")
 		}
-		got := ValidateValue("", "", c.in, inFunc)
+		got := ValidateValue(&FakeIDer{""}, "", c.in, inFunc)
 		if got.Result != false {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, false)
 		}
@@ -47,7 +55,7 @@ func BenchmarkValidateValue(b *testing.B) {
 		return "foo", nil
 	}
 	for n := 0; n < b.N; n++ {
-		ValidateValue("", "", "foo", inFunc)
+		ValidateValue(&FakeIDer{""}, "", "foo", inFunc)
 	}
 }
 
@@ -66,7 +74,7 @@ func TestValidateValues(t *testing.T) {
 		inFunc := func() ([]string, error) {
 			return c.in2, nil
 		}
-		got := ValidateValues("", "", c.in, inFunc)
+		got := ValidateValues(&FakeIDer{""}, "", c.in, inFunc)
 		if got.Result != c.want {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, c.want)
 		}
@@ -78,7 +86,7 @@ func TestValidateValuesErr(t *testing.T) {
 		inFunc := func() ([]string, error) {
 			return c.in2, fmt.Errorf("some err")
 		}
-		got := ValidateValues("", "", c.in, inFunc)
+		got := ValidateValues(&FakeIDer{""}, "", c.in, inFunc)
 		if got.Result != false {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, false)
 		}
@@ -106,7 +114,7 @@ func TestValidateContains(t *testing.T) {
 			reader := strings.NewReader(c.in2)
 			return reader, nil
 		}
-		got := ValidateContains("", "", c.in, inFunc)
+		got := ValidateContains(&FakeIDer{""}, "", c.in, inFunc)
 		if got.Result != c.want {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, c.want)
 		}
@@ -119,7 +127,7 @@ func TestValidateContainsErr(t *testing.T) {
 			reader := strings.NewReader(c.in2)
 			return reader, fmt.Errorf("some err")
 		}
-		got := ValidateContains("", "", c.in, inFunc)
+		got := ValidateContains(&FakeIDer{""}, "", c.in, inFunc)
 		if got.Result != false {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, false)
 		}

--- a/runner.go
+++ b/runner.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aelsabbahy/goss/resource"
 	"github.com/aelsabbahy/goss/system"
 	"github.com/codegangsta/cli"
+	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 )
 
 func Run(specFile string, c *cli.Context) {
@@ -76,9 +78,14 @@ func Run(specFile string, c *cli.Context) {
 		close(out)
 	}()
 
-	var outputer outputs.Outputer
-	outputer = outputs.Rspecish{}
-	if hasFail := outputer.Output(out, c); hasFail {
+	//var outputer outputs.Outputer
+	if c.Bool("no-color") || !isatty.IsTerminal(os.Stdout.Fd()) {
+		color.NoColor = true
+	}
+
+	outputer := outputs.GetOutputer(c.String("format"))
+
+	if hasFail := outputer.Output(out); hasFail {
 		os.Exit(1)
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aelsabbahy/goss/system"
 	"github.com/codegangsta/cli"
 	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
 )
 
 func Run(specFile string, c *cli.Context) {
@@ -77,7 +76,7 @@ func Run(specFile string, c *cli.Context) {
 	}()
 
 	//var outputer outputs.Outputer
-	if c.Bool("no-color") || !isatty.IsTerminal(os.Stdout.Fd()) {
+	if c.Bool("no-color") {
 		color.NoColor = true
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -40,7 +40,7 @@ func Run(specFile string, c *cli.Context) {
 	}
 	configJSON := mergeJSONData(ReadJSONData(data), 0, path)
 
-	out := make(chan resource.TestResult)
+	out := make(chan []resource.TestResult)
 
 	in := make(chan resource.Resource)
 
@@ -65,9 +65,7 @@ func Run(specFile string, c *cli.Context) {
 		go func() {
 			defer wg.Done()
 			for f := range in {
-				for _, r := range f.Validate(sys) {
-					out <- r
-				}
+				out <- f.Validate(sys)
 			}
 
 		}()

--- a/runner.go
+++ b/runner.go
@@ -78,7 +78,7 @@ func Run(specFile string, c *cli.Context) {
 
 	var outputer outputs.Outputer
 	outputer = outputs.Rspecish{}
-	if hasFail := outputer.Output(out); hasFail {
+	if hasFail := outputer.Output(out, c); hasFail {
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Two new features to `goss validate`:
* `goss validate --format FORMAT`, valid options are:
  * `rspecish`: same as before [default]
  * `documentation`: More verbose output, can be useful for audit reports
* color output by default for tty, `goss validate --no-color` to force off