### PR TITLE
Fix issue #28, goss over ssh hangs.

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -51,7 +51,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) {
-				goss.Run(c.GlobalString("gossfile"), c, startTime)
+				goss.Run(c, startTime)
 			},
 		},
 		{

--- a/integration-tests/goss/centos6/goss-expected.json
+++ b/integration-tests/goss/centos6/goss-expected.json
@@ -94,7 +94,7 @@
             "exit-status": "0",
             "stdout": [
                 "Server version: Apache/2.2.15 (Unix)",
-                "Server built:   Aug 24 2015 17:52:49"
+                "Server built:   Dec 15 2015 15:50:14"
             ],
             "stderr": []
         }

--- a/integration-tests/goss/centos6/goss.json
+++ b/integration-tests/goss/centos6/goss.json
@@ -39,7 +39,7 @@
             "exit-status": "0",
             "stdout": [
                 "Server version: Apache/2.2.15 (Unix)",
-                "Server built:   Aug 24 2015 17:52:49"
+                "Server built:   Dec 15 2015 15:50:14"
             ],
             "stderr": []
         },

--- a/runner.go
+++ b/runner.go
@@ -23,7 +23,7 @@ func Run(c *cli.Context, startTime time.Time) {
 	var fh *os.File
 	var err error
 	var path string
-	if hasStdin() && !c.GlobalIsSet("gossfile") {
+	if !c.GlobalIsSet("gossfile") && hasStdin() {
 		fh = os.Stdin
 	} else {
 		specFile := c.GlobalString("gossfile")

--- a/runner.go
+++ b/runner.go
@@ -16,16 +16,17 @@ import (
 	"github.com/fatih/color"
 )
 
-func Run(specFile string, c *cli.Context, startTime time.Time) {
+func Run(c *cli.Context, startTime time.Time) {
 	sys := system.New(c)
 
 	// handle stdin
 	var fh *os.File
 	var err error
 	var path string
-	if hasStdin() {
+	if hasStdin() && !c.GlobalIsSet("gossfile") {
 		fh = os.Stdin
 	} else {
+		specFile := c.GlobalString("gossfile")
 		path = filepath.Dir(specFile)
 		fh, err = os.Open(specFile)
 		if err != nil {


### PR DESCRIPTION
Fix issue #28 

Don't try to read stdin when `-g` is provided.