### PR TITLE
Use duration flag for timeout

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -99,10 +99,9 @@ func main() {
 					Name:  "addr",
 					Usage: "add new remote address:port - ex: google.com:80",
 					Flags: []cli.Flag{
-						cli.IntFlag{
+						cli.DurationFlag{
 							Name:  "timeout",
-							Value: 500,
-							Usage: "Timeout in ms",
+							Value: 500 * time.Millisecond,
 						},
 					},
 					Action: func(c *cli.Context) {
@@ -141,10 +140,9 @@ func main() {
 					Name:  "command",
 					Usage: "add new command",
 					Flags: []cli.Flag{
-						cli.IntFlag{
+						cli.DurationFlag{
 							Name:  "timeout",
-							Value: 10000,
-							Usage: "Timeout in ms",
+							Value: 10 * time.Second,
 						},
 					},
 					Action: func(c *cli.Context) {
@@ -155,10 +153,9 @@ func main() {
 					Name:  "dns",
 					Usage: "add new dns",
 					Flags: []cli.Flag{
-						cli.IntFlag{
+						cli.DurationFlag{
 							Name:  "timeout",
-							Value: 500,
-							Usage: "Timeout in ms",
+							Value: 500 * time.Millisecond,
 						},
 					},
 					Action: func(c *cli.Context) {

--- a/json.go
+++ b/json.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aelsabbahy/goss/resource"
 	"github.com/aelsabbahy/goss/system"
@@ -197,7 +198,7 @@ func WriteJSON(filePath string, configJSON ConfigJSON) error {
 func AppendResource(fileName, resourceName, key string, c *cli.Context) error {
 	config := util.Config{
 		IgnoreList: c.GlobalStringSlice("exclude-attr"),
-		Timeout:    c.Int("timeout"),
+		Timeout:    int(c.Duration("timeout") / time.Millisecond),
 	}
 
 	var configJSON ConfigJSON

--- a/system/command.go
+++ b/system/command.go
@@ -86,6 +86,7 @@ func (c *DefCommand) Exists() (interface{}, error) {
 func runCommand(cmd *util.Command, timeout int) error {
 	c1 := make(chan bool, 1)
 	e1 := make(chan error, 1)
+	timeoutD := time.Duration(timeout) * time.Millisecond
 	go func() {
 		err := cmd.Run()
 		if err != nil {
@@ -98,7 +99,7 @@ func runCommand(cmd *util.Command, timeout int) error {
 		return nil
 	case err := <-e1:
 		return err
-	case <-time.After(time.Millisecond * time.Duration(timeout)):
-		return fmt.Errorf("Command execution timed out (%d milliseconds)", timeout)
+	case <-time.After(timeoutD):
+		return fmt.Errorf("Command execution timed out (%s)", timeoutD)
 	}
 }

--- a/system/dns.go
+++ b/system/dns.go
@@ -79,6 +79,7 @@ func (d *DefDNS) Exists() (interface{}, error) {
 func lookupHost(host string, timeout int) ([]string, error) {
 	c1 := make(chan []string, 1)
 	e1 := make(chan error, 1)
+	timeoutD := time.Duration(timeout) * time.Millisecond
 	go func() {
 		addrs, err := net.LookupHost(host)
 		if err != nil {
@@ -91,7 +92,7 @@ func lookupHost(host string, timeout int) ([]string, error) {
 		return res, nil
 	case err := <-e1:
 		return nil, err
-	case <-time.After(time.Millisecond * time.Duration(timeout)):
-		return nil, fmt.Errorf("DNS lookup timed out (%d milliseconds)", timeout)
+	case <-time.After(timeoutD):
+		return nil, fmt.Errorf("DNS lookup timed out (%s)", timeoutD)
 	}
 }

--- a/system/system.go
+++ b/system/system.go
@@ -70,10 +70,11 @@ func New(c *cli.Context) *System {
 	// Also, cache should be its own object
 	sys.detectService()
 
-	switch {
-	case c.GlobalString("package") == "rpm":
+	p := c.GlobalString("package")
+	switch p {
+	case "rpm":
 		sys.NewPackage = NewRpmPackage
-	case c.GlobalString("package") == "deb":
+	case "deb":
 		sys.NewPackage = NewDebPackage
 	default:
 		sys.NewPackage = detectPackage()


### PR DESCRIPTION
Addr, DNS, and Command `--timeout` flag changed to be in a more human readable format.

Instead of `--timeout 1000` now you can just run `--timeout 1s`