### PR TITLE
Leverage gomega matchers, to allow for more complex asserts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ TRAVIS_TAG ?= "0.0.0"
 all: test-all
 
 install:
-	go install -v $(exe)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(TRAVIS_TAG)" -o release/$(cmd)-linux-amd64 $(exe)
+	cp release/$(cmd)-linux-amd64 $(GOPATH)/bin/goss
+	#CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install -v $(exe)
 
 test:
 	go test $(pkgs)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
         * [Attributes](#attributes-9)
     * [render, r - Render gossfile after importing all referenced gossfiles](#render-r---render-gossfile-after-importing-all-referenced-gossfiles)
     * [Patterns](#patterns)
+    * [Advanced Matchers](#advanced-matchers)
 
 
 ## Introduction
@@ -611,6 +612,8 @@ For the attributes that use patterns (ex. file, command output), each pattern is
 * "/regex/" - verifies that line contains regex
 * "!/regex/" - inverse of above, checks that no line contains regex
 
+**NOTE:** Pattern attrubutes do not support [Advanced Matchers](#advanced-matchers)
+
 ```bash
 $ cat /tmp/test.txt
 foo
@@ -644,3 +647,42 @@ $ goss validate
 
 Count: 2 failed: 1
 ```
+
+### Advanced Matchers
+Goss supports advanced matchers by converting json input to [gomega](https://onsi.github.io/gomega/) matchers. Here are some examples:
+
+Validate that user "nobody" has a uid that is less than 500 and that they are ONLY a member of the "nobody" group.
+```json
+{
+    "user": {
+        "nobody": {
+            "exists": true,
+            "uid": {"lt": 500},
+            "gid": 99,
+            "groups": {"consist-of": ["nobody"]},
+            "home": "/"
+        }
+    }
+}
+```
+
+Matchers can be nested for more complex logic, Ex:
+Ensure that we have 3 kernel versions installed and none of them are "4.1.0":
+```json
+{
+    "package": {
+        "kernel": {
+            "installed": true,
+            "versions": {"and": [
+                {"have-len": 3},
+                {"not": {"contain-element": "4.1.0"}}
+            ]}
+        }
+    }
+}
+
+```
+
+For more information see:
+* [gomega_test.go](https://github.com/aelsabbahy/goss/blob/master/resource/gomega_test.go) - For a complete set of supported json -> Gomega mapping
+* [gomega](https://onsi.github.io/gomega/) - Gomega matchers reference

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,3 +20,5 @@ import:
     ref:     4e6893b05a6aa723daa5f9194361032c6beaca25
     subpackages:
       - /libcontainer/user
+  - package: github.com/onsi/gomega
+    ref:     c72df929b80ef4930aaa75d5e486887ff2f3e06a

--- a/integration-tests/Dockerfile_centos6
+++ b/integration-tests/Dockerfile_centos6
@@ -1,6 +1,6 @@
-FROM centos:centos6
+FROM centos:6.6
 MAINTAINER Ahmed
 
-RUN yum install -y httpd-2.2.15 && yum clean all
+RUN yum -y --disablerepo='*' --enablerepo=base install httpd && yum clean all
 
 RUN chkconfig httpd on

--- a/integration-tests/goss/alpine3/goss-expected-q.json
+++ b/integration-tests/goss/alpine3/goss-expected-q.json
@@ -69,13 +69,13 @@
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [],
             "timeout": 10000
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [],
             "timeout": 10000

--- a/integration-tests/goss/alpine3/goss-expected.json
+++ b/integration-tests/goss/alpine3/goss-expected.json
@@ -75,12 +75,12 @@
         },
         "www-data": {
             "exists": true,
-            "gid": "82"
+            "gid": 82
         }
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: apache2: not found"
@@ -88,7 +88,7 @@
             "timeout": 10000
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: foobar: not found"

--- a/integration-tests/goss/alpine3/goss.json
+++ b/integration-tests/goss/alpine3/goss.json
@@ -20,8 +20,8 @@
     "user": {
         "apache": {
             "exists": true,
-            "uid": "1000",
-            "gid": "1000",
+            "uid": 1000,
+            "gid": 1000,
             "groups": [
                 "apache"
             ],
@@ -31,12 +31,12 @@
     "group": {
         "apache": {
             "exists": true,
-            "gid": "1000"
+            "gid": 1000
         }
     },
     "command": {
         "httpd -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.4.17 (Unix)",
                 "Server built:   Dec 15 2015 12:01:18"
@@ -44,7 +44,7 @@
             "stderr": []
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                "foobar: not found"

--- a/integration-tests/goss/centos6/goss-expected-q.json
+++ b/integration-tests/goss/centos6/goss-expected-q.json
@@ -69,13 +69,13 @@
     },
     "command": {
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [],
             "timeout": 10000
         },
         "httpd -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [],
             "stderr": [],
             "timeout": 10000

--- a/integration-tests/goss/centos6/goss-expected.json
+++ b/integration-tests/goss/centos6/goss-expected.json
@@ -64,8 +64,8 @@
     "user": {
         "apache": {
             "exists": true,
-            "uid": "48",
-            "gid": "48",
+            "uid": 48,
+            "gid": 48,
             "groups": [
                 "apache"
             ],
@@ -78,7 +78,7 @@
     "group": {
         "apache": {
             "exists": true,
-            "gid": "48"
+            "gid": 48
         },
         "foobar": {
             "exists": false
@@ -86,7 +86,7 @@
     },
     "command": {
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: foobar: command not found"
@@ -94,10 +94,10 @@
             "timeout": 10000
         },
         "httpd -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.15 (Unix)",
-                "Server built:   Dec 15 2015 15:50:14"
+                "Server built:   Jul 24 2015 11:52:28"
             ],
             "stderr": [],
             "timeout": 10000

--- a/integration-tests/goss/centos6/goss.json
+++ b/integration-tests/goss/centos6/goss.json
@@ -20,8 +20,8 @@
     "user": {
         "apache": {
             "exists": true,
-            "uid": "48",
-            "gid": "48",
+            "uid": 48,
+            "gid": 48,
             "groups": [
                 "apache"
             ],
@@ -31,20 +31,20 @@
     "group": {
         "apache": {
             "exists": true,
-            "gid": "48"
+            "gid": 48
         }
     },
     "command": {
         "httpd -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.15 (Unix)",
-                "Server built:   Dec 15 2015 15:50:14"
+                "Server built:   Jul 24 2015 11:52:28"
             ],
             "stderr": []
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: foobar: command not found"

--- a/integration-tests/goss/precise/goss-expected-q.json
+++ b/integration-tests/goss/precise/goss-expected-q.json
@@ -69,13 +69,13 @@
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [],
             "stderr": [],
             "timeout": 10000
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [],
             "timeout": 10000

--- a/integration-tests/goss/precise/goss-expected.json
+++ b/integration-tests/goss/precise/goss-expected.json
@@ -67,8 +67,8 @@
         },
         "www-data": {
             "exists": true,
-            "uid": "33",
-            "gid": "33",
+            "uid": 33,
+            "gid": 33,
             "groups": [
                 "www-data"
             ],
@@ -81,12 +81,12 @@
         },
         "www-data": {
             "exists": true,
-            "gid": "33"
+            "gid": 33
         }
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.22 (Ubuntu)",
                 "Server built:   Jul 24 2015 17:25:54"
@@ -95,7 +95,7 @@
             "timeout": 10000
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: 1: foobar: not found"

--- a/integration-tests/goss/precise/goss.json
+++ b/integration-tests/goss/precise/goss.json
@@ -20,8 +20,8 @@
     "user": {
         "www-data": {
             "exists": true,
-            "uid": "33",
-            "gid": "33",
+            "uid": 33,
+            "gid": 33,
             "groups": [
                 "www-data"
             ],
@@ -31,12 +31,12 @@
     "group": {
         "www-data": {
             "exists": true,
-            "gid": "33"
+            "gid": 33
         }
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.22 (Ubuntu)",
                 "Server built:   Jul 24 2015 17:25:54"
@@ -44,7 +44,7 @@
             "stderr": []
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: 1: foobar: not found"

--- a/integration-tests/goss/wheezy/goss-expected-q.json
+++ b/integration-tests/goss/wheezy/goss-expected-q.json
@@ -69,13 +69,13 @@
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [],
             "stderr": [],
             "timeout": 10000
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [],
             "timeout": 10000

--- a/integration-tests/goss/wheezy/goss-expected.json
+++ b/integration-tests/goss/wheezy/goss-expected.json
@@ -67,8 +67,8 @@
         },
         "www-data": {
             "exists": true,
-            "uid": "33",
-            "gid": "33",
+            "uid": 33,
+            "gid": 33,
             "groups": [
                 "www-data"
             ],
@@ -81,12 +81,12 @@
         },
         "www-data": {
             "exists": true,
-            "gid": "33"
+            "gid": 33
         }
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.22 (Debian)",
                 "Server built:   Aug 18 2015 09:49:50"
@@ -95,7 +95,7 @@
             "timeout": 10000
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: 1: foobar: not found"

--- a/integration-tests/goss/wheezy/goss.json
+++ b/integration-tests/goss/wheezy/goss.json
@@ -20,8 +20,8 @@
     "user": {
         "www-data": {
             "exists": true,
-            "uid": "33",
-            "gid": "33",
+            "uid": 33,
+            "gid": 33,
             "groups": [
                 "www-data"
             ],
@@ -31,12 +31,12 @@
     "group": {
         "www-data": {
             "exists": true,
-            "gid": "33"
+            "gid": 33
         }
     },
     "command": {
         "apache2 -v": {
-            "exit-status": "0",
+            "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.22 (Debian)",
                 "Server built:   Aug 18 2015 09:49:50"
@@ -44,7 +44,7 @@
             "stderr": []
         },
         "foobar": {
-            "exit-status": "127",
+            "exit-status": 127,
             "stdout": [],
             "stderr": [
                 "sh: 1: foobar: not found"

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -13,7 +13,7 @@ for arch in amd64 386;do
       if docker ps -a | grep goss_int_test_$os;then
 	docker rm -vf goss_int_test_$os
       fi
-      docker run --privileged -v $PWD/goss:/tmp/goss  -d --name goss_int_test_$os aelsabbahy/goss_$os /sbin/init
+      docker run -v $PWD/goss:/tmp/goss  -d --name goss_int_test_$os aelsabbahy/goss_$os /sbin/init
       # Give httpd time to start up
       sleep 10
     fi
@@ -33,6 +33,6 @@ for arch in amd64 386;do
 
     docker exec goss_int_test_$os bash -c "diff -wu /tmp/goss/${os}/goss-expected-q.json /tmp/goss/${os}/goss-generated.json"
 
-    #docker rm -vf goss_int_test_$os
+    docker rm -vf goss_int_test_$os
   done
 done

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -21,6 +21,21 @@ var red = color.New(color.FgRed).SprintfFunc()
 
 func humanizeResult(r resource.TestResult) string {
 	if r.Err != nil {
+		return red("%s: %s:\nError: %s", r.Title, r.Property, r.Err)
+	}
+
+	if r.Successful {
+		return green("%s: %s: %s: matches expectation: %s", r.ResourceType, r.Title, r.Property, r.Expected)
+	} else {
+		if r.Human != "" {
+			return red("%s: %s: %s:\n%s\n", r.ResourceType, r.Title, r.Property, r.Human)
+		}
+		return humanizeResult2(r)
+	}
+}
+
+func humanizeResult2(r resource.TestResult) string {
+	if r.Err != nil {
 		return red("%s: %s: Error: %s", r.Title, r.Property, r.Err)
 	}
 

--- a/resource/addr.go
+++ b/resource/addr.go
@@ -32,7 +32,7 @@ func NewAddr(sysAddr system.Addr, config util.Config) (*Addr, error) {
 	reachable, err := sysAddr.Reachable()
 	a := &Addr{
 		Address:   address,
-		Reachable: reachable.(bool),
+		Reachable: reachable,
 		Timeout:   config.Timeout,
 	}
 	return a, err

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -6,10 +6,10 @@ import (
 )
 
 type DNS struct {
-	Host        string   `json:"-"`
-	Resolveable bool     `json:"resolveable"`
-	Addrs       []string `json:"addrs,omitempty"`
-	Timeout     int      `json:"timeout"`
+	Host        string  `json:"-"`
+	Resolveable bool    `json:"resolveable"`
+	Addrs       matcher `json:"addrs,omitempty"`
+	Timeout     int     `json:"timeout"`
 }
 
 func (d *DNS) ID() string      { return d.Host }
@@ -25,8 +25,8 @@ func (d *DNS) Validate(sys *system.System) []TestResult {
 
 	results = append(results, ValidateValue(d, "resolveable", d.Resolveable, sysDNS.Resolveable))
 
-	if len(d.Addrs) > 0 {
-		results = append(results, ValidateValues(d, "addrs", d.Addrs, sysDNS.Addrs))
+	if d.Addrs != nil {
+		results = append(results, ValidateValue(d, "addrs", d.Addrs, sysDNS.Addrs))
 	}
 
 	return results
@@ -37,7 +37,7 @@ func NewDNS(sysDNS system.DNS, config util.Config) (*DNS, error) {
 	resolveable, err := sysDNS.Resolveable()
 	d := &DNS{
 		Host:        host,
-		Resolveable: resolveable.(bool),
+		Resolveable: resolveable,
 		Timeout:     config.Timeout,
 	}
 	if !contains(config.IgnoreList, "addrs") {

--- a/resource/file.go
+++ b/resource/file.go
@@ -8,11 +8,11 @@ import (
 type File struct {
 	Path     string   `json:"-"`
 	Exists   bool     `json:"exists"`
-	Mode     string   `json:"mode,omitempty"`
-	Owner    string   `json:"owner,omitempty"`
-	Group    string   `json:"group,omitempty"`
-	LinkedTo string   `json:"linked-to,omitempty"`
-	Filetype string   `json:"filetype,omitempty"`
+	Mode     matcher  `json:"mode,omitempty"`
+	Owner    matcher  `json:"owner,omitempty"`
+	Group    matcher  `json:"group,omitempty"`
+	LinkedTo matcher  `json:"linked-to,omitempty"`
+	Filetype matcher  `json:"filetype,omitempty"`
 	Contains []string `json:"contains"`
 }
 
@@ -26,27 +26,27 @@ func (f *File) Validate(sys *system.System) []TestResult {
 
 	results = append(results, ValidateValue(f, "exists", f.Exists, sysFile.Exists))
 
-	if f.Mode != "" {
+	if f.Mode != nil {
 		results = append(results, ValidateValue(f, "mode", f.Mode, sysFile.Mode))
 	}
 
-	if f.Owner != "" {
+	if f.Owner != nil {
 		results = append(results, ValidateValue(f, "owner", f.Owner, sysFile.Owner))
 	}
 
-	if f.Group != "" {
+	if f.Group != nil {
 		results = append(results, ValidateValue(f, "group", f.Group, sysFile.Group))
 	}
 
-	if f.LinkedTo != "" {
+	if f.LinkedTo != nil {
 		results = append(results, ValidateValue(f, "linkedto", f.LinkedTo, sysFile.LinkedTo))
 	}
 
-	if f.Filetype != "" {
+	if f.Filetype != nil {
 		results = append(results, ValidateValue(f, "filetype", f.Filetype, sysFile.Filetype))
 	}
 
-	if len(f.Contains) != 0 {
+	if len(f.Contains) > 0 {
 		results = append(results, ValidateContains(f, "contains", f.Contains, sysFile.Contains))
 	}
 
@@ -58,28 +58,33 @@ func NewFile(sysFile system.File, config util.Config) (*File, error) {
 	exists, _ := sysFile.Exists()
 	f := &File{
 		Path:     path,
-		Exists:   exists.(bool),
+		Exists:   exists,
 		Contains: []string{},
 	}
 	if !contains(config.IgnoreList, "mode") {
-		mode, _ := sysFile.Mode()
-		f.Mode = mode.(string)
+		if mode, err := sysFile.Mode(); err == nil {
+			f.Mode = mode
+		}
 	}
 	if !contains(config.IgnoreList, "owner") {
-		owner, _ := sysFile.Owner()
-		f.Owner = owner.(string)
+		if owner, err := sysFile.Owner(); err == nil {
+			f.Owner = owner
+		}
 	}
 	if !contains(config.IgnoreList, "group") {
-		group, _ := sysFile.Group()
-		f.Group = group.(string)
+		if group, err := sysFile.Group(); err == nil {
+			f.Group = group
+		}
 	}
 	if !contains(config.IgnoreList, "linked-to") {
-		linkedTo, _ := sysFile.LinkedTo()
-		f.LinkedTo = linkedTo.(string)
+		if linkedTo, err := sysFile.LinkedTo(); err == nil {
+			f.LinkedTo = linkedTo
+		}
 	}
 	if !contains(config.IgnoreList, "filetype") {
-		filetype, _ := sysFile.Filetype()
-		f.Filetype = filetype.(string)
+		if filetype, err := sysFile.Filetype(); err == nil {
+			f.Filetype = filetype
+		}
 	}
 	return f, nil
 }

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -1,0 +1,153 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+var gomegaTests = []struct {
+	in              string
+	want            interface{}
+	useNegateTester bool
+}{
+	// Default for simple types
+	{
+		in:   `"foo"`,
+		want: gomega.Equal("foo"),
+	},
+	{
+		in:   `1`,
+		want: gomega.Equal(float64(1)),
+	},
+	{
+		in:   `true`,
+		want: gomega.Equal(true),
+	},
+	// Default for Array
+	{
+		in:              `["foo", "bar"]`,
+		want:            gomega.And(gomega.ContainElement("foo"), gomega.ContainElement("bar")),
+		useNegateTester: true,
+	},
+
+	// Numeric
+	// Golang json escapes '>', '<' symbols, so we use 'gt', 'le' instead
+	{
+		in:   `{"gt": 1}`,
+		want: gomega.BeNumerically(">", float64(1)),
+	},
+	{
+		in:   `{"ge": 1}`,
+		want: gomega.BeNumerically(">=", float64(1)),
+	},
+	{
+		in:   `{"lt": 1}`,
+		want: gomega.BeNumerically("<", float64(1)),
+	},
+	{
+		in:   `{"le": 1}`,
+		want: gomega.BeNumerically("<=", float64(1)),
+	},
+
+	// String
+	{
+		in:   `{"have-prefix": "foo"}`,
+		want: gomega.HavePrefix("foo"),
+	},
+	{
+		in:   `{"have-suffix": "foo"}`,
+		want: gomega.HaveSuffix("foo"),
+	},
+	{
+		in:   `{"match-regexp": "foo"}`,
+		want: gomega.MatchRegexp("foo"),
+	},
+
+	// Collection
+	{
+		in:   `{"consist-of": ["foo"]}`,
+		want: gomega.ConsistOf(gomega.Equal("foo")),
+	},
+	{
+		in:   `{"contain-element": "foo"}`,
+		want: gomega.ContainElement("foo"),
+	},
+	{
+		in:   `{"have-len": 3}`,
+		want: gomega.HaveLen(3),
+	},
+
+	// Negation
+	{
+		in:   `{"not": "foo"}`,
+		want: gomega.Not(gomega.Equal("foo")),
+	},
+	// Complex logic
+	{
+		in:              `{"and": ["foo", "foo"]}`,
+		want:            gomega.And(gomega.Equal("foo"), gomega.Equal("foo")),
+		useNegateTester: true,
+	},
+	{
+		in:              `{"and": [{"have-prefix": "foo"}, "foo"]}`,
+		want:            gomega.And(gomega.HavePrefix("foo"), gomega.Equal("foo")),
+		useNegateTester: true,
+	},
+	{
+		in:   `{"not": {"have-prefix": "foo"}}`,
+		want: gomega.Not(gomega.HavePrefix("foo")),
+	},
+	{
+		in:   `{"or": ["foo", "foo"]}`,
+		want: gomega.Or(gomega.Equal("foo"), gomega.Equal("foo")),
+	},
+	{
+		in:   `{"not": {"and": [{"have-prefix": "foo"}]}}`,
+		want: gomega.Not(gomega.And(gomega.HavePrefix("foo"))),
+	},
+}
+
+func TestMatcherToGomegaMatcher(t *testing.T) {
+	for _, c := range gomegaTests {
+		var dat interface{}
+		if err := json.Unmarshal([]byte(c.in), &dat); err != nil {
+			t.Fatal(err)
+		}
+		got, err := matcherToGomegaMatcher(dat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gomegaTestEqual(t, got, c.want, c.useNegateTester)
+	}
+}
+
+func gomegaTestEqual(t *testing.T, got, want interface{}, useNegateTester bool) {
+	if !gomegaEqual(got, want, useNegateTester) {
+		t.Errorf("got %T %v, want %T %v", got, got, want, want)
+	}
+}
+func gomegaEqual(g, w interface{}, negateTester bool) bool {
+	gotT := reflect.TypeOf(g)
+	wantT := reflect.TypeOf(w)
+	got := g.(types.GomegaMatcher)
+	want := w.(types.GomegaMatcher)
+	var gotMessage string
+	var wantMessage string
+	if negateTester {
+		gotMessage = got.NegatedFailureMessage("foo")
+		wantMessage = want.NegatedFailureMessage("foo")
+	} else {
+		gotMessage = got.FailureMessage("foo")
+		wantMessage = want.FailureMessage("foo")
+	}
+	fmt.Println("got:", gotMessage)
+	fmt.Println("want:", wantMessage)
+
+	return gotT == wantT &&
+		gotMessage == wantMessage
+}

--- a/resource/process.go
+++ b/resource/process.go
@@ -28,6 +28,6 @@ func NewProcess(sysProcess system.Process, config util.Config) (*Process, error)
 	running, _ := sysProcess.Running()
 	return &Process{
 		Executable: executable,
-		Running:    running.(bool),
+		Running:    running,
 	}, nil
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,7 +1,9 @@
 package resource
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aelsabbahy/goss/system"
 )
@@ -22,4 +24,17 @@ func contains(a []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func deprecateAtoI(depr interface{}, desc string) interface{} {
+	s, ok := depr.(string)
+	if !ok {
+		return depr
+	}
+	fmt.Printf("DEPRICATION WARNING: %s should be an integer not a string\n", desc)
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		panic(err)
+	}
+	return float64(i)
 }

--- a/resource/service.go
+++ b/resource/service.go
@@ -31,7 +31,7 @@ func NewService(sysService system.Service, config util.Config) (*Service, error)
 	running, _ := sysService.Running()
 	return &Service{
 		Service: service,
-		Enabled: enabled.(bool),
-		Running: running.(bool),
+		Enabled: enabled,
+		Running: running,
 	}, nil
 }

--- a/resource/user.go
+++ b/resource/user.go
@@ -1,17 +1,19 @@
 package resource
 
 import (
+	"fmt"
+
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
 )
 
 type User struct {
-	Username string   `json:"-"`
-	Exists   bool     `json:"exists"`
-	UID      string   `json:"uid,omitempty"`
-	GID      string   `json:"gid,omitempty"`
-	Groups   []string `json:"groups,omitempty"`
-	Home     string   `json:"home,omitempty"`
+	Username string  `json:"-"`
+	Exists   bool    `json:"exists"`
+	UID      matcher `json:"uid,omitempty"`
+	GID      matcher `json:"gid,omitempty"`
+	Groups   matcher `json:"groups,omitempty"`
+	Home     matcher `json:"home,omitempty"`
 }
 
 func (u *User) ID() string      { return u.Username }
@@ -24,17 +26,19 @@ func (u *User) Validate(sys *system.System) []TestResult {
 
 	results = append(results, ValidateValue(u, "exists", u.Exists, sysuser.Exists))
 
-	if u.UID != "" {
-		results = append(results, ValidateValue(u, "uid", u.UID, sysuser.UID))
+	if u.UID != nil {
+		uUID := deprecateAtoI(u.UID, fmt.Sprintf("%s: user.uid", u.Username))
+		results = append(results, ValidateValue(u, "uid", uUID, sysuser.UID))
 	}
-	if u.GID != "" {
-		results = append(results, ValidateValue(u, "gid", u.GID, sysuser.GID))
+	if u.GID != nil {
+		uGID := deprecateAtoI(u.GID, fmt.Sprintf("%s: user.gid", u.Username))
+		results = append(results, ValidateValue(u, "gid", uGID, sysuser.GID))
 	}
-	if u.Home != "" {
+	if u.Home != nil {
 		results = append(results, ValidateValue(u, "home", u.Home, sysuser.Home))
 	}
-	if len(u.Groups) > 0 {
-		results = append(results, ValidateValues(u, "groups", u.Groups, sysuser.Groups))
+	if u.Groups != nil {
+		results = append(results, ValidateValue(u, "groups", u.Groups, sysuser.Groups))
 	}
 
 	return results
@@ -45,24 +49,27 @@ func NewUser(sysUser system.User, config util.Config) (*User, error) {
 	exists, _ := sysUser.Exists()
 	u := &User{
 		Username: username,
-		Exists:   exists.(bool),
+		Exists:   exists,
 	}
 	if !contains(config.IgnoreList, "uid") {
-		uid, _ := sysUser.UID()
-		u.UID = uid.(string)
-
+		if uid, err := sysUser.UID(); err == nil {
+			u.UID = uid
+		}
 	}
 	if !contains(config.IgnoreList, "gid") {
-		gid, _ := sysUser.GID()
-		u.GID = gid.(string)
+		if gid, err := sysUser.GID(); err == nil {
+			u.GID = gid
+		}
 	}
 	if !contains(config.IgnoreList, "groups") {
-		groups, _ := sysUser.Groups()
-		u.Groups = groups
+		if groups, err := sysUser.Groups(); err == nil {
+			u.Groups = groups
+		}
 	}
 	if !contains(config.IgnoreList, "home") {
-		home, _ := sysUser.Home()
-		u.Home = home.(string)
+		if home, err := sysUser.Home(); err == nil {
+			u.Home = home
+		}
 	}
 	return u, nil
 }

--- a/resource/validate_test.go
+++ b/resource/validate_test.go
@@ -59,40 +59,6 @@ func BenchmarkValidateValue(b *testing.B) {
 	}
 }
 
-var valuesTests = []struct {
-	in, in2 []string
-	want    bool
-}{
-	{[]string{""}, []string{""}, true},
-	{[]string{"foo"}, []string{"foo"}, true},
-	{[]string{"foo"}, []string{"bar"}, false},
-	{[]string{"foo"}, []string{""}, false},
-}
-
-func TestValidateValues(t *testing.T) {
-	for _, c := range valuesTests {
-		inFunc := func() ([]string, error) {
-			return c.in2, nil
-		}
-		got := ValidateValues(&FakeIDer{""}, "", c.in, inFunc)
-		if got.Successful != c.want {
-			t.Errorf("%+v: got %v, want %v", c, got.Successful, c.want)
-		}
-	}
-}
-
-func TestValidateValuesErr(t *testing.T) {
-	for _, c := range valuesTests {
-		inFunc := func() ([]string, error) {
-			return c.in2, fmt.Errorf("some err")
-		}
-		got := ValidateValues(&FakeIDer{""}, "", c.in, inFunc)
-		if got.Successful != false {
-			t.Errorf("%+v: got %v, want %v", c, got.Successful, false)
-		}
-	}
-}
-
 var containsTests = []struct {
 	in   []string
 	in2  string

--- a/system/addr.go
+++ b/system/addr.go
@@ -10,8 +10,8 @@ import (
 
 type Addr interface {
 	Address() string
-	Exists() (interface{}, error)
-	Reachable() (interface{}, error)
+	Exists() (bool, error)
+	Reachable() (bool, error)
 }
 
 type DefAddr struct {
@@ -33,9 +33,9 @@ func (a *DefAddr) ID() string {
 func (a *DefAddr) Address() string {
 	return a.address
 }
-func (a *DefAddr) Exists() (interface{}, error) { return a.Reachable() }
+func (a *DefAddr) Exists() (bool, error) { return a.Reachable() }
 
-func (a *DefAddr) Reachable() (interface{}, error) {
+func (a *DefAddr) Reachable() (bool, error) {
 	network, address := splitAddress(a.address)
 
 	conn, err := net.DialTimeout(network, address, time.Duration(a.Timeout)*time.Millisecond)

--- a/system/command.go
+++ b/system/command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"strconv"
 	"time"
 
 	"github.com/aelsabbahy/goss/util"
@@ -13,15 +12,15 @@ import (
 
 type Command interface {
 	Command() string
-	Exists() (interface{}, error)
-	ExitStatus() (interface{}, error)
+	Exists() (bool, error)
+	ExitStatus() (int, error)
 	Stdout() (io.Reader, error)
 	Stderr() (io.Reader, error)
 }
 
 type DefCommand struct {
 	command    string
-	exitStatus string
+	exitStatus int
 	stdout     io.Reader
 	stderr     io.Reader
 	loaded     bool
@@ -49,7 +48,7 @@ func (c *DefCommand) setup() error {
 	if _, ok := err.(*exec.ExitError); !ok {
 		c.err = err
 	}
-	c.exitStatus = strconv.Itoa(cmd.Status)
+	c.exitStatus = cmd.Status
 	c.stdout = bytes.NewReader(cmd.Stdout.Bytes())
 	c.stderr = bytes.NewReader(cmd.Stderr.Bytes())
 
@@ -60,7 +59,7 @@ func (c *DefCommand) Command() string {
 	return c.command
 }
 
-func (c *DefCommand) ExitStatus() (interface{}, error) {
+func (c *DefCommand) ExitStatus() (int, error) {
 	err := c.setup()
 
 	return c.exitStatus, err
@@ -79,7 +78,7 @@ func (c *DefCommand) Stderr() (io.Reader, error) {
 }
 
 // Stub out
-func (c *DefCommand) Exists() (interface{}, error) {
+func (c *DefCommand) Exists() (bool, error) {
 	return false, nil
 }
 

--- a/system/dns.go
+++ b/system/dns.go
@@ -12,8 +12,8 @@ import (
 type DNS interface {
 	Host() string
 	Addrs() ([]string, error)
-	Resolveable() (interface{}, error)
-	Exists() (interface{}, error)
+	Resolveable() (bool, error)
+	Exists() (bool, error)
 }
 
 type DefDNS struct {
@@ -65,14 +65,14 @@ func (d *DefDNS) Addrs() ([]string, error) {
 	return d.addrs, err
 }
 
-func (d *DefDNS) Resolveable() (interface{}, error) {
+func (d *DefDNS) Resolveable() (bool, error) {
 	err := d.setup()
 
 	return d.resolveable, err
 }
 
 // Stub out
-func (d *DefDNS) Exists() (interface{}, error) {
+func (d *DefDNS) Exists() (bool, error) {
 	return false, nil
 }
 

--- a/system/file.go
+++ b/system/file.go
@@ -14,13 +14,13 @@ import (
 
 type File interface {
 	Path() string
-	Exists() (interface{}, error)
+	Exists() (bool, error)
 	Contains() (io.Reader, error)
-	Mode() (interface{}, error)
-	Filetype() (interface{}, error)
-	Owner() (interface{}, error)
-	Group() (interface{}, error)
-	LinkedTo() (interface{}, error)
+	Mode() (string, error)
+	Filetype() (string, error)
+	Owner() (string, error)
+	Group() (string, error)
+	LinkedTo() (string, error)
 }
 
 type DefFile struct {
@@ -36,7 +36,7 @@ func (f *DefFile) Path() string {
 	return f.path
 }
 
-func (f *DefFile) Exists() (interface{}, error) {
+func (f *DefFile) Exists() (bool, error) {
 	if _, err := os.Stat(f.path); os.IsNotExist(err) {
 		return false, nil
 	}
@@ -51,7 +51,7 @@ func (f *DefFile) Contains() (io.Reader, error) {
 	return fh, nil
 }
 
-func (f *DefFile) Mode() (interface{}, error) {
+func (f *DefFile) Mode() (string, error) {
 	fi, err := os.Lstat(f.path)
 	if err != nil {
 		return "", err
@@ -60,7 +60,7 @@ func (f *DefFile) Mode() (interface{}, error) {
 	return fmt.Sprintf("%#o", fi.Mode().Perm()), nil
 }
 
-func (f *DefFile) Filetype() (interface{}, error) {
+func (f *DefFile) Filetype() (string, error) {
 	fi, err := os.Lstat(f.path)
 	if err != nil {
 		return "", err
@@ -78,7 +78,7 @@ func (f *DefFile) Filetype() (interface{}, error) {
 	return "file", nil
 }
 
-func (f *DefFile) Owner() (interface{}, error) {
+func (f *DefFile) Owner() (string, error) {
 	fi, err := os.Lstat(f.path)
 	if err != nil {
 		return "", err
@@ -97,7 +97,7 @@ func (f *DefFile) Owner() (interface{}, error) {
 	return user.Name, nil
 }
 
-func (f *DefFile) Group() (interface{}, error) {
+func (f *DefFile) Group() (string, error) {
 	fi, err := os.Lstat(f.path)
 	if err != nil {
 		return "", err
@@ -116,7 +116,7 @@ func (f *DefFile) Group() (interface{}, error) {
 	return group.Name, nil
 }
 
-func (f *DefFile) LinkedTo() (interface{}, error) {
+func (f *DefFile) LinkedTo() (string, error) {
 	dst, err := os.Readlink(f.path)
 	if err != nil {
 		return "", err

--- a/system/gossfile.go
+++ b/system/gossfile.go
@@ -4,7 +4,7 @@ import "github.com/aelsabbahy/goss/util"
 
 type Gossfile interface {
 	Path() string
-	Exists() (interface{}, error)
+	Exists() (bool, error)
 }
 
 type DefGossfile struct {
@@ -16,7 +16,7 @@ func (g *DefGossfile) Path() string {
 }
 
 // Stub out
-func (g *DefGossfile) Exists() (interface{}, error) {
+func (g *DefGossfile) Exists() (bool, error) {
 	return false, nil
 }
 

--- a/system/group.go
+++ b/system/group.go
@@ -1,16 +1,14 @@
 package system
 
 import (
-	"strconv"
-
 	"github.com/aelsabbahy/goss/util"
 	"github.com/opencontainers/runc/libcontainer/user"
 )
 
 type Group interface {
 	Groupname() string
-	Exists() (interface{}, error)
-	Gid() (interface{}, error)
+	Exists() (bool, error)
+	GID() (int, error)
 }
 
 type DefGroup struct {
@@ -25,7 +23,7 @@ func (u *DefGroup) Groupname() string {
 	return u.groupname
 }
 
-func (u *DefGroup) Exists() (interface{}, error) {
+func (u *DefGroup) Exists() (bool, error) {
 	_, err := user.LookupGroup(u.groupname)
 	if err != nil {
 		return false, nil
@@ -33,11 +31,11 @@ func (u *DefGroup) Exists() (interface{}, error) {
 	return true, nil
 }
 
-func (u *DefGroup) Gid() (interface{}, error) {
+func (u *DefGroup) GID() (int, error) {
 	group, err := user.LookupGroup(u.groupname)
 	if err != nil {
-		return "", nil
+		return 0, err
 	}
 
-	return strconv.Itoa(group.Gid), nil
+	return group.Gid, nil
 }

--- a/system/package.go
+++ b/system/package.go
@@ -8,8 +8,8 @@ import (
 
 type Package interface {
 	Name() string
-	Exists() (interface{}, error)
-	Installed() (interface{}, error)
+	Exists() (bool, error)
+	Installed() (bool, error)
 	Versions() ([]string, error)
 }
 
@@ -25,9 +25,9 @@ func NewNullPackage(name string, system *System, config util.Config) Package {
 
 func (p *NullPackage) Name() string { return p.name }
 
-func (p *NullPackage) Exists() (interface{}, error) { return p.Installed() }
+func (p *NullPackage) Exists() (bool, error) { return p.Installed() }
 
-func (p *NullPackage) Installed() (interface{}, error) {
+func (p *NullPackage) Installed() (bool, error) {
 	return false, ErrNullPackage
 }
 

--- a/system/package_alpine.go
+++ b/system/package_alpine.go
@@ -44,9 +44,9 @@ func (p *AlpinePackage) Name() string {
 	return p.name
 }
 
-func (p *AlpinePackage) Exists() (interface{}, error) { return p.Installed() }
+func (p *AlpinePackage) Exists() (bool, error) { return p.Installed() }
 
-func (p *AlpinePackage) Installed() (interface{}, error) {
+func (p *AlpinePackage) Installed() (bool, error) {
 	p.setup()
 
 	return p.installed, nil

--- a/system/package_deb.go
+++ b/system/package_deb.go
@@ -44,9 +44,9 @@ func (p *DebPackage) Name() string {
 	return p.name
 }
 
-func (p *DebPackage) Exists() (interface{}, error) { return p.Installed() }
+func (p *DebPackage) Exists() (bool, error) { return p.Installed() }
 
-func (p *DebPackage) Installed() (interface{}, error) {
+func (p *DebPackage) Installed() (bool, error) {
 	p.setup()
 
 	return p.installed, nil

--- a/system/package_rpm.go
+++ b/system/package_rpm.go
@@ -35,9 +35,9 @@ func (p *RpmPackage) Name() string {
 	return p.name
 }
 
-func (p *RpmPackage) Exists() (interface{}, error) { return p.Installed() }
+func (p *RpmPackage) Exists() (bool, error) { return p.Installed() }
 
-func (p *RpmPackage) Installed() (interface{}, error) {
+func (p *RpmPackage) Installed() (bool, error) {
 	p.setup()
 
 	return p.installed, nil

--- a/system/port.go
+++ b/system/port.go
@@ -10,8 +10,8 @@ import (
 
 type Port interface {
 	Port() string
-	Exists() (interface{}, error)
-	Listening() (interface{}, error)
+	Exists() (bool, error)
+	Listening() (bool, error)
 	IP() ([]string, error)
 }
 
@@ -46,9 +46,9 @@ func (p *DefPort) Port() string {
 	return p.port
 }
 
-func (p *DefPort) Exists() (interface{}, error) { return p.Listening() }
+func (p *DefPort) Exists() (bool, error) { return p.Listening() }
 
-func (p *DefPort) Listening() (interface{}, error) {
+func (p *DefPort) Listening() (bool, error) {
 	if _, ok := p.sysPorts[p.port]; ok {
 		return true, nil
 	}

--- a/system/process.go
+++ b/system/process.go
@@ -10,8 +10,8 @@ import (
 
 type Process interface {
 	Executable() string
-	Exists() (interface{}, error)
-	Running() (interface{}, error)
+	Exists() (bool, error)
+	Running() (bool, error)
 	Pids() ([]int, error)
 }
 
@@ -31,7 +31,7 @@ func (p *DefProcess) Executable() string {
 	return p.executable
 }
 
-func (p *DefProcess) Exists() (interface{}, error) { return p.Running() }
+func (p *DefProcess) Exists() (bool, error) { return p.Running() }
 
 func (p *DefProcess) Pids() ([]int, error) {
 	var pids []int
@@ -41,7 +41,7 @@ func (p *DefProcess) Pids() ([]int, error) {
 	return pids, nil
 }
 
-func (p *DefProcess) Running() (interface{}, error) {
+func (p *DefProcess) Running() (bool, error) {
 	if _, ok := p.procMap[p.executable]; ok {
 		return true, nil
 	}

--- a/system/service.go
+++ b/system/service.go
@@ -2,7 +2,7 @@ package system
 
 type Service interface {
 	Service() string
-	Exists() (interface{}, error)
-	Enabled() (interface{}, error)
-	Running() (interface{}, error)
+	Exists() (bool, error)
+	Enabled() (bool, error)
+	Running() (bool, error)
 }

--- a/system/service_dbus.go
+++ b/system/service_dbus.go
@@ -23,7 +23,7 @@ func (s *ServiceDbus) Service() string {
 	return s.service
 }
 
-func (s *ServiceDbus) Exists() (interface{}, error) {
+func (s *ServiceDbus) Exists() (bool, error) {
 	units, err := s.dbus.ListUnits()
 	if err != nil {
 		return false, err
@@ -36,7 +36,7 @@ func (s *ServiceDbus) Exists() (interface{}, error) {
 	return false, err
 }
 
-func (s *ServiceDbus) Enabled() (interface{}, error) {
+func (s *ServiceDbus) Enabled() (bool, error) {
 	stateRaw, err := s.dbus.GetUnitProperty(s.service+".service", "UnitFileState")
 	if err != nil {
 		return false, err
@@ -56,7 +56,7 @@ func (s *ServiceDbus) Enabled() (interface{}, error) {
 	return false, nil
 }
 
-func (s *ServiceDbus) Running() (interface{}, error) {
+func (s *ServiceDbus) Running() (bool, error) {
 	stateRaw, err := s.dbus.GetUnitProperty(s.service+".service", "ActiveState")
 	if err != nil {
 		return false, err

--- a/system/service_init.go
+++ b/system/service_init.go
@@ -25,14 +25,14 @@ func (s *ServiceInit) Service() string {
 	return s.service
 }
 
-func (s *ServiceInit) Exists() (interface{}, error) {
+func (s *ServiceInit) Exists() (bool, error) {
 	if _, err := os.Stat(fmt.Sprintf("/etc/init.d/%s", s.service)); err == nil {
 		return true, err
 	}
 	return false, nil
 }
 
-func (s *ServiceInit) Enabled() (interface{}, error) {
+func (s *ServiceInit) Enabled() (bool, error) {
 	if s.alpine {
 		return alpineInitServiceEnabled(s.service, "sysinit")
 	} else {
@@ -40,7 +40,7 @@ func (s *ServiceInit) Enabled() (interface{}, error) {
 	}
 }
 
-func (s *ServiceInit) Running() (interface{}, error) {
+func (s *ServiceInit) Running() (bool, error) {
 	cmd := util.NewCommand("service", s.service, "status")
 	cmd.Run()
 	if cmd.Status == 0 {

--- a/system/service_upstart.go
+++ b/system/service_upstart.go
@@ -24,7 +24,7 @@ func (s *ServiceUpstart) Service() string {
 	return s.service
 }
 
-func (s *ServiceUpstart) Exists() (interface{}, error) {
+func (s *ServiceUpstart) Exists() (bool, error) {
 	// upstart
 	if _, err := os.Stat(fmt.Sprintf("/etc/init/%s.conf", s.service)); err == nil {
 		return true, err
@@ -37,7 +37,7 @@ func (s *ServiceUpstart) Exists() (interface{}, error) {
 	return false, nil
 }
 
-func (s *ServiceUpstart) Enabled() (interface{}, error) {
+func (s *ServiceUpstart) Enabled() (bool, error) {
 	if fh, err := os.Open(fmt.Sprintf("/etc/init/%s.conf", s.service)); err == nil {
 		scanner := bufio.NewScanner(fh)
 		for scanner.Scan() {
@@ -56,7 +56,7 @@ func (s *ServiceUpstart) Enabled() (interface{}, error) {
 	return false, nil
 }
 
-func (s *ServiceUpstart) Running() (interface{}, error) {
+func (s *ServiceUpstart) Running() (bool, error) {
 	cmd := util.NewCommand("service", s.service, "status")
 	cmd.Run()
 	out := cmd.Stdout.String()

--- a/system/system.go
+++ b/system/system.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Resource interface {
-	Exists() (interface{}, error)
+	Exists() (bool, error)
 }
 
 type System struct {

--- a/system/user.go
+++ b/system/user.go
@@ -3,7 +3,6 @@ package system
 import (
 	"fmt"
 	"sort"
-	"strconv"
 
 	"github.com/aelsabbahy/goss/util"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -11,11 +10,11 @@ import (
 
 type User interface {
 	Username() string
-	Exists() (interface{}, error)
-	UID() (interface{}, error)
-	GID() (interface{}, error)
+	Exists() (bool, error)
+	UID() (int, error)
+	GID() (int, error)
 	Groups() ([]string, error)
-	Home() (interface{}, error)
+	Home() (string, error)
 }
 
 type DefUser struct {
@@ -30,7 +29,7 @@ func (u *DefUser) Username() string {
 	return u.username
 }
 
-func (u *DefUser) Exists() (interface{}, error) {
+func (u *DefUser) Exists() (bool, error) {
 	_, err := user.LookupUser(u.username)
 	if err != nil {
 		return false, nil
@@ -38,28 +37,28 @@ func (u *DefUser) Exists() (interface{}, error) {
 	return true, nil
 }
 
-func (u *DefUser) UID() (interface{}, error) {
+func (u *DefUser) UID() (int, error) {
 	user, err := user.LookupUser(u.username)
 	if err != nil {
-		return "", nil
+		return 0, err
 	}
 
-	return strconv.Itoa(user.Uid), nil
+	return user.Uid, nil
 }
 
-func (u *DefUser) GID() (interface{}, error) {
+func (u *DefUser) GID() (int, error) {
 	user, err := user.LookupUser(u.username)
 	if err != nil {
-		return "", nil
+		return 0, err
 	}
 
-	return strconv.Itoa(user.Gid), nil
+	return user.Gid, nil
 }
 
-func (u *DefUser) Home() (interface{}, error) {
+func (u *DefUser) Home() (string, error) {
 	user, err := user.LookupUser(u.username)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return user.Home, nil


### PR DESCRIPTION
Convert the following attributes to numeric. This allows for numeric
comparisons like `{"uid": {"lt": 1000 }}`:
  * user.uid
  * user.gid
  * group.gid
  * command.exit-status

Added deprication warning if the above arent numeric, to migrate goss file, run:
`sed -ri 's/("(uid|gid|exit-status)": )"(.*)"/\1\3/g' goss.json`

#31 