### PR TITLE
Add TAP output support

### DIFF
--- a/outputs/tap.go
+++ b/outputs/tap.go
@@ -1,0 +1,47 @@
+package outputs
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aelsabbahy/goss/resource"
+)
+
+type Tap struct{}
+
+func (r Tap) Output(results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
+	testCount := 0
+	failed := 0
+
+	var summary map[int]string
+	summary = make(map[int]string)
+
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			if testResult.Successful {
+				summary[testCount] = "ok " + strconv.Itoa(testCount+1) + " - " + humanizeResult2(testResult) + "\n"
+			} else {
+				summary[testCount] = "not ok " + strconv.Itoa(testCount+1) + " - " + humanizeResult2(testResult) + "\n"
+				failed++
+			}
+			testCount++
+		}
+	}
+
+	fmt.Printf("1..%d\n", testCount)
+
+	for i := 0; i < testCount; i++ {
+		fmt.Printf("%s", summary[i])
+	}
+
+	if failed > 0 {
+		return 1
+	}
+
+	return 0
+}
+
+func init() {
+	RegisterOutputer("tap", &Tap{})
+}


### PR DESCRIPTION
Implementing the TAP specification (https://testanything.org/tap-specification.html) this allows usage of goss e.g. with Jenkins' TAP Plugin.

Output example:

````
% release/goss-linux-amd64 v --format tap --no-color
1..4
ok 1 - Package: zsh: installed: matches expectation: [true]
not ok 2 - Package: zsh: version: doesn't match, expect: [["5.0.7-6"]] found: [["5.0.7-5"]]
ok 3 - Package: vim: installed: matches expectation: [true]
ok 4 - Package: vim: version: matches expectation: [["2:7.4.488-7"]]
````

Signed-off-by: Michael Prokop <mprokop@sipwise.com>