### PR TITLE
Print a more clear message when a command is not in path

### DIFF
--- a/system/service_init.go
+++ b/system/service_init.go
@@ -44,7 +44,7 @@ func (s *ServiceInit) Running() (bool, error) {
 	cmd := util.NewCommand("service", s.service, "status")
 	cmd.Run()
 	if cmd.Status == 0 {
-		return true, nil
+		return true, cmd.Err
 	}
 	return false, nil
 }

--- a/system/service_upstart.go
+++ b/system/service_upstart.go
@@ -61,7 +61,7 @@ func (s *ServiceUpstart) Running() (bool, error) {
 	cmd.Run()
 	out := cmd.Stdout.String()
 	if cmd.Status == 0 && (strings.Contains(out, "running") || strings.Contains(out, "online")) {
-		return true, nil
+		return true, cmd.Err
 	}
 	return false, nil
 }

--- a/util/command.go
+++ b/util/command.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Command struct {
+	name           string
 	Cmd            *exec.Cmd
 	Stdout, Stderr bytes.Buffer
 	Err            error
@@ -17,6 +18,7 @@ type Command struct {
 func NewCommand(name string, arg ...string) *Command {
 	//fmt.Println(arg)
 	command := new(Command)
+	command.name = name
 	command.Cmd = exec.Command(name, arg...)
 	return command
 }
@@ -24,6 +26,11 @@ func NewCommand(name string, arg ...string) *Command {
 func (c *Command) Run() error {
 	c.Cmd.Stdout = &c.Stdout
 	c.Cmd.Stderr = &c.Stderr
+
+	if _, err := exec.LookPath(c.name); err != nil {
+		c.Err = err
+		return c.Err
+	}
 
 	if err := c.Cmd.Start(); err != nil {
 		c.Err = err


### PR DESCRIPTION
util.Command was failing silently when the `service` command wasn't found in service_init and service_upstart.