### PR TITLE
Provide clear messages when regex compile fails

### DIFF
--- a/integration-tests/goss/centos6/goss-expected.json
+++ b/integration-tests/goss/centos6/goss-expected.json
@@ -97,7 +97,7 @@
             "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.15 (Unix)",
-                "Server built:   Jul 24 2015 11:52:28"
+                "Server built:   May 11 2016 19:28:33"
             ],
             "stderr": [],
             "timeout": 10000

--- a/integration-tests/goss/centos6/goss.json
+++ b/integration-tests/goss/centos6/goss.json
@@ -39,7 +39,7 @@
             "exit-status": 0,
             "stdout": [
                 "Server version: Apache/2.2.15 (Unix)",
-                "Server built:   Jul 24 2015 11:52:28"
+                "Server built:   May 11 2016 19:28:33"
             ],
             "stderr": []
         },

--- a/integration-tests/goss/goss-shared.json
+++ b/integration-tests/goss/goss-shared.json
@@ -35,7 +35,7 @@
         },
         "tcp://google.com:443": {
             "reachable": true,
-            "timeout": 500
+            "timeout": 2000
         }
     },
     "port": {

--- a/resource/validate_test.go
+++ b/resource/validate_test.go
@@ -104,3 +104,14 @@ func TestValidateContainsErr(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateContainsBadRegexErr(t *testing.T) {
+	inFunc := func() (io.Reader, error) {
+		reader := strings.NewReader("dummy")
+		return reader, nil
+	}
+	got := ValidateContains(&FakeResource{""}, "", []string{"/*\\.* @@.*/"}, inFunc)
+	if got.Err == nil {
+		t.Errorf("Expected bad regex to raise error, got nil")
+	}
+}


### PR DESCRIPTION
fixes #82

Given:
```yaml
file:
  /etc/passwd:
    exists: true
    contains: [/*\.* @@.*/]
```

Output:
```bash
$ goss validate
.F

Failures:

/etc/passwd: contains: Error: error parsing regexp: missing argument to repetition operator: `*`

Total Duration: 0.001s
Count: 2, Failed: 1

```