### PR TITLE
Split amd64 and 386 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ dist: trusty
 services:
 - docker
 
-env:
-- GO15VENDOREXPERIMENT=1
-
 before_install:
 - curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.zip
   > glide.zip
@@ -21,7 +18,7 @@ before_install:
 
 script:
 - make deps
-- make -j10
+- make
 
 deploy:
   provider: releases

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,10 @@ pkgs = $(shell glide novendor)
 cmd = goss
 TRAVIS_TAG ?= "0.0.0"
 GO_FILES = $(shell find . \( -path ./vendor -o -name '_test.go' \) -prune -o -name '*.go' -print)
-MAKEFLAGS = -O
 
-.PHONY: all build install test coverage deps release bench test-int lint gen centos7 wheezy precise alpine3 arch
+.PHONY: all build install test coverage deps release bench test-int lint gen centos7 wheezy precise alpine3 arch test-int32 centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
 
-all: test-all
+all: test-all test-all-32
 
 install: release/goss-linux-amd64
 	$(info INFO: Starting build $@)
@@ -50,24 +49,41 @@ release:
 build: release/goss-linux-386 release/goss-linux-amd64
 
 test-int: centos7 wheezy precise alpine3 arch
+test-int-32: centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
 
+centos7-32: build
+	$(info INFO: Starting build $@)
+	cd integration-tests/ && ./test.sh centos7 386
+wheezy-32: build
+	$(info INFO: Starting build $@)
+	cd integration-tests/ && ./test.sh wheezy 386
+precise-32: build
+	$(info INFO: Starting build $@)
+	cd integration-tests/ && ./test.sh precise 386
+alpine3-32: build
+	$(info INFO: Starting build $@)
+	cd integration-tests/ && ./test.sh alpine3 386
+arch-32: build
+	$(info INFO: Starting build $@)
+	cd integration-tests/ && ./test.sh arch 386
 centos7: build
 	$(info INFO: Starting build $@)
-	cd integration-tests/ && ./test.sh $@
+	cd integration-tests/ && ./test.sh centos7 amd64
 wheezy: build
 	$(info INFO: Starting build $@)
-	cd integration-tests/ && ./test.sh $@
+	cd integration-tests/ && ./test.sh wheezy amd64
 precise: build
 	$(info INFO: Starting build $@)
-	cd integration-tests/ && ./test.sh $@
+	cd integration-tests/ && ./test.sh precise amd64
 alpine3: build
 	$(info INFO: Starting build $@)
-	cd integration-tests/ && ./test.sh $@
+	cd integration-tests/ && ./test.sh alpine3 amd64
 arch: build
 	$(info INFO: Starting build $@)
-	cd integration-tests/ && ./test.sh $@
+	cd integration-tests/ && ./test.sh arch amd64
 
 
+test-all-32: lint test test-int-32
 test-all: lint test test-int
 
 deps:

--- a/integration-tests/goss/generate_goss.sh
+++ b/integration-tests/goss/generate_goss.sh
@@ -7,12 +7,12 @@ ARCH=$2
 [[ $3 == "-q" ]] && args=("--exclude-attr" "*")
 
 goss() {
-  $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-generated.json "$@"
+  $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-generated-$ARCH.json "$@"
   # Validate that duplicates are ignored
-  $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-generated.json "$@"
+  $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-generated-$ARCH.json "$@"
 }
 
-rm -f $SCRIPT_DIR/${OS}/goss*generated*.json
+rm -f $SCRIPT_DIR/${OS}/goss*generated*-$ARCH.json
 
 for x in /etc/passwd /tmp/goss/foobar;do
   goss a "${args[@]}" file $x
@@ -42,8 +42,7 @@ goss a "${args[@]}" kernel-param kernel.ostype
 
 goss a "${args[@]}" mount /dev
 
-
 # Auto-add
-$SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated.json aa $package
+$SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa $package
 # Validate that duplicates are ignored
-$SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated.json aa $package
+$SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa $package

--- a/integration-tests/goss/goss-shared.json
+++ b/integration-tests/goss/goss-shared.json
@@ -51,7 +51,7 @@
         },
         "tcp://google.com:443": {
             "reachable": true,
-            "timeout": 2000
+            "timeout": 5000
         }
     },
     "port": {

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -3,6 +3,7 @@
 set -xeu
 
 os=$1
+arch=$2
 
 seccomp_opts() {
   local docker_ver minor_ver
@@ -13,50 +14,50 @@ seccomp_opts() {
   fi
 }
 
-for arch in amd64 386;do
-  cp ../release/goss-linux-$arch "goss/$os/"
-  # Run build if it's been changed since master
-  if [[ $(git log master... -- "Dockerfile_$os") ]] || [[ $(git diff -- "Dockerfile_$os") ]]; then
-    docker build -t "aelsabbahy/goss_${os}:latest" - < "Dockerfile_$os"
-  # Pull if image doesn't exist locally
-  elif ! docker images | grep "aelsabbahy/goss_$os";then
-    docker pull "aelsabbahy/goss_$os"
-  fi
+cp ../release/goss-linux-$arch "goss/$os/"
+# Run build if it's been changed since master
+if [[ $(git log master... -- "Dockerfile_$os") ]] || [[ $(git diff -- "Dockerfile_$os") ]]; then
+  docker build -t "aelsabbahy/goss_${os}:latest" - < "Dockerfile_$os"
+# Pull if image doesn't exist locally
+elif ! docker images | grep "aelsabbahy/goss_$os";then
+  docker pull "aelsabbahy/goss_$os"
+fi
 
-  # Cleanup any old containers
-  if docker ps -a | grep "goss_int_test_$os";then
-    docker rm -vf "goss_int_test_$os"
-  fi
-  opts=(--cap-add SYS_ADMIN -v "$PWD/goss:/goss"  -d --name "goss_int_test_$os" $(seccomp_opts))
-  id=$(docker run "${opts[@]}" "aelsabbahy/goss_$os" /sbin/init)
-  ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$id")
-  trap "rv=\$?; docker rm -vf $id; exit \$rv" INT TERM EXIT
-  # Give httpd time to start up
-  for _ in {1..10};do curl -sL -o /dev/null -m 1 "$ip" && break;sleep 1;done
+container_name="goss_int_test_${os}_${arch}"
+# Cleanup any old containers
+if docker ps -a | grep "$container_name";then
+  docker rm -vf "$container_name"
+fi
+opts=(--cap-add SYS_ADMIN -v "$PWD/goss:/goss"  -d --name "$container_name" $(seccomp_opts))
+id=$(docker run "${opts[@]}" "aelsabbahy/goss_$os" /sbin/init)
+ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$id")
+trap "rv=\$?; docker rm -vf $id; exit \$rv" INT TERM EXIT
+# Give httpd time to start up
+for _ in {1..10};do curl -sL -o /dev/null -m 1 "$ip" && break;sleep 1;done
+sleep 1
 
-  out=$(docker exec "goss_int_test_$os" bash -c "time /goss/$os/goss-linux-$arch -g /goss/$os/goss.json validate")
-  echo "$out"
+out=$(docker exec "$container_name" bash -c "time /goss/$os/goss-linux-$arch -g /goss/$os/goss.json validate")
+echo "$out"
 
-  if [[ $os == "arch" ]]; then
-    egrep -q 'Count: 35, Failed: 0' <<<"$out"
-  else
-    egrep -q 'Count: 50, Failed: 0' <<<"$out"
-  fi
+if [[ $os == "arch" ]]; then
+  egrep -q 'Count: 35, Failed: 0' <<<"$out"
+else
+  egrep -q 'Count: 50, Failed: 0' <<<"$out"
+fi
 
-  if [[ ! $os == "arch" ]]; then
-    docker exec "goss_int_test_$os" bash -c "bash -x /goss/generate_goss.sh $os $arch"
+if [[ ! $os == "arch" ]]; then
+  docker exec "$container_name" bash -c "bash -x /goss/generate_goss.sh $os $arch"
 
-    #docker exec goss_int_test_$os bash -c "cp /goss/${os}/goss-generated.json /goss/${os}/goss-expected.json"
-    docker exec "goss_int_test_$os" bash -c "diff -wu /goss/${os}/goss-expected.json /goss/${os}/goss-generated.json"
+  #docker exec goss_int_test_$os bash -c "cp /goss/${os}/goss-generated-$arch.json /goss/${os}/goss-expected.json"
+  docker exec "$container_name" bash -c "diff -wu /goss/${os}/goss-expected.json /goss/${os}/goss-generated-$arch.json"
 
-    #docker exec goss_int_test_$os bash -c "cp /goss/${os}/goss-aa-generated.json /goss/${os}/goss-aa-expected.json"
-    docker exec "goss_int_test_$os" bash -c "diff -wu /goss/${os}/goss-aa-expected.json /goss/${os}/goss-aa-generated.json"
+  #docker exec goss_int_test_$os bash -c "cp /goss/${os}/goss-aa-generated-$arch.json /goss/${os}/goss-aa-expected.json"
+  docker exec "$container_name" bash -c "diff -wu /goss/${os}/goss-aa-expected.json /goss/${os}/goss-aa-generated-$arch.json"
 
-    docker exec "goss_int_test_$os" bash -c "bash -x /goss/generate_goss.sh $os $arch -q"
+  docker exec "$container_name" bash -c "bash -x /goss/generate_goss.sh $os $arch -q"
 
-    #docker exec goss_int_test_$os bash -c "cp /goss/${os}/goss-generated.json /goss/${os}/goss-expected-q.json"
-    docker exec "goss_int_test_$os" bash -c "diff -wu /goss/${os}/goss-expected-q.json /goss/${os}/goss-generated.json"
-  fi
+  #docker exec goss_int_test_$os bash -c "cp /goss/${os}/goss-generated-$arch.json /goss/${os}/goss-expected-q.json"
+  docker exec "$container_name" bash -c "diff -wu /goss/${os}/goss-expected-q.json /goss/${os}/goss-generated-$arch.json"
+fi
 
-  #docker rm -vf goss_int_test_$os
-done
+#docker rm -vf goss_int_test_$os


### PR DESCRIPTION
Allows me to run builds faster locally, and slow down builds on CI to allow for clarity when doing parallel builds.