### PR TITLE
Junit: Remove LoadLocation, since it's not alwasy available

### DIFF
--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -15,8 +15,7 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult, startTi
 	var testCount, failed, skipped int
 
 	// ISO8601 timeformat
-	location, _ := time.LoadLocation("Etc/UTC")
-	timestamp := time.Now().In(location).Format(time.RFC3339)
+	timestamp := time.Now().Format(time.RFC3339)
 
 	var summary map[int]string
 	summary = make(map[int]string)


### PR DESCRIPTION
Fixes #134 