### PR TITLE
Test absolute path for gossfile loading

### DIFF
--- a/store.go
+++ b/store.go
@@ -94,7 +94,12 @@ func mergeJSONData(gossConfig GossConfig, depth int, path string) GossConfig {
 	}
 
 	for _, g := range gossConfig.Gossfiles {
-		fpath := filepath.Join(path, g.ID())
+		var fpath string
+		if strings.HasPrefix(g.ID(), "/") {
+			fpath = g.ID()
+		} else {
+			fpath = filepath.Join(path, g.ID())
+		}
 		fdir := filepath.Dir(fpath)
 		j := mergeJSONData(ReadJSON(fpath), depth, fdir)
 		gossConfig = mergeGoss(gossConfig, j)


### PR DESCRIPTION
This should fix #137 

The example below shows that context still chains, i.e. when you add in a gossfile from an absolute path, any relative references it has to other gossfiles are still relative to its own path. Compare to the failure to parse relative paths in #137 

```
testy$ cat shellshock_goss.yml
command:
  env x='() { :;}; echo vulnerable' bash -c 'echo this is a test':
    exit-status: 0
    stdout:
    - '!/vulnerable/'
    stderr: []
    timeout: 0
gossfile:
  shellshock2_goss.yml: {}
testy$ cat shellshock2_goss.yml
command:
  "env x='() { :;}; echo vulnerable' bash -c 'echo this is not a test'":
    exit-status: 0
    stdout:
      - "!/vulnerable/"
    stderr: []
testy$ ./goss-linux-amd64 -g /tmp/goss.yml add goss $(pwd)/shellshock_goss.yml
Adding Gossfile to '/tmp/goss.yml':

/home/someuser/golang/src/github.com/aelsabbahy/goss/release/shellshock_goss.yml: {}


testy$ ./goss-linux-amd64 -g /tmp/goss.yml validate
....

Total Duration: 0.005s
Count: 4, Failed: 0, Skipped: 0
testy$
```