### PR TITLE
add failures to Nagios long output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 # Random stuff for my local testing/development that I don't want checked in
 tmp/
 /goss.yaml
+
+/.idea

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ package:
 * TAP
 * JUnit
 * nagios - Nagios/Sensu compatible output /w exit code 2 for failures.
+* nagios_verbose - nagios output with verbose failure output.
 
 ## Community Contribuations
 * [goss-ansible](https://github.com/indusbox/goss-ansible) - Ansible module for Goss

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -90,6 +90,7 @@ Valid formats:
   * TAP
   * JUnit
   * nagios - Nagios/Sensu compatible output /w exit code 2 for failures.
+  * nagios_verbose - nagios output with verbose failure output.
 * --no-color (disable color)
 
 ### Example:

--- a/outputs/nagios.go
+++ b/outputs/nagios.go
@@ -13,12 +13,15 @@ type Nagios struct{}
 
 func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	var testCount, failed, skipped int
+
 	var summary map[int]string
+	summary = make(map[int]string)
+
 	for resultGroup := range results {
 		for _, testResult := range resultGroup {
 			switch testResult.Result {
 			case resource.FAIL:
-				summary[failed] = "not ok " + strconv.Itoa(failed+1) + " - " + humanizeResult2(testResult) + "\n"
+				summary[failed] = "Failure " + strconv.Itoa(failed+1) + " - " + humanizeResult2(testResult) + "\n"
 				failed++
 			case resource.SKIP:
 				skipped++

--- a/outputs/nagios.go
+++ b/outputs/nagios.go
@@ -18,7 +18,7 @@ func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startT
 		for _, testResult := range resultGroup {
 			switch testResult.Result {
 			case resource.FAIL:
-				summary[failed] = "not ok " + strconv.Itoa(testCount+1) + " - " + humanizeResult2(testResult) + "\n"
+				summary[failed] = "not ok " + strconv.Itoa(failed+1) + " - " + humanizeResult2(testResult) + "\n"
 				failed++
 			case resource.SKIP:
 				skipped++

--- a/outputs/nagios.go
+++ b/outputs/nagios.go
@@ -12,10 +12,12 @@ type Nagios struct{}
 
 func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	var testCount, failed, skipped int
+	var summary map[int]string
 	for resultGroup := range results {
 		for _, testResult := range resultGroup {
 			switch testResult.Result {
 			case resource.FAIL:
+				summary[failed] = "not ok " + strconv.Itoa(testCount+1) + " - " + humanizeResult2(testResult) + "\n"
 				failed++
 			case resource.SKIP:
 				skipped++
@@ -27,6 +29,9 @@ func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startT
 	duration := time.Since(startTime)
 	if failed > 0 {
 		fmt.Fprintf(w, "GOSS CRITICAL - Count: %d, Failed: %d, Skipped: %d, Duration: %.3fs\n", testCount, failed, skipped, duration.Seconds())
+		for i := 0; i < failed; i++ {
+			fmt.Fprintf(w, "%s", summary[i])
+		}
 		return 2
 	}
 	fmt.Fprintf(w, "GOSS OK - Count: %d, Failed: %d, Skipped: %d, Duration: %.3fs\n", testCount, failed, skipped, duration.Seconds())

--- a/outputs/nagios.go
+++ b/outputs/nagios.go
@@ -3,6 +3,7 @@ package outputs
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/aelsabbahy/goss/resource"

--- a/outputs/nagios_verbose.go
+++ b/outputs/nagios_verbose.go
@@ -3,19 +3,25 @@ package outputs
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/aelsabbahy/goss/resource"
 )
 
-type Nagios struct{}
+type NagiosVerbose struct{}
 
-func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
+func (r NagiosVerbose) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	var testCount, failed, skipped int
+
+	var summary map[int]string
+	summary = make(map[int]string)
+
 	for resultGroup := range results {
 		for _, testResult := range resultGroup {
 			switch testResult.Result {
 			case resource.FAIL:
+				summary[failed] = "Fail " + strconv.Itoa(failed+1) + " - " + humanizeResult2(testResult) + "\n"
 				failed++
 			case resource.SKIP:
 				skipped++
@@ -27,6 +33,9 @@ func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startT
 	duration := time.Since(startTime)
 	if failed > 0 {
 		fmt.Fprintf(w, "GOSS CRITICAL - Count: %d, Failed: %d, Skipped: %d, Duration: %.3fs\n", testCount, failed, skipped, duration.Seconds())
+		for i := 0; i < failed; i++ {
+			fmt.Fprintf(w, "%s", summary[i])
+		}
 		return 2
 	}
 	fmt.Fprintf(w, "GOSS OK - Count: %d, Failed: %d, Skipped: %d, Duration: %.3fs\n", testCount, failed, skipped, duration.Seconds())
@@ -34,5 +43,5 @@ func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startT
 }
 
 func init() {
-	RegisterOutputer("nagios", &Nagios{})
+	RegisterOutputer("nagios_verbose", &NagiosVerbose{})
 }


### PR DESCRIPTION
Hi,

I thought I'd open up a PR to output the actual failures in the Nagios ($longserviceoutput$) this makes Goss's Nagios output more contextual showing what has failed improving alerts if used with Sensu, Nagios etc.

Any feedback or discussion welcome.

Thanks,

Tim.