### PR TITLE
Dns reverse lookup

### DIFF
--- a/add.go
+++ b/add.go
@@ -64,6 +64,13 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 			os.Exit(1)
 		}
 		resourcePrint(fileName, res)
+	case "ReverseDNS":
+		res, err := gossConfig.ReverseDNS.AppendSysResource(key, sys, config)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		resourcePrint(fileName, res)
 	case "File":
 		res, err := gossConfig.Files.AppendSysResource(key, sys, config)
 		if err != nil {

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -222,6 +222,20 @@ func main() {
 					},
 				},
 				{
+					Name:  "reverse-dns",
+					Usage: "add new reverse dns",
+					Flags: []cli.Flag{
+						cli.DurationFlag{
+							Name:  "timeout",
+							Value: 500 * time.Millisecond,
+						},
+					},
+					Action: func(c *cli.Context) error {
+						goss.AddResources(c.GlobalString("gossfile"), "ReverseDNS", c.Args(), c)
+						return nil
+					},
+				},
+				{
 					Name:  "process",
 					Usage: "add new process name",
 					Action: func(c *cli.Context) error {

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -70,7 +70,7 @@ func main() {
 		{
 			Name:    "serve",
 			Aliases: []string{"s"},
-			Usage:   "Serve a health enpoint",
+			Usage:   "Serve a health endpoint",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:   "format, f",

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -28,6 +28,7 @@
       * [group](#group)
       * [command](#command)
       * [dns](#dns)
+      * [reverse-dns](#reverse-dns)
       * [process](#process)
       * [kernel-param](#kernel-param)
       * [mount](#mount)
@@ -138,6 +139,7 @@ Will automatically add the following matching resources:
 Will **NOT** automatically add:
 * commands - for safety
 * dns
+* reverse-dns
 * addr
 * kernel-param
 * mount
@@ -198,6 +200,7 @@ This will add a test for a resource. Non existent resources will add a test to e
 * group - add new group
 * command - add new command
 * dns - add new dns
+* reverse-dns - add a new reverse-dns
 * process - add new process name
 * kernel-param - add new kernel-param
 * mount - add new mount
@@ -357,6 +360,19 @@ dns:
     addrs:
     - 127.0.0.1
     - ::1
+    timeout: 500 # in milliseconds
+```
+### reverse-dns
+Validates that the provided IP has a resolveable PTR record and the hosts it resolves to.
+
+```yaml
+reverse-dns:
+  64.233.184.26:
+    # required attributes
+    resolveable: true
+    # optional attributes
+    hosts:
+    - wa-in-f26.1e100.net.
     timeout: 500 # in milliseconds
 ```
 ### process

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -52,7 +52,7 @@ VERSION:
 
 COMMANDS:
    validate, v	Validate system
-   serve, s	Serve a health enpoint
+   serve, s	Serve a health endpoint
    render, r	render gossfile after imports
    autoadd, aa	automatically add all matching resource to the test suite
    add, a	add a resource to the test suite

--- a/goss_config.go
+++ b/goss_config.go
@@ -16,6 +16,7 @@ type GossConfig struct {
 	Groups       resource.GroupMap       `json:"group,omitempty" yaml:"group,omitempty"`
 	Commands     resource.CommandMap     `json:"command,omitempty" yaml:"command,omitempty"`
 	DNS          resource.DNSMap         `json:"dns,omitempty" yaml:"dns,omitempty"`
+	ReverseDNS   resource.ReverseDNSMap  `json:"reverse-dns,omitempty" yaml:"reverse-dns,omitempty"`
 	Processes    resource.ProcessMap     `json:"process,omitempty" yaml:"process,omitempty"`
 	Gossfiles    resource.GossfileMap    `json:"gossfile,omitempty" yaml:"gossfile,omitempty"`
 	KernelParams resource.KernelParamMap `json:"kernel-param,omitempty" yaml:"kernel-param,omitempty"`
@@ -35,6 +36,7 @@ func NewGossConfig() *GossConfig {
 		Groups:       make(resource.GroupMap),
 		Commands:     make(resource.CommandMap),
 		DNS:          make(resource.DNSMap),
+		ReverseDNS:   make(resource.ReverseDNSMap),
 		Processes:    make(resource.ProcessMap),
 		Gossfiles:    make(resource.GossfileMap),
 		KernelParams: make(resource.KernelParamMap),
@@ -47,7 +49,7 @@ func NewGossConfig() *GossConfig {
 func (c *GossConfig) Resources() []resource.Resource {
 	var tests []resource.Resource
 
-	gm := genericConcatMaps(c.Commands, c.HTTPs, c.Addrs, c.DNS, c.Packages, c.Services, c.Files, c.Processes, c.Users, c.Groups, c.Ports, c.KernelParams, c.Mounts, c.Interfaces)
+	gm := genericConcatMaps(c.Commands, c.HTTPs, c.Addrs, c.DNS, c.ReverseDNS, c.Packages, c.Services, c.Files, c.Processes, c.Users, c.Groups, c.Ports, c.KernelParams, c.Mounts, c.Interfaces)
 	for _, m := range gm {
 		for _, t := range m {
 			// FIXME: Can this be moved to a safer compile-time check?
@@ -118,6 +120,10 @@ func mergeGoss(g1, g2 GossConfig) GossConfig {
 
 	for k, v := range g2.DNS {
 		g1.DNS[k] = v
+	}
+
+	for k, v := range g2.ReverseDNS {
+		g1.ReverseDNS[k] = v
 	}
 
 	for k, v := range g2.Processes {

--- a/integration-tests/goss/alpine3/goss-expected-q.json
+++ b/integration-tests/goss/alpine3/goss-expected-q.json
@@ -87,6 +87,12 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "timeout": 1000
+        }
+    },
     "process": {
         "apache2": {
             "running": false

--- a/integration-tests/goss/alpine3/goss-expected.json
+++ b/integration-tests/goss/alpine3/goss-expected.json
@@ -107,6 +107,15 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "hosts": [
+                "wa-in-f26.1e100.net."
+            ],
+            "timeout": 1000
+        }
+    },
     "process": {
         "apache2": {
             "running": false

--- a/integration-tests/goss/centos7/goss-expected-q.json
+++ b/integration-tests/goss/centos7/goss-expected-q.json
@@ -87,6 +87,12 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "timeout": 1000
+        }
+    },
     "process": {
         "foobar": {
             "running": false

--- a/integration-tests/goss/centos7/goss-expected.json
+++ b/integration-tests/goss/centos7/goss-expected.json
@@ -114,6 +114,15 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "hosts": [
+                "wa-in-f26.1e100.net."
+            ],
+            "timeout": 1000
+        }
+    },
     "process": {
         "foobar": {
             "running": false

--- a/integration-tests/goss/centos7/goss.json
+++ b/integration-tests/goss/centos7/goss.json
@@ -45,6 +45,15 @@
             "ip": ["::"]
         }
     },
+    "reverse-dns": {
+        "64.233.184.26" : {
+            "resolveable": true,
+            "hosts": [
+                "wa-in-f26.1e100.net."
+            ],
+            "timeout": 1000
+        }
+    },
     "gossfile": {
         "../goss-shared.json": {},
         "../goss-service.json": {}

--- a/integration-tests/goss/generate_goss.sh
+++ b/integration-tests/goss/generate_goss.sh
@@ -36,6 +36,8 @@ goss a "${args[@]}" command "echo 'hi'" foobar
 
 goss a "${args[@]}" dns --timeout 1s localhost
 
+goss a "${args[@]}" reverse-dns --timeout 1s 64.233.184.26
+
 goss a "${args[@]}" process $package foobar
 
 goss a "${args[@]}" kernel-param kernel.ostype

--- a/integration-tests/goss/goss-shared.json
+++ b/integration-tests/goss/goss-shared.json
@@ -82,6 +82,15 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26" : {
+            "resolveable": true,
+            "hosts": [
+                "wa-in-f26.1e100.net."
+            ],
+            "timeout": 1000
+        }
+    },
     "process": {
         "foobar": {
             "running": false

--- a/integration-tests/goss/precise/goss-expected-q.json
+++ b/integration-tests/goss/precise/goss-expected-q.json
@@ -87,6 +87,12 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "timeout": 1000
+        }
+    },
     "process": {
         "apache2": {
             "running": true

--- a/integration-tests/goss/precise/goss-expected.json
+++ b/integration-tests/goss/precise/goss-expected.json
@@ -114,6 +114,15 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "hosts": [
+                "wa-in-f26.1e100.net."
+            ],
+            "timeout": 1000
+        }
+    },
     "process": {
         "apache2": {
             "running": true

--- a/integration-tests/goss/wheezy/goss-expected-q.json
+++ b/integration-tests/goss/wheezy/goss-expected-q.json
@@ -87,6 +87,12 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "timeout": 1000
+        }
+    },
     "process": {
         "apache2": {
             "running": true

--- a/integration-tests/goss/wheezy/goss-expected.json
+++ b/integration-tests/goss/wheezy/goss-expected.json
@@ -114,6 +114,15 @@
             "timeout": 1000
         }
     },
+    "reverse-dns": {
+        "64.233.184.26": {
+            "resolveable": true,
+            "hosts": [
+                "wa-in-f26.1e100.net."
+            ],
+            "timeout": 1000
+        }
+    },
     "process": {
         "apache2": {
             "running": true

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -44,9 +44,9 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" -g "/goss/$os/goss.json" validate
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-  egrep -q 'Count: 35, Failed: 0' <<<"$out"
+  egrep -q 'Count: 37, Failed: 0' <<<"$out"
 else
-  egrep -q 'Count: 51, Failed: 0' <<<"$out"
+  egrep -q 'Count: 53, Failed: 0' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then

--- a/resource/resource_list.go
+++ b/resource/resource_list.go
@@ -1016,6 +1016,117 @@ func (r *ProcessMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 //go:generate sed -i -e "/^\\/\\/ +build genny/d" resource_list.go
 //go:generate goimports -w resource_list.go resource_list.go
 
+type ReverseDNSMap map[string]*ReverseDNS
+
+func (r ReverseDNSMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*ReverseDNS, error) {
+	sysres := sys.NewReverseDNS(sr, sys, config)
+	res, err := NewReverseDNS(sysres, config)
+	if err != nil {
+		return nil, err
+	}
+	if old_res, ok := r[res.ID()]; ok {
+		res.Title = old_res.Title
+		res.Meta = old_res.Meta
+	}
+	r[res.ID()] = res
+	return res, nil
+}
+
+func (r ReverseDNSMap) AppendSysResourceIfExists(sr string, sys *system.System) (*ReverseDNS, system.ReverseDNS, bool) {
+	sysres := sys.NewReverseDNS(sr, sys, util.Config{})
+	// FIXME: Do we want to be silent about errors?
+	res, _ := NewReverseDNS(sysres, util.Config{})
+	if e, _ := sysres.Exists(); e != true {
+		return res, sysres, false
+	}
+	if old_res, ok := r[res.ID()]; ok {
+		res.Title = old_res.Title
+		res.Meta = old_res.Meta
+	}
+	r[res.ID()] = res
+	return res, sysres, true
+}
+
+func (r *ReverseDNSMap) UnmarshalJSON(data []byte) error {
+	resEmpty := ReverseDNS{}
+	validAttrs, err := validAttrs(resEmpty, "json")
+	if err != nil {
+		return err
+	}
+	var validate map[string]map[string]interface{}
+	if err := json.Unmarshal(data, &validate); err != nil {
+		return err
+	}
+
+	typ := reflect.TypeOf(resEmpty)
+	typs := strings.Split(typ.String(), ".")[1]
+	for id, v := range validate {
+		for k, _ := range v {
+			if !validAttrs[k] {
+				return fmt.Errorf("Invalid Attribute for %s:%s: %s", typs, id, k)
+			}
+		}
+	}
+
+	var tmp map[string]*ReverseDNS
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	for id, res := range tmp {
+		if res == nil {
+			return fmt.Errorf("Could not parse resource %s:%s", typs, id)
+		}
+		res.SetID(id)
+	}
+
+	*r = tmp
+
+	return nil
+}
+
+//func (r *ReverseDNSMap) UnmarshalYAML(data []byte) error {
+func (r *ReverseDNSMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	resEmpty := ReverseDNS{}
+	validAttrs, err := validAttrs(resEmpty, "yaml")
+	if err != nil {
+		return err
+	}
+	var validate map[string]map[string]interface{}
+	if err := unmarshal(&validate); err != nil {
+		return err
+	}
+
+	typ := reflect.TypeOf(resEmpty)
+	typs := strings.Split(typ.String(), ".")[1]
+	for id, v := range validate {
+		for k, _ := range v {
+			if !validAttrs[k] {
+				return fmt.Errorf("Invalid Attribute for %s:%s: %s", typs, id, k)
+			}
+		}
+	}
+
+	var tmp map[string]*ReverseDNS
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+
+	for id, res := range tmp {
+		if res == nil {
+			return fmt.Errorf("Could not parse resource %s:%s", typs, id)
+		}
+		res.SetID(id)
+	}
+
+	*r = tmp
+
+	return nil
+}
+
+//go:generate sed -i -e "/^\\/\\/ +build genny/d" resource_list.go
+//go:generate goimports -w resource_list.go resource_list.go
+
 type ServiceMap map[string]*Service
 
 func (r ServiceMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Service, error) {

--- a/resource/resource_list_genny.go
+++ b/resource/resource_list_genny.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cheekybits/genny/generic"
 )
 
-//go:generate genny -in=$GOFILE -out=resource_list.go gen "ResourceType=Addr,Command,DNS,File,Gossfile,Group,Package,Port,Process,Service,User,KernelParam,Mount,Interface,HTTP"
+//go:generate genny -in=$GOFILE -out=resource_list.go gen "ResourceType=Addr,Command,DNS,File,Gossfile,Group,Package,Port,Process,ReverseDNS,Service,User,KernelParam,Mount,Interface,HTTP"
 //go:generate sed -i -e "/^\\/\\/ +build genny/d" resource_list.go
 //go:generate goimports -w resource_list.go resource_list.go
 

--- a/resource/reverse_dns.go
+++ b/resource/reverse_dns.go
@@ -1,0 +1,54 @@
+package resource
+
+import (
+	"github.com/aelsabbahy/goss/system"
+	"github.com/aelsabbahy/goss/util"
+)
+
+type ReverseDNS struct {
+	Title       string  `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta        meta    `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Addr        string  `json:"-" yaml:"-"`
+	Resolveable matcher `json:"resolveable" yaml:"resolveable"`
+	Hosts       matcher `json:"hosts,omitempty" yaml:"hosts,omitempty"`
+	Timeout     int     `json:"timeout" yaml:"timeout"`
+}
+
+func (d *ReverseDNS) ID() string      { return d.Addr }
+func (d *ReverseDNS) SetID(id string) { d.Addr = id }
+
+func (d *ReverseDNS) GetTitle() string { return d.Title }
+func (d *ReverseDNS) GetMeta() meta    { return d.Meta }
+
+func (d *ReverseDNS) Validate(sys *system.System) []TestResult {
+	skip := false
+	if d.Timeout == 0 {
+		d.Timeout = 500
+	}
+	sysReverseDNS := sys.NewReverseDNS(d.Addr, sys, util.Config{Timeout: d.Timeout})
+
+	var results []TestResult
+	results = append(results, ValidateValue(d, "resolveable", d.Resolveable, sysReverseDNS.Resolveable, skip))
+	if shouldSkip(results) {
+		skip = true
+	}
+	if d.Hosts != nil {
+		results = append(results, ValidateValue(d, "hosts", d.Hosts, sysReverseDNS.Hosts, skip))
+	}
+	return results
+}
+
+func NewReverseDNS(sysReverseDNS system.ReverseDNS, config util.Config) (*ReverseDNS, error) {
+	addr := sysReverseDNS.Addr()
+	resolveable, err := sysReverseDNS.Resolveable()
+	d := &ReverseDNS{
+		Addr:        addr,
+		Resolveable: resolveable,
+		Timeout:     config.Timeout,
+	}
+	if !contains(config.IgnoreList, "hosts") {
+		hosts, _ := sysReverseDNS.Hosts()
+		d.Hosts = hosts
+	}
+	return d, err
+}

--- a/system/reverse_dns.go
+++ b/system/reverse_dns.go
@@ -9,43 +9,43 @@ import (
 	"github.com/aelsabbahy/goss/util"
 )
 
-type DNS interface {
-	Host() string
-	Addrs() ([]string, error)
+type ReverseDNS interface {
+	Addr() string
+	Hosts() ([]string, error)
 	Resolveable() (bool, error)
 	Exists() (bool, error)
 }
 
-type DefDNS struct {
-	host        string
+type DefReverseDNS struct {
+	addr        string
 	resolveable bool
-	addrs       []string
+	hosts       []string
 	Timeout     int
 	loaded      bool
 	err         error
 }
 
-func NewDefDNS(host string, system *System, config util.Config) DNS {
-	return &DefDNS{
-		host:    host,
+func NewDefReverseDNS(addr string, system *System, config util.Config) ReverseDNS {
+	return &DefReverseDNS{
+		addr:    addr,
 		Timeout: config.Timeout,
 	}
 }
 
-func (d *DefDNS) Host() string {
-	return d.host
+func (d *DefReverseDNS) Addr() string {
+	return d.addr
 }
 
-func (d *DefDNS) setup() error {
+func (d *DefReverseDNS) setup() error {
 	if d.loaded {
 		return d.err
 	}
 	d.loaded = true
 
-	addrs, err := lookupHost(d.host, d.Timeout)
-	if err != nil || len(addrs) == 0 {
+	hosts, err := lookupAddr(d.addr, d.Timeout)
+	if err != nil || len(hosts) == 0 {
 		d.resolveable = false
-		d.addrs = []string{}
+		d.hosts = []string{}
 		// DNSError is resolvable == false, ignore error
 		if _, ok := err.(*net.DNSError); ok {
 			return nil
@@ -53,39 +53,39 @@ func (d *DefDNS) setup() error {
 		d.err = err
 		return d.err
 	}
-  sort.Strings(addrs)
+	sort.Strings(hosts)
 	d.resolveable = true
-	d.addrs = addrs
+	d.hosts = hosts
 	return nil
 }
 
-func (d *DefDNS) Addrs() ([]string, error) {
+func (d *DefReverseDNS) Hosts() ([]string, error) {
 	err := d.setup()
 
-	return d.addrs, err
+	return d.hosts, err
 }
 
-func (d *DefDNS) Resolveable() (bool, error) {
+func (d *DefReverseDNS) Resolveable() (bool, error) {
 	err := d.setup()
 
 	return d.resolveable, err
 }
 
 // Stub out
-func (d *DefDNS) Exists() (bool, error) {
+func (d *DefReverseDNS) Exists() (bool, error) {
 	return false, nil
 }
 
-func lookupHost(host string, timeout int) ([]string, error) {
+func lookupAddr(addr string, timeout int) ([]string, error) {
 	c1 := make(chan []string, 1)
 	e1 := make(chan error, 1)
 	timeoutD := time.Duration(timeout) * time.Millisecond
 	go func() {
-		addrs, err := net.LookupHost(host)
+		hosts, err := net.LookupAddr(addr)
 		if err != nil {
 			e1 <- err
 		}
-		c1 <- addrs
+		c1 <- hosts
 	}()
 	select {
 	case res := <-c1:

--- a/system/system.go
+++ b/system/system.go
@@ -28,6 +28,7 @@ type System struct {
 	NewGroup       func(string, *System, util2.Config) Group
 	NewCommand     func(string, *System, util2.Config) Command
 	NewDNS         func(string, *System, util2.Config) DNS
+	NewReverseDNS  func(string, *System, util2.Config) ReverseDNS
 	NewProcess     func(string, *System, util2.Config) Process
 	NewGossfile    func(string, *System, util2.Config) Gossfile
 	NewKernelParam func(string, *System, util2.Config) KernelParam
@@ -63,6 +64,7 @@ func New(c *cli.Context) *System {
 		NewGroup:       NewDefGroup,
 		NewCommand:     NewDefCommand,
 		NewDNS:         NewDefDNS,
+		NewReverseDNS:  NewDefReverseDNS,
 		NewProcess:     NewDefProcess,
 		NewGossfile:    NewDefGossfile,
 		NewKernelParam: NewDefKernelParam,


### PR DESCRIPTION
This PR adds the ability to check DNS reverse lookups which are required for various application servers like Oracle's Weblogic to function properly.

It's basically a clone of the existing DNS resource but takes the IP address to lookup and uses net.lookupAddr to resolve the PTR record(s) for that IP address.

The reverse DNS resource will also help identify old PTR records hanging around (which results in IP's resolving to incorrect hostnames).

I've also made appropriate additions to the tests and documentation.

Any feedback appreciated. 