### PR TITLE
Added NoFollowRedirects option, closes #160

### DIFF
--- a/add.go
+++ b/add.go
@@ -16,9 +16,10 @@ import (
 func AddResources(fileName, resourceName string, keys []string, c *cli.Context) error {
 	setStoreFormatFromFileName(fileName)
 	config := util.Config{
-		IgnoreList:    c.GlobalStringSlice("exclude-attr"),
-		Timeout:       int(c.Duration("timeout") / time.Millisecond),
-		AllowInsecure: c.Bool("insecure"),
+		IgnoreList:        c.GlobalStringSlice("exclude-attr"),
+		Timeout:           int(c.Duration("timeout") / time.Millisecond),
+		AllowInsecure:     c.Bool("insecure"),
+		NoFollowRedirects: c.Bool("no-follow-redirects"),
 	}
 
 	var gossConfig GossConfig

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -248,6 +248,9 @@ func main() {
 						cli.BoolFlag{
 							Name: "insecure, k",
 						},
+						cli.BoolFlag{
+							Name: "no-follow-redirects, r",
+						},
 						cli.DurationFlag{
 							Name:  "timeout",
 							Value: 5 * time.Second,

--- a/integration-tests/goss/alpine3/goss-expected-q.json
+++ b/integration-tests/goss/alpine3/goss-expected-q.json
@@ -106,9 +106,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/alpine3/goss-expected.json
+++ b/integration-tests/goss/alpine3/goss-expected.json
@@ -132,9 +132,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/centos7/goss-expected-q.json
+++ b/integration-tests/goss/centos7/goss-expected-q.json
@@ -106,9 +106,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/centos7/goss-expected.json
+++ b/integration-tests/goss/centos7/goss-expected.json
@@ -139,9 +139,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/generate_goss.sh
+++ b/integration-tests/goss/generate_goss.sh
@@ -44,6 +44,8 @@ goss a "${args[@]}" mount /dev
 
 goss a "${args[@]}" http https://www.google.com
 
+goss a "${args[@]}" http http://google.com -r
+
 # Auto-add
 $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa $package
 # Validate that duplicates are ignored

--- a/integration-tests/goss/precise/goss-expected-q.json
+++ b/integration-tests/goss/precise/goss-expected-q.json
@@ -106,9 +106,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/precise/goss-expected.json
+++ b/integration-tests/goss/precise/goss-expected.json
@@ -139,9 +139,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/wheezy/goss-expected-q.json
+++ b/integration-tests/goss/wheezy/goss-expected-q.json
@@ -106,9 +106,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/integration-tests/goss/wheezy/goss-expected.json
+++ b/integration-tests/goss/wheezy/goss-expected.json
@@ -139,9 +139,17 @@
         }
     },
     "http": {
+        "http://google.com": {
+            "status": 301,
+            "allow-insecure": false,
+            "no-follow-redirects": true,
+            "timeout": 5000,
+            "body": []
+        },
         "https://www.google.com": {
             "status": 200,
             "allow-insecure": false,
+            "no-follow-redirects": false,
             "timeout": 5000,
             "body": []
         }

--- a/resource/http.go
+++ b/resource/http.go
@@ -6,13 +6,14 @@ import (
 )
 
 type HTTP struct {
-	Title         string   `json:"title,omitempty" yaml:"title,omitempty"`
-	Meta          meta     `json:"meta,omitempty" yaml:"meta,omitempty"`
-	HTTP          string   `json:"-" yaml:"-"`
-	Status        matcher  `json:"status" yaml:"status"`
-	AllowInsecure bool     `json:"allow-insecure" yaml:"allow-insecure"`
-	Timeout       int      `json:"timeout" yaml:"timeout"`
-	Body          []string `json:"body" yaml:"body"`
+	Title             string   `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta              meta     `json:"meta,omitempty" yaml:"meta,omitempty"`
+	HTTP              string   `json:"-" yaml:"-"`
+	Status            matcher  `json:"status" yaml:"status"`
+	AllowInsecure     bool     `json:"allow-insecure" yaml:"allow-insecure"`
+	NoFollowRedirects bool     `json:"no-follow-redirects" yaml:"no-follow-redirects"`
+	Timeout           int      `json:"timeout" yaml:"timeout"`
+	Body              []string `json:"body" yaml:"body"`
 }
 
 func (u *HTTP) ID() string      { return u.HTTP }
@@ -27,8 +28,9 @@ func (u *HTTP) Validate(sys *system.System) []TestResult {
 	if u.Timeout == 0 {
 		u.Timeout = 5000
 	}
-	sysHTTP := sys.NewHTTP(u.HTTP, sys, util.Config{AllowInsecure: u.AllowInsecure, Timeout: u.Timeout})
+	sysHTTP := sys.NewHTTP(u.HTTP, sys, util.Config{AllowInsecure: u.AllowInsecure, NoFollowRedirects: u.NoFollowRedirects, Timeout: u.Timeout})
 	sysHTTP.SetAllowInsecure(u.AllowInsecure)
+	sysHTTP.SetNoFollowRedirects(u.NoFollowRedirects)
 
 	var results []TestResult
 	results = append(results, ValidateValue(u, "status", u.Status, sysHTTP.Status, skip))
@@ -46,11 +48,12 @@ func NewHTTP(sysHTTP system.HTTP, config util.Config) (*HTTP, error) {
 	http := sysHTTP.HTTP()
 	status, err := sysHTTP.Status()
 	u := &HTTP{
-		HTTP:          http,
-		Status:        status,
-		Body:          []string{},
-		AllowInsecure: config.AllowInsecure,
-		Timeout:       config.Timeout,
+		HTTP:              http,
+		Status:            status,
+		Body:              []string{},
+		AllowInsecure:     config.AllowInsecure,
+		NoFollowRedirects: config.NoFollowRedirects,
+		Timeout:           config.Timeout,
 	}
 	return u, err
 }

--- a/system/system.go
+++ b/system/system.go
@@ -33,7 +33,7 @@ type System struct {
 	NewKernelParam func(string, *System, util2.Config) KernelParam
 	NewMount       func(string, *System, util2.Config) Mount
 	NewInterface   func(string, *System, util2.Config) Interface
-	NewHTTP         func(string, *System, util2.Config) HTTP
+	NewHTTP        func(string, *System, util2.Config) HTTP
 	ports          map[string][]GOnetstat.Process
 	portsOnce      sync.Once
 	procMap        map[string][]ps.Process
@@ -68,7 +68,7 @@ func New(c *cli.Context) *System {
 		NewKernelParam: NewDefKernelParam,
 		NewMount:       NewDefMount,
 		NewInterface:   NewDefInterface,
-		NewHTTP:         NewDefHTTP,
+		NewHTTP:        NewDefHTTP,
 	}
 	sys.detectService()
 	sys.detectPackage(c)

--- a/util/config.go
+++ b/util/config.go
@@ -1,7 +1,8 @@
 package util
 
 type Config struct {
-	IgnoreList    []string
-	Timeout       int
-	AllowInsecure bool
+	IgnoreList        []string
+	Timeout           int
+	AllowInsecure     bool
+	NoFollowRedirects bool
 }


### PR DESCRIPTION
I added reversed boolean option `no-follow-redirects` in order not to break compatibility with the previous versions. If you think that it is better to have `follow-redirects` then I can reverse and rebase. 

Another idea is to make this flag and json elements optional but from the overall code convention I can see that all are required. 

Usage: (added `-r` to say "do not follow redirects)

```
➜  resource git:(master) goss add http http://wp.pl/ -r
Adding HTTP to './goss.yaml':

http://wp.pl/:
  status: 301
  allow-insecure: false
  no-follow-redirects: true
  timeout: 5000
  body: []
```

Please comment and review. 