### PR TITLE
Prometheus Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ package:
 * JUnit
 * nagios - Nagios/Sensu compatible output /w exit code 2 for failures.
 * nagios_verbose - nagios output with verbose failure output.
+* prometheus - prometheus metrics output
 
 ## Community Contributions
 * [goss-ansible](https://github.com/indusbox/goss-ansible) - Ansible module for Goss

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -1,0 +1,87 @@
+package outputs
+
+import (
+	"fmt"
+	"io"
+	"time"
+  "strings"
+
+	"github.com/aelsabbahy/goss/resource"
+
+)
+
+type Prometheus struct{}
+
+func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
+	testCount := 0
+	failed := 0
+	success := 0
+	skipped := 0
+
+	var summary map[int]string
+	summary = make(map[int]string)
+
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			switch testResult.Result {
+			case resource.SUCCESS:
+				summary[testCount] = mechanizeResult(testResult) + "\n"
+				success++
+			case resource.FAIL:
+				summary[testCount] = mechanizeResult(testResult) + "\n"
+				failed++
+			case resource.SKIP:
+				summary[testCount] = mechanizeResult(testResult) + "\n"
+				skipped++
+			default:
+				panic(fmt.Sprintf("Unexpected Result Code: %v\n", testResult.Result))
+			}
+			testCount++
+		}
+	}
+
+	for i := 0; i < testCount; i++ {
+		fmt.Fprintf(w, "%s", summary[i])
+	}
+
+  // Print goss run metrics
+	fmt.Fprintf(w, "goss_count %d \n", testCount)
+	fmt.Fprintf(w, "goss_success_count %d \n", success)
+	fmt.Fprintf(w, "goss_skipped_count %d \n", skipped)
+	fmt.Fprintf(w, "goss_failed_count %d \n", failed)
+
+	duration := float64(time.Since(startTime).Seconds())
+	fmt.Fprintf(w, "goss_duration_seconds %.3f \n", duration)
+
+	if failed > 0 {
+		return 1
+	}
+
+	return 0
+}
+
+func init() {
+	RegisterOutputer("prometheus", &Prometheus{})
+}
+
+func mechanizeResult(r resource.TestResult) string {
+	var res string
+  var err string
+
+	if r.Err != nil {
+		err = fmt.Sprintf(",error=\"%v\"", r.Err)
+		res = "error"
+	} else {
+	  switch r.Result {
+	  case resource.SUCCESS:
+      res = "success"
+ 	  case resource.SKIP:
+      res = "skipped"
+	  case resource.FAIL:
+	  	res = "failed"
+	  default:
+	  	panic(fmt.Sprintf("Unexpected Result Code: %v\n", r.Result))
+	  }
+	}
+	return fmt.Sprintf("goss_%s{resource_id=\"%s\",property=\"%s\",result=\"%s\"%s} %d", strings.ToLower(r.ResourceType), r.ResourceId, r.Property, res, err, int64(r.Duration))
+}

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -45,13 +45,13 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult, st
 	}
 
   // Print goss run metrics
-	fmt.Fprintf(w, "goss_count %d \n", testCount)
-	fmt.Fprintf(w, "goss_success_count %d \n", success)
-	fmt.Fprintf(w, "goss_skipped_count %d \n", skipped)
-	fmt.Fprintf(w, "goss_failed_count %d \n", failed)
+	fmt.Fprintf(w, "goss_count %d\n", testCount)
+	fmt.Fprintf(w, "goss_success_count %d\n", success)
+	fmt.Fprintf(w, "goss_skipped_count %d\n", skipped)
+	fmt.Fprintf(w, "goss_failed_count %d\n", failed)
 
 	duration := float64(time.Since(startTime).Seconds())
-	fmt.Fprintf(w, "goss_duration_seconds %.3f \n", duration)
+	fmt.Fprintf(w, "goss_duration_seconds %.3f\n", duration)
 
 	if failed > 0 {
 		return 1

--- a/serve.go
+++ b/serve.go
@@ -30,6 +30,9 @@ func Serve(c *cli.Context) {
 	if c.String("format") == "json" {
 		health.contentType = "application/json"
 	}
+	if c.String("format") == "prometheus" {
+		health.contentType = "text/plain; version=0.0.4"
+	}
 	http.Handle(endpoint, health)
 	listenAddr := c.String("listen-addr")
 	log.Printf("Starting to listen on: %s", listenAddr)


### PR DESCRIPTION
Here's an interesting output idea I had...

I've taken a naive approach to get output that matches the text format described here:
https://prometheus.io/docs/instrumenting/exposition_formats/

Here's some example output:
```
goss_dns{resource_id="localhost",property="resolveable",result="success"} 68436
goss_dns{resource_id="localhost",property="addrs",result="success"} 26209
goss_command{resource_id="foobar",property="exit-status",result="success"} 8798172
goss_command{resource_id="foobar",property="stderr",result="success"} 12580
goss_command{resource_id="echo 'hi'",property="exit-status",result="success"} 3230123
goss_command{resource_id="echo 'hi'",property="stdout",result="success"} 7177
goss_file{resource_id="/etc/passwd",property="exists",result="success"} 128051
goss_file{resource_id="/etc/passwd",property="mode",result="success"} 16502
goss_file{resource_id="/etc/passwd",property="owner",result="success"} 82310
goss_file{resource_id="/etc/passwd",property="group",result="success"} 51925
goss_file{resource_id="/etc/passwd",property="filetype",result="success"} 7915
goss_file{resource_id="/etc/passwd",property="contains",result="success"} 15575
goss_file{resource_id="/tmp/goss/foobar",property="exists",result="success"} 38996
goss_file{resource_id="~root",property="exists",result="success"} 150526
goss_file{resource_id="~root",property="mode",result="success"} 13414
goss_file{resource_id="/tmp",property="exists",result="success"} 8830
goss_file{resource_id="/tmp",property="mode",result="success"} 5096
goss_service{resource_id="foobar",property="enabled",result="success"} 7821491
goss_service{resource_id="foobar",property="running",result="success"} 4883760
goss_user{resource_id="root",property="exists",result="success"} 98996
goss_user{resource_id="apache",property="exists",result="success"} 41065
goss_user{resource_id="apache",property="uid",result="success"} 33580
goss_user{resource_id="apache",property="gid",result="success"} 43345
goss_user{resource_id="apache",property="home",result="success"} 34521
goss_user{resource_id="apache",property="groups",result="success"} 75610
goss_process{resource_id="foobar",property="running",result="success"} 4313
goss_process{resource_id="httpd",property="running",result="success"} 1641
goss_user{resource_id="foobar",property="exists",result="success"} 47746
goss_port{resource_id="tcp6:80",property="listening",result="success"} 5713
goss_port{resource_id="tcp6:80",property="ip",result="success"} 8581
goss_port{resource_id="tcp:9999",property="listening",result="success"} 1756
goss_group{resource_id="apache",property="exists",result="success"} 41460
goss_group{resource_id="apache",property="gid",result="success"} 71444
goss_group{resource_id="foobar",property="exists",result="success"} 35029
goss_kernelparam{resource_id="kernel.ostype",property="value",result="success"} 22934
goss_mount{resource_id="/dev",property="exists",result="success"} 445609
goss_mount{resource_id="/dev",property="opts",result="success"} 7576
goss_mount{resource_id="/dev",property="source",result="success"} 7988
goss_mount{resource_id="/dev",property="filesystem",result="success"} 1868
goss_interface{resource_id="eth0",property="exists",result="success"} 70178
goss_interface{resource_id="eth0",property="addrs",result="success"} 58664
goss_service{resource_id="autofs",property="enabled",result="success"} 12339980
goss_service{resource_id="autofs",property="running",result="success"} 39094396
goss_service{resource_id="httpd",property="enabled",result="success"} 17970486
goss_service{resource_id="httpd",property="running",result="success"} 10993788
goss_package{resource_id="httpd",property="installed",result="success"} 34295714
goss_package{resource_id="httpd",property="version",result="success"} 9533
goss_http{resource_id="https://www.google.com",property="status",result="error",error="Get https://www.google.com: dial tcp: lookup www.google.com on 172.16.67.2:53: no such host"} 44317285
goss_addr{resource_id="tcp://google.com:443",property="reachable",result="failed"} 48585913
goss_addr{resource_id="tcp://google.com:22",property="reachable",result="success"} 54879544
goss_package{resource_id="foobar",property="installed",result="success"} 36231897
goss_count 51
goss_success_count 49
goss_skipped_count 0
goss_failed_count 2
goss_duration_seconds 0.064
```

The metric value for each test is the duration of that particular test (r.Duration) which might be useful for graphing.

Most of the useful information is in the metric labels which makes it easy query on the prometheus server.

Currently the metrics are untyped and I'd like to get a Prometheus Server container up and running and get some screenshots to show the value of this output (if any).