### PR TITLE
Fix error output when an error is encountered in parsing file

### DIFF
--- a/integration-tests/goss/generate_goss.sh
+++ b/integration-tests/goss/generate_goss.sh
@@ -47,6 +47,18 @@ goss a "${args[@]}" http https://www.google.com
 goss a "${args[@]}" http http://google.com -r
 
 # Auto-add
+# Validate that empty configs don't get created
+$SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa nosuchresource
+if [[ -f $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json ]]
+then
+  echo "Error! Empty config file exists!" && exit 1
+fi
 $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa $package
 # Validate that duplicates are ignored
 $SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa $package
+# Validate that we can aa none existent resources without destroying the file
+$SCRIPT_DIR/$OS/goss-linux-$ARCH -g $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json aa nosuchresource
+if [[ ! -f $SCRIPT_DIR/${OS}/goss-aa-generated-$ARCH.json ]]
+then
+  echo "Error! Config file removed by aa!" && exit 1
+fi

--- a/store.go
+++ b/store.go
@@ -65,7 +65,7 @@ func ReadJSON(filePath string) GossConfig {
 // Reads json byte array returning GossConfig
 func ReadJSONData(data []byte) GossConfig {
 	if StoreFormat == UNSET {
-	  setStoreFormatFromData(data)
+		setStoreFormatFromData(data)
 	}
 	gossConfig := NewGossConfig()
 	// Horrible, but will do for now
@@ -128,17 +128,17 @@ func WriteJSON(filePath string, gossConfig GossConfig) error {
 		log.Fatalf("Error writing: %v\n", err)
 	}
 
-  // check if the auto added json data is empty before writing to file.
+	// check if the auto added json data is empty before writing to file.
 	emptyConfig := *NewGossConfig()
 	emptyData, err := marshal(emptyConfig)
 	if err != nil {
 		log.Fatalf("Error writing: %v\n", err)
 	}
 
-  if string(emptyData) == string(jsonData) {
-	  log.Printf("Can't write empty configuration file. Please check resource name(s).")
+	if string(emptyData) == string(jsonData) {
+		log.Printf("Can't write empty configuration file. Please check resource name(s).")
 		return nil
-  }
+	}
 
 	if err := ioutil.WriteFile(filePath, jsonData, 0644); err != nil {
 		log.Fatalf("Error writing: %v\n", err)

--- a/store.go
+++ b/store.go
@@ -136,7 +136,7 @@ func WriteJSON(filePath string, gossConfig GossConfig) error {
 	}
 
   if string(emptyData) == string(jsonData) {
-	  log.Printf("Configuration empty! Please check resource name(s). Not writing.")
+	  log.Printf("Can't write empty configuration file. Please check resource name(s).")
 		return nil
   }
 

--- a/store.go
+++ b/store.go
@@ -46,7 +46,7 @@ func setStoreFormatFromData(data []byte) {
 		StoreFormat = YAML
 		return
 	}
-	log.Fatalf("Unable to determine format from content")
+	log.Printf("Unable to determine format from content")
 }
 
 // Reads json file returning GossConfig

--- a/store.go
+++ b/store.go
@@ -46,7 +46,7 @@ func setStoreFormatFromData(data []byte) {
 		StoreFormat = YAML
 		return
 	}
-	log.Printf("Unable to determine format from content")
+	log.Fatalf("Unable to determine format from content")
 }
 
 // Reads json file returning GossConfig
@@ -64,7 +64,9 @@ func ReadJSON(filePath string) GossConfig {
 
 // Reads json byte array returning GossConfig
 func ReadJSONData(data []byte) GossConfig {
-	setStoreFormatFromData(data)
+	if StoreFormat == UNSET {
+	  setStoreFormatFromData(data)
+	}
 	gossConfig := NewGossConfig()
 	// Horrible, but will do for now
 	if err := unmarshal(data, gossConfig); err != nil {

--- a/store.go
+++ b/store.go
@@ -128,6 +128,18 @@ func WriteJSON(filePath string, gossConfig GossConfig) error {
 		log.Fatalf("Error writing: %v\n", err)
 	}
 
+  // check if the auto added json data is empty before writing to file.
+	emptyConfig := *NewGossConfig()
+	emptyData, err := marshal(emptyConfig)
+	if err != nil {
+		log.Fatalf("Error writing: %v\n", err)
+	}
+
+  if string(emptyData) == string(jsonData) {
+	  log.Printf("Configuration empty! Please check resource name(s). Not writing.")
+		return nil
+  }
+
 	if err := ioutil.WriteFile(filePath, jsonData, 0644); err != nil {
 		log.Fatalf("Error writing: %v\n", err)
 	}

--- a/validate.go
+++ b/validate.go
@@ -19,27 +19,24 @@ import (
 func getGossConfig(c *cli.Context) GossConfig {
 	// handle stdin
 	var fh *os.File
-	var err error
 	var path, source string
+	var gossConfig GossConfig
 	specFile := c.GlobalString("gossfile")
 	if specFile == "-" {
 		source = "STDIN"
 		fh = os.Stdin
-	} else {
-		source = specFile
-		path = filepath.Dir(specFile)
-		fh, err = os.Open(specFile)
+		data, err := ioutil.ReadAll(fh)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
+		gossConfig = mergeJSONData(ReadJSONData(data), 0, path)
+	} else {
+		source = specFile
+		path = filepath.Dir(specFile)
+		gossConfig = mergeJSONData(ReadJSON(specFile), 0, path)
 	}
-	data, err := ioutil.ReadAll(fh)
-	if err != nil {
-		fmt.Printf("Error: %v\n", err)
-		os.Exit(1)
-	}
-	gossConfig := mergeJSONData(ReadJSONData(data), 0, path)
+
 	if len(gossConfig.Resources()) == 0 {
 		fmt.Printf("Error: found 0 tests, source: %v\n", source)
 		os.Exit(1)


### PR DESCRIPTION
This PR fixes the issue reported in #173 

Thought I'd have a look at this issue to learn more about the way in which goss loads configuration. Initially, it was a little confusing but I realised the reason for readJSONData in store.go is to handle configuration passed to STDIN.

The simplest answer seemed to be to amend validate.go and use readJSONData only when reading from STDIN and to make use of readJSON (which sets the StoreFormat based on file type) when passing a file config to goss.

It was also necessary to amend the setStoreFormatFromData function as the use of log.Fatalf was causing goss to exit before functions that output informative errors had run. 

 Examples of output from a `\.` in configuration:

JSON:
```
2016/11/20 22:51:23 Unable to determine format from content
Error: invalid character '.' in string escape code
```
 
YAML:
```
2016/11/20 22:49:07 Unable to determine format from content
Error: yaml: line 5: found unknown escape character
```

If configuration sent in via STDIN is invalid goss will exit with:
```
Error: StoreFormat unset
2016/11/20 23:36:27 Unable to determine format from content
```

Any feedback appreciated!

Thanks,

Tim.