### PR TITLE
MD5 File checksums

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -463,6 +463,7 @@ file:
     group: root
     filetype: file # file, symlink, directory
     contains: [] # Check file content for these patterns
+    md5: 7c9bb14b3bf178e82c00c2a4398c93cd # md5 checksum of file
 ```
 
 `contains` can be a string or a [pattern](#patterns)

--- a/integration-tests/goss/goss-shared.json
+++ b/integration-tests/goss/goss-shared.json
@@ -26,13 +26,17 @@
                 "root"
             ]
         },
+        "/goss/hellogoss.txt": {
+            "exists": true,
+            "md5": "7c9bb14b3bf178e82c00c2a4398c93cd"
+        },
         "/tmp/goss/foobar": {
             "exists": false,
             "contains": []
         },
         "~root": {
             "exists": true,
-            "mode": "0700"
+            "mode": "0700",
         },
         "/tmp": {
             "exists": true,

--- a/integration-tests/goss/goss-shared.json
+++ b/integration-tests/goss/goss-shared.json
@@ -36,7 +36,7 @@
         },
         "~root": {
             "exists": true,
-            "mode": "0700",
+            "mode": "0700"
         },
         "/tmp": {
             "exists": true,

--- a/integration-tests/goss/hellogoss.txt
+++ b/integration-tests/goss/hellogoss.txt
@@ -1,0 +1,1 @@
+Goss Rocks!!

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -44,9 +44,9 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" -g "/goss/$os/goss.json" validate
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-  egrep -q 'Count: 35, Failed: 0' <<<"$out"
+  egrep -q 'Count: 37, Failed: 0' <<<"$out"
 else
-  egrep -q 'Count: 51, Failed: 0' <<<"$out"
+  egrep -q 'Count: 53, Failed: 0' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then

--- a/resource/file.go
+++ b/resource/file.go
@@ -17,6 +17,7 @@ type File struct {
 	LinkedTo matcher  `json:"linked-to,omitempty" yaml:"linked-to,omitempty"`
 	Filetype matcher  `json:"filetype,omitempty" yaml:"filetype,omitempty"`
 	Contains []string `json:"contains" yaml:"contains"`
+	Md5      matcher  `json:"md5,omitempty" yaml:"md5,omitempty"`
 }
 
 func (f *File) ID() string      { return f.Path }
@@ -54,6 +55,9 @@ func (f *File) Validate(sys *system.System) []TestResult {
 	}
 	if f.Size != nil {
 		results = append(results, ValidateValue(f, "size", f.Size, sysFile.Size, skip))
+	}
+	if f.Md5 != nil {
+		results = append(results, ValidateValue(f, "md5", f.Md5, sysFile.Md5, skip))
 	}
 	return results
 }

--- a/system/file.go
+++ b/system/file.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"crypto/md5"
 	"fmt"
 	"io"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"crypto/md5"
 
 	"github.com/aelsabbahy/goss/util"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -218,7 +218,7 @@ func realPath(path string) (string, error) {
 }
 
 func (f *DefFile) Md5() (string, error) {
-  var result []byte
+
 	if err := f.setup(); err != nil {
 		return "", err
 	}
@@ -227,12 +227,12 @@ func (f *DefFile) Md5() (string, error) {
 	if err != nil {
 		return "", err
 	}
-  defer fh.Close()
+	defer fh.Close()
 
 	hash := md5.New()
-  if _, err := io.Copy(hash, fh); err != nil {
-    return string(result), err
-  }
+	if _, err := io.Copy(hash, fh); err != nil {
+		return "", err
+	}
 
-  return fmt.Sprintf("%x", hash.Sum(result)), nil
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }

--- a/system/file.go
+++ b/system/file.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"crypto/md5"
 
 	"github.com/aelsabbahy/goss/util"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -23,6 +24,7 @@ type File interface {
 	Owner() (string, error)
 	Group() (string, error)
 	LinkedTo() (string, error)
+	Md5() (string, error)
 }
 
 type DefFile struct {
@@ -213,4 +215,24 @@ func realPath(path string) (string, error) {
 	realPath, err = filepath.Abs(realPath)
 
 	return realPath, err
+}
+
+func (f *DefFile) Md5() (string, error) {
+  var result []byte
+	if err := f.setup(); err != nil {
+		return "", err
+	}
+
+	fh, err := os.Open(f.realPath)
+	if err != nil {
+		return "", err
+	}
+  defer fh.Close()
+
+	hash := md5.New()
+  if _, err := io.Copy(hash, fh); err != nil {
+    return string(result), err
+  }
+
+  return fmt.Sprintf("%x", hash.Sum(result)), nil
 }


### PR DESCRIPTION
Hey @aelsabbahy,

I thought a good addition to the `file` resource would be the ability to validate an md5 checksum of the file. It was pretty simple to do. 

I've added the appropriate code, docs and a test file / goss test. 

Output on error looks like: 
```
Failures/Skipped:

File: /etc/passwd: md5:
Expected
    <string>: 6b0364b78fb8968a2d15879125556c3c
to equal
    <string>: 12341234

Total Duration: 1.012s
Count: 52, Failed: 1, Skipped: 0'
```

Errors such as validating an md5 on a directory are handled:
```
Failures/Skipped:

/tmp: md5: Error: read /tmp: is a directory

Total Duration: 1.013s
Count: 54, Failed: 1, Skipped: 0'
```

Any feedback appreciated. Thanks!