### PR TITLE
fix explanation of "validate" over ssh in manual

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -291,7 +291,7 @@ $ curl -s https://static/or/dynamic/goss.json | goss validate
 Total Duration: 0.002s
 Count: 6, Failed: 2, Skipped: 0
 
-$ goss render | ssh remote-host 'goss -f - validate'
+$ goss render | ssh remote-host 'goss -g - validate'
 ......
 
 Total Duration: 0.002s

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -291,7 +291,7 @@ $ curl -s https://static/or/dynamic/goss.json | goss validate
 Total Duration: 0.002s
 Count: 6, Failed: 2, Skipped: 0
 
-$ goss render | ssh remote-host 'goss validate'
+$ goss render | ssh remote-host 'goss -f - validate'
 ......
 
 Total Duration: 0.002s


### PR DESCRIPTION
STDIN is currently not implicitly used (#133), so fixed the manual.