### PR TITLE
Added Molecule to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ package:
 * nagios_verbose - nagios output with verbose failure output.
 
 ## Community Contributions
-* [goss-ansible](https://github.com/indusbox/goss-ansible) - Ansible module for Goss
-* [kitchen-goss](https://github.com/ahelal/kitchen-goss) - A test-kitchen verifier plugin for GOSS
-* [goss-fpm-files](https://github.com/deanwilson/unixdaemon-fpm-cookery-recipes) - Might be useful for building goss system packages
+* [goss-ansible](https://github.com/indusbox/goss-ansible) - Ansible module for Goss.
+* [kitchen-goss](https://github.com/ahelal/kitchen-goss) - A test-kitchen verifier plugin for Goss.
+* [goss-fpm-files](https://github.com/deanwilson/unixdaemon-fpm-cookery-recipes) - Might be useful for building goss system packages.
+* [molecule](https://github.com/metacloud/molecule) - Automated testing for Ansible roles, with native Goss support.
 
 ## Limitations
 


### PR DESCRIPTION
Added Molecule[1] to the 'Community Contributions' section of
the README. Goss is a native Molecule verifier[2], and will be
incorporated into Molecule v2.

[1] http://molecule.readthedocs.io
[2] http://molecule.readthedocs.io/en/stable-1.20/verifier.html#goss