### PR TITLE
Feature/dgoss accept gossfile

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -56,7 +56,9 @@ Run is used to validate a docker container. It expects a `./goss.yaml` file to e
   * This allows writing tests or waits against the docker output
 * (optional) Run `goss` with `$GOSS_WAIT_OPTS` if `./goss_wait.yaml` file exists in the current dir
 * Run `goss` with `$GOSS_OPTS` using `./goss.yaml`
+* Pass an alternate gossfile if --gossfile is specified, default is goss.yaml.
 
+`$ ./dgoss run --gossfile goss2.yaml -it ubuntu bash`
 
 ### Edit
 
@@ -65,6 +67,25 @@ Edit will launch a docker container, install goss, and drop the user into an int
 **Example:**
 
 `dgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine`
+
+To write to the alternate gossfile when inside the container you need to add it to the command run:
+
+`./dgoss edit --gossfile goss2.yaml -it ubuntu bash`
+
+Followed by
+```
+  goss --g goss2.yaml a user root
+  Adding User to 'goss2.yaml':
+
+  root:
+    exists: true
+    uid: 0
+    gid: 0
+    groups:
+    - root
+    home: /root
+    shell: /bin/bash
+```
 
 ### Environment vars and defaults
 The following environment variables can be set to change the behavior of dgoss.
@@ -93,5 +114,6 @@ If unset (or empty), the `--vars` flag is omitted, which is the normal behavior.
 (Default: `''`).
 
 ##### GOSS_FILES_STRATEGY
-Strategy used for copying goss files into the docker container. If set to `'mount'` a volume with goss files is mounted and log output is streamed into the container as `/goss/docker_output.log` file. Other strategy is `'cp'` which uses `'docker cp'` command to copy goss files into docker container. With the `'cp'` strategy you lose the ability to write tests or waits against the docker output. The `'cp'` strategy is required especially when docker daemon is not on the local machine. 
+Strategy used for copying goss files into the docker container. If set to `'mount'` a volume with goss files is mounted and log output is streamed into the container as `/goss/docker_output.log` file. Other strategy is `'cp'` which uses `'docker cp'` command to copy goss files into docker container. With the `'cp'` strategy you lose the ability to write tests or waits against the docker output. The `'cp'` strategy is required especially when docker daemon is not on the local machine.
 (Default `'mount'`)
+=======

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -31,7 +31,7 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        id=$(docker run -d -v "$tmp_dir:/goss" "${@:2}")
+        id=$(docker run -d -v "$tmp_dir:/goss" "${@:${docker_args}}")
         docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
         ;;
       cp)
@@ -68,6 +68,14 @@ GOSS_PATH="${GOSS_PATH:-$(which goss 2> /dev/null || true)}"
 [[ ${GOSS_WAIT_OPTS+x} ]] || GOSS_WAIT_OPTS="-r 30s -s 1s > /dev/null"
 GOSS_SLEEP=${GOSS_SLEEP:-0.2}
 
+if [ $2 == "--gossfile" ]; then
+  goss_file=$3
+  docker_args=4
+else
+  goss_file="goss.yaml"
+  docker_args=2
+fi
+
 case "$1" in
     run)
         run "$@"
@@ -95,7 +103,7 @@ case "$1" in
         run "$@"
         info "Run goss add/autoadd to add resources"
         docker exec -it "$id" sh -c 'cd /goss; PATH="/goss:$PATH" exec sh'
-        get_docker_file "/goss/goss.yaml"
+        get_docker_file "/goss/${goss_file}"
         get_docker_file "/goss/goss_wait.yaml"
         [[ ! -z "${GOSS_VARS}" ]] && get_docker_file "/goss/${GOSS_VARS}"
         ;;

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -22,7 +22,6 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
-<<<<<<< b0d0e31e3b67aac1e8ab0fa9f6bdbbeb40afc9fc
     [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && cp "${GOSS_FILES_PATH}/goss.yaml" "$tmp_dir"
     [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir"
     [[ ! -z "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir"
@@ -46,13 +45,6 @@ run(){
       *) error "Wrong goss files strategy used! Correct options are \"mount\" or \"cp\"."
     esac
 
-=======
-    [[ -e $goss_file ]] && cp $goss_file "$tmp_dir" && chmod 766 "$tmp_dir/$goss_file"
-    [[ -e goss_wait.yaml ]] && cp goss_wait.yaml "$tmp_dir"
-    info "Starting docker container"
-    id=$(docker run -d -v "$tmp_dir:/goss" "${@:${docker_args}}")
-    docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
->>>>>>> Mod: Set write variable on gossfile when existing file being passed in for edit
     log_pid=$!
     info "Container ID: ${id:0:8}"
 }

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -22,6 +22,7 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
+<<<<<<< b0d0e31e3b67aac1e8ab0fa9f6bdbbeb40afc9fc
     [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && cp "${GOSS_FILES_PATH}/goss.yaml" "$tmp_dir"
     [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir"
     [[ ! -z "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir"
@@ -45,6 +46,13 @@ run(){
       *) error "Wrong goss files strategy used! Correct options are \"mount\" or \"cp\"."
     esac
 
+=======
+    [[ -e $goss_file ]] && cp $goss_file "$tmp_dir" && chmod 766 "$tmp_dir/$goss_file"
+    [[ -e goss_wait.yaml ]] && cp goss_wait.yaml "$tmp_dir"
+    info "Starting docker container"
+    id=$(docker run -d -v "$tmp_dir:/goss" "${@:${docker_args}}")
+    docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
+>>>>>>> Mod: Set write variable on gossfile when existing file being passed in for edit
     log_pid=$!
     info "Container ID: ${id:0:8}"
 }


### PR DESCRIPTION
Can use the --gossfile flag to pass in an alternate goss file to the edit or run commands. Makes life easier for when testing many docker containers with this!