### PR TITLE
Add a silent output

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ package:
 * JUnit
 * nagios - Nagios/Sensu compatible output /w exit code 2 for failures.
 * nagios_verbose - nagios output with verbose failure output.
+* silent - No output. Avoids exposing system information (e.g. when serving tests as a healthcheck endpoint).
 
 ## Community Contributions
 * [goss-ansible](https://github.com/indusbox/goss-ansible) - Ansible module for Goss.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -283,6 +283,7 @@ $ curl localhost:8080/healthz
   * `nagios_verbose` - Nagios output with verbose failure output.
   * `rspecish` **(default)** - Similar to rspec output
   * `TAP`
+  * `silent` - No output. Avoids exposing system information (e.g. when serving tests as a healthcheck endpoint).
 * `--max-concurrent` - Max number of tests to run concurrently
 * `--no-color` - Disable color
 * `--color` - Force enable color

--- a/outputs/silent.go
+++ b/outputs/silent.go
@@ -1,0 +1,31 @@
+package outputs
+
+import (
+	"io"
+	"time"
+
+	"github.com/aelsabbahy/goss/resource"
+)
+
+type Silent struct{}
+
+func (r Silent) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
+	var failed int
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			switch testResult.Result {
+			case resource.FAIL:
+				failed++
+			}
+		}
+	}
+
+	if failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+func init() {
+	RegisterOutputer("silent", &Silent{})
+}


### PR DESCRIPTION
When using goss as a helathchecking endpoint, it may be desirable to
suppress verbose test output so that potential malicious entities can't
scrape healthcheck endpoints for system information.

Add the `silent` output, which simply checks whether any tests have
failed and returns 1 or 0 accordingly, without printing any output.