### PR TITLE
Fixed typo in dgoss Mac instructions

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -21,7 +21,7 @@ curl -L https://raw.githubusercontent.com/aelsabbahy/goss/master/extras/dgoss/dg
 chmod +rx /usr/local/bin/dgoss
 
 # Download goss to your preferred location
-curl -L https://github.com/aelsabbahy/goss/releases/download/v0.3.1/goss-linux-amd64 - o ~/Downloads/goss-linux-amd64
+curl -L https://github.com/aelsabbahy/goss/releases/download/v0.3.1/goss-linux-amd64 -o ~/Downloads/goss-linux-amd64
 
 # Set your GOSS_PATH to the above location
 export GOSS_PATH=~/Downloads/goss-linux-amd64


### PR DESCRIPTION
Just fixed a simple typo in the Mac instructions
`- o` should be `-o`
otherwise, the user gets this:
```
curl: option -: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
```