### PR TITLE
Steal regexMatch from consul-template

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -766,6 +766,7 @@ Available functions beyond text/template [built-in functions](https://golang.org
 * `getEnv "var" ["default"]` - A more forgiving env var lookup. If key is missing either "" or default (if provided) is returned.
 * `readFile "fileName"` - Reads file content into a a string, trims whitespace. Useful when a file contains a token.
   * **NOTE:** Goss will error out during during the parsing phase if the file does not exist, no tests will be executed.
+* `regexMatch "(some)?reg[eE]xp"` - Tests the piped input against the regular expression argument.
 
 **NOTE:** gossfiles containing text/template `{{}}` controls will no longer work with `goss add/autoadd`. One way to get around this is to split your template and static goss files and use [gossfile](#gossfile) to import.
 
@@ -822,8 +823,8 @@ package:
     {{end}}
 {{end}}
 
-# This test is only when OS=centos variable is defined
-{{if eq .Env.OS "centos"}}
+# This test is only when the OS environment variable matches the pattern
+{{if .Env.OS | "[Cc]ent(OS|os)"}}
   libselinux:
     installed: true
 {{end}}

--- a/integration-tests/goss/goss-service.yaml
+++ b/integration-tests/goss/goss-service.yaml
@@ -3,7 +3,7 @@ service:
   foobar:
     enabled: false
     running: false
-{{if eq .Env.OS "centos7"}}
+{{ if .Env.OS | regexMatch "centos[7]" }}
   httpd:
 {{else}}
   apache2:

--- a/template.go
+++ b/template.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 )
@@ -32,10 +33,20 @@ func getEnv(key string, def ...string) string {
 	return os.Getenv(key)
 }
 
+func regexMatch(re, s string) (bool, error) {
+	compiled, err := regexp.Compile(re)
+	if err != nil {
+		return false, err
+	}
+
+	return compiled.MatchString(s), nil
+}
+
 var funcMap = map[string]interface{}{
-	"mkSlice":  mkSlice,
-	"readFile": readFile,
-	"getEnv":   getEnv,
+	"mkSlice":    mkSlice,
+	"readFile":   readFile,
+	"getEnv":     getEnv,
+	"regexMatch": regexMatch,
 }
 
 func NewTemplateFilter(varsFile string) func([]byte) []byte {


### PR DESCRIPTION
Makes it possible to do pattern-based template blocks.