### PR TITLE
HTTP Connection Leak

### DIFF
--- a/resource/validate.go
+++ b/resource/validate.go
@@ -297,6 +297,14 @@ func ValidateContains(res ResourceRead, property string, expectedValues []string
 			Duration:     time.Now().Sub(startTime),
 		}
 	}
+
+	defer func() {
+		//Do we need to close the stream?
+		if rc, ok := fh.(io.ReadCloser); ok {
+			rc.Close()
+		}
+	}()
+
 	scanner := bufio.NewScanner(fh)
 	var found []patternMatcher
 	for scanner.Scan() {

--- a/system/http.go
+++ b/system/http.go
@@ -45,6 +45,7 @@ func (u *DefHTTP) setup() error {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: u.allowInsecure},
+		DisableKeepAlives: true,
 	}
 	client := &http.Client{
 		Transport: tr,


### PR DESCRIPTION
`ContainsValue` now closes streams if they are of type `io.ReadCloser`

The system HTTP resource also does not cache connections anymore. I don't think they were actually reused since each new http resources created a new client.