### PR TITLE
Add glob pattern support to gossfile

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -528,11 +528,12 @@ file:
 
 
 ### gossfile
-Import other gossfiles from this one. This is the best way to maintain a large mumber of tests, and/or create profiles. See [render](#render-r---render-gossfile-after-importing-all-referenced-gossfiles) for more examples.
+Import other gossfiles from this one. This is the best way to maintain a large mumber of tests, and/or create profiles. See [render](#render-r---render-gossfile-after-importing-all-referenced-gossfiles) for more examples. Glob patterns can be also be used to specify matching gossfiles.
 
 ```yaml
 gossfile:
   goss_httpd.yaml: {}
+  /etc/goss.d/*.yaml: {}
 ```
 
 

--- a/integration-tests/goss/alpine3/goss.yaml
+++ b/integration-tests/goss/alpine3/goss.yaml
@@ -24,5 +24,4 @@ port:
     ip:
     - "::"
 gossfile:
-  "../goss-shared.yaml": {}
-  "../goss-service.yaml": {}
+  "../goss-s*.yaml": {}

--- a/integration-tests/goss/centos7/goss.yaml
+++ b/integration-tests/goss/centos7/goss.yaml
@@ -24,5 +24,4 @@ port:
     ip:
     - "::"
 gossfile:
-  "../goss-shared.yaml": {}
-  "../goss-service.yaml": {}
+  "../goss-s*.yaml": {}

--- a/integration-tests/goss/precise/goss.yaml
+++ b/integration-tests/goss/precise/goss.yaml
@@ -24,5 +24,4 @@ port:
     ip:
     - 0.0.0.0
 gossfile:
-  "../goss-shared.yaml": {}
-  "../goss-service.yaml": {}
+  "../goss-s*.yaml": {}

--- a/integration-tests/goss/wheezy/goss.yaml
+++ b/integration-tests/goss/wheezy/goss.yaml
@@ -24,5 +24,4 @@ port:
     ip:
     - "::"
 gossfile:
-  "../goss-shared.yaml": {}
-  "../goss-service.yaml": {}
+  "../goss-s*.yaml": {}

--- a/store.go
+++ b/store.go
@@ -158,9 +158,16 @@ func mergeJSONData(gossConfig GossConfig, depth int, path string) GossConfig {
 		} else {
 			fpath = filepath.Join(path, g.ID())
 		}
-		fdir := filepath.Dir(fpath)
-		j := mergeJSONData(ReadJSON(fpath), depth, fdir)
-		ret = mergeGoss(ret, j)
+		matches, err := filepath.Glob(fpath)
+		if err != nil {
+			fmt.Printf("Error in expanding glob pattern: \"%s\"\n", err.Error())
+			os.Exit(1)
+		}
+		for _, match := range matches {
+			fdir := filepath.Dir(match)
+			j := mergeJSONData(ReadJSON(match), depth, fdir)
+			ret = mergeGoss(ret, j)
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
This will ease the addition of tests to an existing goss test suite.

All that is necessary is to drop in a file matching the existing pattern. As an example:

```yml
gossfile:
  /etc/goss.d/*.yaml: {}
```

Unfortunately, I wasn't sure where to place this in the existing integration tests; where might a good place for such a test be?

References #222