### PR TITLE
Adds Gomega HaveKey matcher

### DIFF
--- a/resource/gomega.go
+++ b/resource/gomega.go
@@ -45,6 +45,12 @@ func matcherToGomegaMatcher(matcher interface{}) (types.GomegaMatcher, error) {
 	case "have-len":
 		value = sanitizeExpectedValue(value)
 		return gomega.HaveLen(value.(int)), nil
+	case "have-key":
+		subMatcher, err := matcherToGomegaMatcher(value)
+		if err != nil {
+			return nil, err
+		}
+		return gomega.HaveKey(subMatcher), nil
 	case "contain-element":
 		subMatcher, err := matcherToGomegaMatcher(value)
 		if err != nil {

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -83,6 +83,10 @@ var gomegaTests = []struct {
 		in:   `{"have-len": 3}`,
 		want: gomega.HaveLen(3),
 	},
+	{
+		in:   `{"have-key": "foo"}`,
+		want: gomega.HaveKey(gomega.Equal("foo")),
+	},
 
 	// Negation
 	{


### PR DESCRIPTION
Adds support for Gomega HaveKey so that given a test that return a map, you can search that the map has a key:

This might be useful in validating something like HTTP headers a la #197 