### PR TITLE
Add Gomega HaveKeyWithValue

### DIFF
--- a/resource/gomega.go
+++ b/resource/gomega.go
@@ -118,13 +118,8 @@ func mapToGomega(value interface{}) (subMatchers []types.GomegaMatcher, err erro
 		return nil, fmt.Errorf("Matcher expected map, got: %t", value)
 	}
 
-	var key, val types.GomegaMatcher
-	for k, v := range valueI {
-		key, err = matcherToGomegaMatcher(k)
-		if err != nil {
-			return
-		}
-		val, err = matcherToGomegaMatcher(v)
+	for key, val := range valueI {
+		val, err = matcherToGomegaMatcher(val)
 		if err != nil {
 			return
 		}

--- a/resource/gomega.go
+++ b/resource/gomega.go
@@ -45,6 +45,17 @@ func matcherToGomegaMatcher(matcher interface{}) (types.GomegaMatcher, error) {
 	case "have-len":
 		value = sanitizeExpectedValue(value)
 		return gomega.HaveLen(value.(int)), nil
+	case "have-key-with-value":
+		subMatchers, err := mapToGomega(value)
+		if err != nil {
+			return nil, err
+		}
+		for key, val := range subMatchers {
+			if val == nil {
+				fmt.Printf("%d is nil", key)
+			}
+		}
+		return gomega.And(subMatchers...), nil
 	case "contain-element":
 		subMatcher, err := matcherToGomegaMatcher(value)
 		if err != nil {
@@ -93,6 +104,29 @@ func matcherToGomegaMatcher(matcher interface{}) (types.GomegaMatcher, error) {
 		return nil, fmt.Errorf("Unknown matcher: %s", matchType)
 
 	}
+}
+
+func mapToGomega(value interface{}) (subMatchers []types.GomegaMatcher, err error) {
+	valueI, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Matcher expected map, got: %t", value)
+	}
+
+	var key, val types.GomegaMatcher
+	for k, v := range valueI {
+		key, err = matcherToGomegaMatcher(k)
+		if err != nil {
+			return
+		}
+		val, err = matcherToGomegaMatcher(v)
+		if err != nil {
+			return
+		}
+
+		subMatcher := gomega.HaveKeyWithValue(key, val)
+		subMatchers = append(subMatchers, subMatcher)
+	}
+	return
 }
 
 func sliceToGomega(value interface{}) ([]types.GomegaMatcher, error) {

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -83,6 +83,14 @@ var gomegaTests = []struct {
 		in:   `{"have-len": 3}`,
 		want: gomega.HaveLen(3),
 	},
+	{
+		in: `{"have-key-with-value": { "foo": 1, "bar": "baz" }}`,
+		want: gomega.And(
+			gomega.HaveKeyWithValue(gomega.Equal("foo"), gomega.Equal(1)),
+			gomega.HaveKeyWithValue(gomega.Equal("bar"), gomega.Equal("baz")),
+		),
+		useNegateTester: true,
+	},
 
 	// Negation
 	{

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -86,8 +86,8 @@ var gomegaTests = []struct {
 	{
 		in: `{"have-key-with-value": { "foo": 1, "bar": "baz" }}`,
 		want: gomega.And(
-			gomega.HaveKeyWithValue(gomega.Equal("foo"), gomega.Equal(1)),
-			gomega.HaveKeyWithValue(gomega.Equal("bar"), gomega.Equal("baz")),
+			gomega.HaveKeyWithValue("foo", gomega.Equal(1)),
+			gomega.HaveKeyWithValue("bar", gomega.Equal("baz")),
 		),
 		useNegateTester: true,
 	},
@@ -136,13 +136,13 @@ func TestMatcherToGomegaMatcher(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		gomegaTestEqual(t, got, c.want, c.useNegateTester)
+		gomegaTestEqual(t, got, c.want, c.useNegateTester, c.in)
 	}
 }
 
-func gomegaTestEqual(t *testing.T, got, want interface{}, useNegateTester bool) {
+func gomegaTestEqual(t *testing.T, got, want interface{}, useNegateTester bool, in string) {
 	if !gomegaEqual(got, want, useNegateTester) {
-		t.Errorf("got %T %v, want %T %v", got, got, want, want)
+		t.Errorf("For input '%s': got %T %v, want %T %v", in, got, got, want, want)
 	}
 }
 func gomegaEqual(g, w interface{}, negateTester bool) bool {


### PR DESCRIPTION
In my fork, I have an EC2 resource that returns a map of instance tags. This Gomega matcher allows you to do checks like the following:

```yml
aws_ec2:
  tags:
     have-key-with-value:
       foo: 1
       bar: baz
```