### PR TITLE
Adds Matching resource

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -24,6 +24,7 @@
   * [interface](#interface)
   * [kernel-param](#kernel-param)
   * [mount](#mount)
+  * [matching](#matching)
   * [package](#package)
   * [port](#port)
   * [process](#process)
@@ -609,6 +610,30 @@ mount:
     filesystem: xfs
 ```
 
+### matching
+Validates specified content against a matcher. Best used with [Templates](#templates).
+
+```yaml
+matching:
+  has_substr: # friendly test name
+    content: some string
+    matches:
+      match-regexp: some str
+  has_2:
+    content:
+      - 2
+    matches:
+      contain-element: 2
+  has_foo_bar_and_baz:
+    content:
+      foo: bar
+      baz: bing
+    matches:
+      and:
+        - have-key-with-value:
+            foo: bar
+        - have-key: baz
+```
 
 ### package
 Validates the state of a package

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -618,6 +618,39 @@ mount:
 ### matching
 Validates specified content against a matcher. Best used with [Templates](#templates).
 
+#### With [Templates](#templates):
+Let's say we have a `data.json` file that gets generated as part of some testing pipeline:
+
+```json
+{
+  "instance_count": 14,
+  "failures": 3,
+  "status": "FAIL"
+}
+```
+
+This could then be passed into goss: `goss --vars data.json validate`
+
+And then validated against:
+
+```yaml
+matching:
+  check_instance_count: # Make sure there is at least one instance
+    content: {{ .Vars.instance_count }}
+    matches:
+      gt: 0
+
+  check_failure_count_from_all_instance: # expect no failures
+    content: {{ .Vars.failures }}
+    matches: 0
+
+  check_status:
+    content: {{ .Vars.status }}
+    matches:
+      - not: FAIL
+```
+
+#### Without [Templates](#templates):
 ```yaml
 matching:
   has_substr: # friendly test name

--- a/goss_config.go
+++ b/goss_config.go
@@ -45,8 +45,8 @@ func NewGossConfig() *GossConfig {
 	}
 }
 
-func (c *GossConfig) Resources() []resourceTypes.Resource {
-	var tests []resourceTypes.Resource
+func (c *GossConfig) Resources() []resource.Resource {
+	var tests []resource.Resource
 
 	gm := genericConcatMaps(c.Commands,
 		c.HTTPs,

--- a/goss_config.go
+++ b/goss_config.go
@@ -22,6 +22,7 @@ type GossConfig struct {
 	Mounts       resource.MountMap       `json:"mount,omitempty" yaml:"mount,omitempty"`
 	Interfaces   resource.InterfaceMap   `json:"interface,omitempty" yaml:"interface,omitempty"`
 	HTTPs        resource.HTTPMap        `json:"http,omitempty" yaml:"http,omitempty"`
+	Matchings    resource.MatchingMap    `json:"matching,omitempty" yaml:"matching,omitempty"`
 }
 
 func NewGossConfig() *GossConfig {
@@ -44,10 +45,26 @@ func NewGossConfig() *GossConfig {
 	}
 }
 
-func (c *GossConfig) Resources() []resource.Resource {
-	var tests []resource.Resource
+func (c *GossConfig) Resources() []resourceTypes.Resource {
+	var tests []resourceTypes.Resource
 
-	gm := genericConcatMaps(c.Commands, c.HTTPs, c.Addrs, c.DNS, c.Packages, c.Services, c.Files, c.Processes, c.Users, c.Groups, c.Ports, c.KernelParams, c.Mounts, c.Interfaces)
+	gm := genericConcatMaps(c.Commands,
+		c.HTTPs,
+		c.Addrs,
+		c.DNS,
+		c.Packages,
+		c.Services,
+		c.Files,
+		c.Processes,
+		c.Users,
+		c.Groups,
+		c.Ports,
+		c.KernelParams,
+		c.Mounts,
+		c.Interfaces,
+		c.Matchings,
+	)
+
 	for _, m := range gm {
 		for _, t := range m {
 			// FIXME: Can this be moved to a safer compile-time check?

--- a/resource/matching.go
+++ b/resource/matching.go
@@ -6,17 +6,16 @@ import (
 	"reflect"
 	"strings"
 
-	. "github.com/aelsabbahy/goss/resource/types"
-	system "github.com/aelsabbahy/goss/system/types"
+	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
 )
 
 type Matching struct {
 	Title   string      `json:"title,omitempty" yaml:"title,omitempty"`
-	Meta    Meta        `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Meta    meta        `json:"meta,omitempty" yaml:"meta,omitempty"`
 	Content interface{} `json:"content,omitempty" yaml:"content,omitempty"`
 	Id      string      `json:"-" yaml:"-"`
-	Matches Matcher     `json:"matches" yaml:"matches"`
+	Matches matcher     `json:"matches" yaml:"matches"`
 }
 
 type MatchingMap map[string]*Matching
@@ -26,7 +25,7 @@ func (a *Matching) SetID(id string) { a.Id = id }
 
 // FIXME: Can this be refactored?
 func (r *Matching) GetTitle() string { return r.Title }
-func (r *Matching) GetMeta() Meta    { return r.Meta }
+func (r *Matching) GetMeta() meta    { return r.Meta }
 
 func (a *Matching) Validate(sys system.System) []TestResult {
 	skip := false

--- a/resource/matching.go
+++ b/resource/matching.go
@@ -1,0 +1,108 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	. "github.com/aelsabbahy/goss/resource/types"
+	system "github.com/aelsabbahy/goss/system/types"
+	"github.com/aelsabbahy/goss/util"
+)
+
+type Matching struct {
+	Title   string      `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta    Meta        `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Content interface{} `json:"content,omitempty" yaml:"content,omitempty"`
+	Id      string      `json:"-" yaml:"-"`
+	Matches Matcher     `json:"matches" yaml:"matches"`
+}
+
+type MatchingMap map[string]*Matching
+
+func (a *Matching) ID() string      { return a.Id }
+func (a *Matching) SetID(id string) { a.Id = id }
+
+// FIXME: Can this be refactored?
+func (r *Matching) GetTitle() string { return r.Title }
+func (r *Matching) GetMeta() Meta    { return r.Meta }
+
+func (a *Matching) Validate(sys system.System) []TestResult {
+	skip := false
+
+	// ValidateValue expects a function
+	stub := func() (interface{}, error) {
+		return a.Content, nil
+	}
+
+	var results []TestResult
+	results = append(results, ValidateValue(a, "matches", a.Matches, stub, skip))
+	return results
+}
+
+func (ret *MatchingMap) UnmarshalJSON(data []byte) error {
+	// Curried json.Unmarshal
+	unmarshal := func(i interface{}) error {
+		if err := json.Unmarshal(data, i); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Validate configuration
+	zero := Matching{}
+	whitelist, err := util.WhitelistAttrs(zero, util.JSON)
+	if err != nil {
+		return err
+	}
+	if err := util.ValidateSections(unmarshal, zero, whitelist); err != nil {
+		return err
+	}
+
+	var tmp map[string]*Matching
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+
+	typ := reflect.TypeOf(zero)
+	typs := strings.Split(typ.String(), ".")[1]
+	for id, res := range tmp {
+		if res == nil {
+			return fmt.Errorf("Could not parse resource %s:%s", typs, id)
+		}
+		res.SetID(id)
+	}
+
+	*ret = tmp
+	return nil
+}
+
+func (ret *MatchingMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	// Validate configuration
+	zero := Matching{}
+	whitelist, err := util.WhitelistAttrs(zero, util.YAML)
+	if err != nil {
+		return err
+	}
+	if err := util.ValidateSections(unmarshal, zero, whitelist); err != nil {
+		return err
+	}
+
+	var tmp map[string]*Matching
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+
+	typ := reflect.TypeOf(zero)
+	typs := strings.Split(typ.String(), ".")[1]
+	for id, res := range tmp {
+		if res == nil {
+			return fmt.Errorf("Could not parse resource %s:%s", typs, id)
+		}
+		res.SetID(id)
+	}
+
+	*ret = tmp
+	return nil
+}

--- a/util/config.go
+++ b/util/config.go
@@ -1,9 +1,76 @@
 package util
 
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/oleiade/reflections"
+)
+
 type Config struct {
 	IgnoreList        []string
 	Timeout           int
 	AllowInsecure     bool
 	NoFollowRedirects bool
 	Server            string
+}
+
+type format string
+
+const (
+	JSON format = "json"
+	YAML format = "yaml"
+)
+
+func ValidateSection(unmarshal func(interface{}) error, i interface{}, whitelist map[string]bool) error {
+	// Get generic input
+	var toValidate map[string]interface{}
+	if err := unmarshal(&toValidate); err != nil {
+		return err
+	}
+
+	// Run input through whitelist
+	typ := reflect.TypeOf(i)
+	typs := strings.Split(typ.String(), ".")[1]
+	for k, _ := range toValidate {
+		if !whitelist[k] {
+			return fmt.Errorf("Invalid Attribute for %s: %s", typs, k)
+		}
+	}
+
+	return nil
+}
+
+func ValidateSections(unmarshal func(interface{}) error, i interface{}, whitelist map[string]bool) error {
+	// Get generic input
+	var toValidate map[string]map[string]interface{}
+	if err := unmarshal(&toValidate); err != nil {
+		return err
+	}
+
+	// Run input through whitelist
+	typ := reflect.TypeOf(i)
+	typs := strings.Split(typ.String(), ".")[1]
+	for id, v := range toValidate {
+		for k, _ := range v {
+			if !whitelist[k] {
+				return fmt.Errorf("Invalid Attribute for %s:%s: %s", typs, id, k)
+			}
+		}
+	}
+
+	return nil
+}
+
+func WhitelistAttrs(i interface{}, format format) (map[string]bool, error) {
+	validAttrs := make(map[string]bool)
+	tags, err := reflections.Tags(i, string(format))
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range tags {
+		validAttrs[strings.Split(v, ",")[0]] = true
+	}
+	return validAttrs, nil
 }


### PR DESCRIPTION
This resource lets you define arbitrary data to match and report against. I use this when piping in a generated file and using templates to match against its contents:

Let's say we have a `data.json` file that gets generated as part of some testing pipeline:

```json
{
  "instance_count": 14,
  "failures": 3,
  "status": "FAIL"
}
```

This could be piped into goss: `goss --vars data.json validate`

And then validated against:

```yaml
---
matching:
  check_instance_count: # Make sure there is at least one instance
    content: {{ .Vars.instance_count }}
    matches:
      gt: 0

  check_failure_count_from_all_instance: # expect no failures
    content: {{ .Vars.failure_count }}
    matches: 0

  check_status:
    content: {{ .Vars.status }}
    matches:
      - not: FAIL
```