### PR TITLE
update dgoss to support imported goss files

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -22,8 +22,8 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
-    [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && cp "${GOSS_FILES_PATH}/goss.yaml" "$tmp_dir"
-    [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir"
+    [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && "${GOSS_PATH}" render "${GOSS_FILES_PATH}/goss.yaml" > "$tmp_dir/goss.yaml"
+    [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && "${GOSS_PATH}" render "${GOSS_FILES_PATH}/goss_wait.yaml" > "$tmp_dir/goss_wait.yaml"
     info "Starting docker container"
     id=$(docker run -d -v "$tmp_dir:/goss" "${@:2}")
     docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &


### PR DESCRIPTION
Currently, `dgoss` doesn't seem to support importing gossfiles via the `gossfile` test. This happens because `dgoss` copies `goss.yaml ` but does not copy any imported files to the container. One way to fix this would be to render `goss.yaml` and copy the rendered result to the container.

### Steps to reproduce

Create the following files in the `aelsabbahy/goss` project root directory.

```
# file: goss.yaml
gossfile:
  ./included.yaml: {}
```

```
# file: included.yaml
process:
  nginx:
    running: true
```

Then run goss.

```
./extras/dgoss/dgoss run nginx
```

### Expected result

```
~$ ./extras/dgoss/dgoss run nginx
INFO: Starting docker container
INFO: Container ID: ab483077
INFO: Sleeping for 0.2
INFO: Running Tests
Process: nginx: running: matches expectation: [true]


Total Duration: 0.001s
Count: 1, Failed: 0, Skipped: 0
INFO: Deleting container
```

### Actual result

```
~$ ./extras/dgoss/dgoss run -it nginx
INFO: Starting docker container
INFO: Container ID: dafb62d8
INFO: Sleeping for 0.2
INFO: Running Tests
Error: found 0 tests, source: /goss/goss.yaml
INFO: Deleting container
```