### PR TITLE
Ignore devices where the source doesn't start with /

### DIFF
--- a/system/mount.go
+++ b/system/mount.go
@@ -95,7 +95,8 @@ func getMount(mountpoint string) (*mount.Info, error) {
 
 	// Search the table for the mountpoint
 	for _, e := range entries {
-		if e.Mountpoint == mountpoint {
+		// Make sure that the source is a full path
+		if (e.Mountpoint == mountpoint) && (string(e.Source[0]) == "/") {
 			return e, nil
 		}
 	}


### PR DESCRIPTION
## Problem

When adding a mount point check, it is very frustrating that for Systemd OSes the mount listing gets the first mountpoint, which in systemd case it can result to something like this:

```
$ mount -l | grep /mnt/data
systemd-1 on /mnt/data type autofs (rw,relatime,fd=26,pgrp=1,timeout=300,minproto=5,maxproto=5,direct)
/dev/mapper/lxc-data on /mnt/data type xfs (rw,relatime,seclabel,attr2,discard,inode64,prjquota)
```

So when trying to add a check that checks the source it might fail, example check:

```yaml
mount:
  /mnt/data:
    exists: true
    source: /dev/mapper/lxc-data
    filesystem: xfs
```

```sh
$ goss validate
1..2
not ok 1 - Mount: /mnt/data: source: doesn't match, expect: ["/dev/mapper/lxc-data"] found: ["systemd-1"]
not ok 2 - Mount: /mnt/data: filesystem: doesn't match, expect: ["xfs"] found: ["autofs"]
```