### PR TITLE
Add upstart check for /etc/init/<service>.override

### DIFF
--- a/integration-tests/Dockerfile_precise
+++ b/integration-tests/Dockerfile_precise
@@ -9,6 +9,7 @@ RUN mv /sbin/initctl /sbin/initctl.orig && \
     apt-get remove -y vim-tiny && \
     apt-get clean && \
     rm -f /sbin/initctl && \
-    mv /sbin/initctl.orig /sbin/initctl
+    mv /sbin/initctl.orig /sbin/initctl && \
+    echo manual > /etc/init/apache2.override
 
 RUN chkconfig apache2 on

--- a/integration-tests/goss/goss-service.yaml
+++ b/integration-tests/goss/goss-service.yaml
@@ -8,5 +8,9 @@ service:
 {{else}}
   apache2:
 {{end}}
+{{ if .Env.OS | regexMatch "precise" }}
+    enabled: false
+{{else}}
     enabled: true
+{{end}}
     running: true

--- a/integration-tests/goss/precise/goss-aa-expected.yaml
+++ b/integration-tests/goss/precise/goss-aa-expected.yaml
@@ -10,7 +10,7 @@ port:
     - 0.0.0.0
 service:
   apache2:
-    enabled: true
+    enabled: false
     running: true
 process:
   apache2:

--- a/integration-tests/goss/precise/goss-expected-q.yaml
+++ b/integration-tests/goss/precise/goss-expected-q.yaml
@@ -28,7 +28,7 @@ port:
     listening: false
 service:
   apache2:
-    enabled: true
+    enabled: false
     running: true
   foobar:
     enabled: false

--- a/integration-tests/goss/precise/goss-expected.yaml
+++ b/integration-tests/goss/precise/goss-expected.yaml
@@ -39,7 +39,7 @@ port:
     ip: []
 service:
   apache2:
-    enabled: true
+    enabled: false
     running: true
   foobar:
     enabled: false

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -39,6 +39,9 @@ trap "rv=\$?; docker rm -vf $id; exit \$rv" INT TERM EXIT
 # Give httpd time to start up, adding 1 second to see if it helps with intermittent CI failures
 [[ $os != "arch" ]] && docker_exec "/goss/$os/goss-linux-$arch" -g "/goss/goss-wait.yaml" validate -r 10s -s 100ms && sleep 1
 
+# Disable apache2 service on boot for "precise"
+[[ $os == "precise" ]] && docker_exec bash -c "echo manual > /etc/init/apache2.override"
+
 #out=$(docker exec "$container_name" bash -c "time /goss/$os/goss-linux-$arch -g /goss/$os/goss.yaml validate")
 out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" -g "/goss/$os/goss.yaml" validate)
 echo "$out"

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -39,9 +39,6 @@ trap "rv=\$?; docker rm -vf $id; exit \$rv" INT TERM EXIT
 # Give httpd time to start up, adding 1 second to see if it helps with intermittent CI failures
 [[ $os != "arch" ]] && docker_exec "/goss/$os/goss-linux-$arch" -g "/goss/goss-wait.yaml" validate -r 10s -s 100ms && sleep 1
 
-# Disable apache2 service on boot for "precise"
-[[ $os == "precise" ]] && docker_exec bash -c "echo manual > /etc/init/apache2.override"
-
 #out=$(docker exec "$container_name" bash -c "time /goss/$os/goss-linux-$arch -g /goss/$os/goss.yaml validate")
 out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" -g "/goss/$os/goss.yaml" validate)
 echo "$out"


### PR DESCRIPTION
Checks wether the service is disabled with the upstart override file `/etc/init/<service>.override`.

Before this, even if you had manually overridden the service to be `manual` it would just check the upstart file `/etc/init/<service>.conf` and report the service as enabled when it wasn't.