### PR TITLE
Enhancement: Support variables files in dgoss

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -83,3 +83,11 @@ Time to sleep after running container (and optionally `goss_wait.yaml`) and befo
 
 ##### GOSS_FILES_PATH
 Location of the goss yaml files. (Default: `.`)
+
+##### GOSS_VARS
+The name of the variables file relative to `GOSS_FILES_PATH` to copy into the
+docker container and use for valiation (i.e. `dgoss run`) and copy out of the
+docker container when writing tests (i.e. `dgoss edit`). If set, the
+`--vars` flag is passed to `goss validate` commands inside the container.
+If unset (or empty), the `--vars` flag is omitted, which is the normal behavior.
+(Default: `''`).

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -24,6 +24,7 @@ run(){
     chmod 755 "$tmp_dir/goss"
     [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && cp "${GOSS_FILES_PATH}/goss.yaml" "$tmp_dir"
     [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir"
+    [[ ! -z "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir"
     info "Starting docker container"
     id=$(docker run -d -v "$tmp_dir:/goss" "${@:2}")
     docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
@@ -55,13 +56,23 @@ case "$1" in
         run "$@"
         if [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]]; then
             info "Found goss_wait.yaml, waiting for it to pass before running tests"
-            if ! docker exec "$id" sh -c "/goss/goss -g /goss/goss_wait.yaml validate $GOSS_WAIT_OPTS"; then
-                error "goss_wait.yaml never passed"
+            if [[ -z "${GOSS_VARS}" ]]; then
+                if ! docker exec "$id" sh -c "/goss/goss -g /goss/goss_wait.yaml validate $GOSS_WAIT_OPTS"; then
+                    error "goss_wait.yaml never passed"
+                fi
+            else
+                if ! docker exec "$id" sh -c "/goss/goss -g /goss/goss_wait.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_WAIT_OPTS"; then
+                    error "goss_wait.yaml never passed"
+                fi
             fi
         fi
         [[ $GOSS_SLEEP ]] && { info "Sleeping for $GOSS_SLEEP"; sleep "$GOSS_SLEEP"; }
         info "Running Tests"
-        docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml validate $GOSS_OPTS"
+        if [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]]; then
+            docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_OPTS"
+        else
+            docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml validate $GOSS_OPTS"
+        fi
         ;;
     edit)
         run "$@"
@@ -69,6 +80,7 @@ case "$1" in
         docker exec -it "$id" sh -c 'cd /goss; PATH="/goss:$PATH" exec sh'
         get_docker_file "/goss/goss.yaml"
         get_docker_file "/goss/goss_wait.yaml"
+        [[ ! -z "${GOSS_VARS}" ]] && get_docker_file "/goss/${GOSS_VARS}"
         ;;
     *)
         error "$USAGE"


### PR DESCRIPTION
Reason for Change
-----------------
Before this change, `dgoss` had limited variable/templating support. For
example, `.Env` variables were accessible/usable, but `.Vars` were
not. It is desirable to have comparable variable/templating support
for `dgoss` as regular `goss`. It helps dry up GOSS files for
docker-based testing, which should make them easier to maintain.

Summary
-------
The `dgoss` script recognizes a new setting/environment variable
(which is identical to its `goss` counterpart), i.e. `GOSS_VARS`.
The change consists of modifications to the `dgoss` script which
use the referenced variables file in subsequent `goss validate`
commands. It is also extracted from the docker container after
running `dgoss edit`.