### PR TITLE
Enhancement: Support for SHA-256 file checksums

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -518,6 +518,8 @@ file:
     filetype: file # file, symlink, directory
     contains: [] # Check file content for these patterns
     md5: 7c9bb14b3bf178e82c00c2a4398c93cd # md5 checksum of file
+    # A stronger checksum alternative to md5 (recommended)
+    sha256: 7f78ce27859049f725936f7b52c6e25d774012947d915e7b394402cfceb70c4c
   /etc/alternatives/mta:
     # required attributes
     exists: true

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -24,6 +24,7 @@ file:
   "/goss/hellogoss.txt":
     exists: true
     md5: 7c9bb14b3bf178e82c00c2a4398c93cd
+    sha256: 7f78ce27859049f725936f7b52c6e25d774012947d915e7b394402cfceb70c4c
   "/tmp/goss/foobar":
     exists: false
     contains: []

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -44,9 +44,9 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" -g "/gos
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-  egrep -q 'Count: 64, Failed: 0' <<<"$out"
+  egrep -q 'Count: 65, Failed: 0' <<<"$out"
 else
-  egrep -q 'Count: 78, Failed: 0' <<<"$out"
+  egrep -q 'Count: 79, Failed: 0' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then

--- a/resource/file.go
+++ b/resource/file.go
@@ -18,6 +18,7 @@ type File struct {
 	Filetype matcher  `json:"filetype,omitempty" yaml:"filetype,omitempty"`
 	Contains []string `json:"contains" yaml:"contains"`
 	Md5      matcher  `json:"md5,omitempty" yaml:"md5,omitempty"`
+	Sha256   matcher  `json:"sha256,omitempty" yaml:"sha256,omitempty"`
 }
 
 func (f *File) ID() string      { return f.Path }
@@ -58,6 +59,9 @@ func (f *File) Validate(sys *system.System) []TestResult {
 	}
 	if f.Md5 != nil {
 		results = append(results, ValidateValue(f, "md5", f.Md5, sysFile.Md5, skip))
+	}
+	if f.Sha256 != nil {
+		results = append(results, ValidateValue(f, "sha256", f.Sha256, sysFile.Sha256, skip))
 	}
 	return results
 }

--- a/system/file.go
+++ b/system/file.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -25,6 +26,7 @@ type File interface {
 	Group() (string, error)
 	LinkedTo() (string, error)
 	Md5() (string, error)
+	Sha256() (string, error)
 }
 
 type DefFile struct {
@@ -220,6 +222,26 @@ func (f *DefFile) Md5() (string, error) {
 	defer fh.Close()
 
 	hash := md5.New()
+	if _, err := io.Copy(hash, fh); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func (f *DefFile) Sha256() (string, error) {
+
+	if err := f.setup(); err != nil {
+		return "", err
+	}
+
+	fh, err := os.Open(f.realPath)
+	if err != nil {
+		return "", err
+	}
+	defer fh.Close()
+
+	hash := sha256.New()
 	if _, err := io.Copy(hash, fh); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Summary
-------

This change adds support for SHA-256 file checksums. Example:

```yaml
file:
  /goss/hellogoss.txt:
    exists: true
    sha256: 7f78ce27859049f725936f7b52c6e25d774012947d915e7b394402cfceb70c4c
```

This change includes:

* Go code (modeled from md5 functionality) for a sha256 equivalent
* A new (shared) integration test for `sha256` file checksums.
* Documentation update showcasing a `sha256` example.

Additional changes
------------------

I had to make some additional changes because `make deps && make` (as per
the `.travis.yml`) didn't work as is. There seemed to be changes in either
the Docker base images or in upstream package repos (e.g. a specific `apache2`
package version was just _gone_). I also noticed that the ArchLinux container
fails to start properly when invoked via the `test.sh` script because `/sbin/init`
doesn't exist. After digging through some community forums and stackoverflow posts
I didn't understand, I decided it wasn't worth the effort to "fix", so I replaced
the command with a `sleep 1h`. Fortunately, the container still gets cleaned up
and it seems to work fine.

To summarize:

* Integration test/Dockerfile updates
* ArchLinux Docker image doesn't have `/sbin/init` (anymore)