### PR TITLE
Hotfix for dgoss vars (#248)

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -68,10 +68,10 @@ case "$1" in
         fi
         [[ $GOSS_SLEEP ]] && { info "Sleeping for $GOSS_SLEEP"; sleep "$GOSS_SLEEP"; }
         info "Running Tests"
-        if [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]]; then
-            docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_OPTS"
-        else
+        if [[ -z "${GOSS_VARS}" ]]; then
             docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml validate $GOSS_OPTS"
+        else
+            docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_OPTS"
         fi
         ;;
     edit)


### PR DESCRIPTION
Previously, the file path exists, but is a directory. This is
rectified by checking if the GOSS_VARS variable is empty (as in
previous checks).

This is a patch for #248 and fixes #254.