### PR TITLE
Fix flakiness of have-key-with-value test

### DIFF
--- a/resource/gomega.go
+++ b/resource/gomega.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -118,7 +119,16 @@ func mapToGomega(value interface{}) (subMatchers []types.GomegaMatcher, err erro
 		return nil, fmt.Errorf("Matcher expected map, got: %t", value)
 	}
 
-	for key, val := range valueI {
+	// Get keys
+	keys := []string{}
+	for key, _ := range valueI {
+		keys = append(keys, key)
+	}
+	// Iterate through keys in a deterministic way, since ranging over a map
+	// does not guarantee order
+	sort.Strings(keys)
+	for _, key := range keys {
+		val := valueI[key]
 		val, err = matcherToGomegaMatcher(val)
 		if err != nil {
 			return

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -85,9 +85,11 @@ var gomegaTests = []struct {
 	},
 	{
 		in: `{"have-key-with-value": { "foo": 1, "bar": "baz" }}`,
+		// Keys are sorted and then passed to gomega.And so the order
+		// of the conditions in this `want` is important
 		want: gomega.And(
-			gomega.HaveKeyWithValue("foo", gomega.Equal(1)),
 			gomega.HaveKeyWithValue("bar", gomega.Equal("baz")),
+			gomega.HaveKeyWithValue("foo", gomega.Equal(1)),
 		),
 		useNegateTester: true,
 	},


### PR DESCRIPTION
The gomega `have-key-with value` test was flaky because of ranging over a map in Go is not deterministic so the order that submatchers being passed to `gomega.And` was unpredictable. This caused the test to sometimes pass and sometimes fail.

This commit fixes this by ensuring that `mapToGomega` sorts keys before iterating through map values.