### PR TITLE
Adding ARM building in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ release/goss-linux-386: $(GO_FILES)
 release/goss-linux-amd64: $(GO_FILES)
 	$(info INFO: Starting build $@)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-linux-amd64 $(exe)
+release/goss-linux-arm: $(GO_FILES)
+	$(info INFO: Starting build $@)
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-linux-arm $(exe)
+
+
 
 release:
 	$(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-linux-386 release/goss-linux-amd64
+build: release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm
 
 test-int: centos7 wheezy precise alpine3 arch
 test-int-32: centos7-32 wheezy-32 precise-32 alpine3-32 arch-32


### PR DESCRIPTION
This PR enables an ARM binary to be build by running `make release/goss-linux-arm`. The resulting binary was ran on Beaglebone black debian and works fine when running 

``` 
./goss-linux-arm  autoadd sshd
./goss-linux-arm validate
```