### PR TITLE
Print dgoss info/error to stderr

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -5,8 +5,13 @@ set -e
 USAGE="USAGE: $(basename "$0") [run|edit] <docker_run_params>"
 GOSS_FILES_PATH="${GOSS_FILES_PATH:-.}"
 
-info() { echo -e "INFO: $*"; }
-error() { echo -e "ERROR: $*";exit 1; }
+info() {
+    echo -e "INFO: $*" >&2;
+}
+error() {
+    echo -e "ERROR: $*" >&2;
+    exit 1;
+}
 
 cleanup() {
     set +e


### PR DESCRIPTION
When using a different formatter (like json or junit), having the dgoss debug messages print to stdout along with the actual goss test result output is annoying when redirecting the output to a file, e.g. `dgoss run my-container > results.json`. This simply changes the `echo` functions to print to stderr instead.