### PR TITLE
Decompose system/file.go for POSIX/Windows to allow building for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,15 @@ release/goss-linux-amd64: $(GO_FILES)
 release/goss-linux-arm: $(GO_FILES)
 	$(info INFO: Starting build $@)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-linux-arm $(exe)
-
-
+release/goss-windows.exe: $(GO_FILES)
+	$(info INFO: Starting build $@)
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-windows.exe $(exe)
 
 release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm
+build: release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-windows.exe
 
 test-int: centos7 wheezy precise alpine3 arch
 test-int-32: centos7-32 wheezy-32 precise-32 alpine3-32 arch-32

--- a/system/file_common.go
+++ b/system/file_common.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/aelsabbahy/goss/util"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -84,22 +83,6 @@ func (f *DefFile) Contains() (io.Reader, error) {
 	return fh, nil
 }
 
-func (f *DefFile) Mode() (string, error) {
-	if err := f.setup(); err != nil {
-		return "", err
-	}
-
-	fi, err := os.Lstat(f.realPath)
-	if err != nil {
-		return "", err
-	}
-
-	sys := fi.Sys()
-	stat := sys.(*syscall.Stat_t)
-	mode := fmt.Sprintf("%04o", (stat.Mode & 07777))
-	return mode, nil
-}
-
 func (f *DefFile) Size() (int, error) {
 	if err := f.setup(); err != nil {
 		return 0, err
@@ -134,42 +117,6 @@ func (f *DefFile) Filetype() (string, error) {
 	}
 	// FIXME: file as a catchall?
 	return "file", nil
-}
-
-func (f *DefFile) Owner() (string, error) {
-	if err := f.setup(); err != nil {
-		return "", err
-	}
-
-	fi, err := os.Lstat(f.realPath)
-	if err != nil {
-		return "", err
-	}
-
-	uidS := fmt.Sprint(fi.Sys().(*syscall.Stat_t).Uid)
-	uid, err := strconv.Atoi(uidS)
-	if err != nil {
-		return "", err
-	}
-	return getUserForUid(uid)
-}
-
-func (f *DefFile) Group() (string, error) {
-	if err := f.setup(); err != nil {
-		return "", err
-	}
-
-	fi, err := os.Lstat(f.realPath)
-	if err != nil {
-		return "", err
-	}
-
-	gidS := fmt.Sprint(fi.Sys().(*syscall.Stat_t).Gid)
-	gid, err := strconv.Atoi(gidS)
-	if err != nil {
-		return "", err
-	}
-	return getGroupForGid(gid)
 }
 
 func (f *DefFile) LinkedTo() (string, error) {

--- a/system/file_posix.go
+++ b/system/file_posix.go
@@ -1,0 +1,62 @@
+// +build linux darwin !windows
+
+package system
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func (f *DefFile) Mode() (string, error) {
+	if err := f.setup(); err != nil {
+		return "", err
+	}
+
+	fi, err := os.Lstat(f.realPath)
+	if err != nil {
+		return "", err
+	}
+
+	sys := fi.Sys()
+	stat := sys.(*syscall.Stat_t)
+	mode := fmt.Sprintf("%04o", (stat.Mode & 07777))
+	return mode, nil
+}
+
+func (f *DefFile) Owner() (string, error) {
+	if err := f.setup(); err != nil {
+		return "", err
+	}
+
+	fi, err := os.Lstat(f.realPath)
+	if err != nil {
+		return "", err
+	}
+
+	uidS := fmt.Sprint(fi.Sys().(*syscall.Stat_t).Uid)
+	uid, err := strconv.Atoi(uidS)
+	if err != nil {
+		return "", err
+	}
+	return getUserForUid(uid)
+}
+
+func (f *DefFile) Group() (string, error) {
+	if err := f.setup(); err != nil {
+		return "", err
+	}
+
+	fi, err := os.Lstat(f.realPath)
+	if err != nil {
+		return "", err
+	}
+
+	gidS := fmt.Sprint(fi.Sys().(*syscall.Stat_t).Gid)
+	gid, err := strconv.Atoi(gidS)
+	if err != nil {
+		return "", err
+	}
+	return getGroupForGid(gid)
+}

--- a/system/file_windows.go
+++ b/system/file_windows.go
@@ -1,0 +1,15 @@
+// +build windows
+
+package system
+
+func (f *DefFile) Mode() (string, error) {
+	return "0000", nil // TODO implement
+}
+
+func (f *DefFile) Owner() (string, error) {
+	return getUserForUid(1000)
+}
+
+func (f *DefFile) Group() (string, error) {
+	return getGroupForGid(1000)
+}


### PR DESCRIPTION
**Note**: The minor changes here was done to allow for an internal specific use case, I'm just putting this here in case someone wants to pick it up. Personally I probably won't be working more on this.

This change enables goss to build for Windows. Initial step for #191.

Some caveats:

- a test suite hasn't been created
   - cannot really use Docker for this, maybe Vagrant in the future?
   - this means that there are probably many bugs that I haven't seen
- I've only tested it on Windows 8.1, using cygwin x86_64
   - which also means that there are probably many more issues on "pure" Windows
- the Mode, Owner and Group function of `system/file.go` has been mocked with dummy data to build on Windows. Ideally these should be implemented in some platform native manner (that I'm not familiar with)

Example from my usecase:

```
vagrant@test_goss_windows ~
$ ./goss-windows.exe -g goss.yaml validate
.........

Total Duration: 0.033s
Count: 9, Failed: 0, Skipped: 0

vagrant@test_goss_windows ~
$ cat goss.yaml
file:
  C:\cygwin64\home\vagrant\some_file_that_doesnt_exist:
    exists: false
    contains: []
  C:\cygwin64\home\vagrant\consul.exe:
    exists: true
    mode: "0000"
    size: 43419136
    owner: Other Organization
    group: Other Organization
    filetype: file
    contains: []
command:
  /home/vagrant/disk_usage.exe -warning 50 -critical 60:
    exit-status: 0
    stdout: []
    stderr: []
    timeout: 10000
process:
  consul.exe:
    running: true

vagrant@test_goss_windows ~
$ uname -a
CYGWIN_NT-6.3 test_goss_windows 2.0.4(0.287/5/3) 2015-06-09 12:22 x86_64 Cygwin
```