### PR TITLE
Add report flag for sending reports to remote endpoints

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -49,6 +49,12 @@ func main() {
 					Usage:  fmt.Sprintf("Format to output in, valid options: %s", outputs.Outputers()),
 					EnvVar: "GOSS_FMT",
 				},
+				cli.StringFlag{
+					Name:   "report",
+					Value:  "localhost:9090",
+					Usage:  "Optional report URL to send output to",
+					EnvVar: "GOSS_REPORT",
+				},
 				cli.BoolFlag{
 					Name:   "color",
 					Usage:  "Force color on",

--- a/outputs/documentation.go
+++ b/outputs/documentation.go
@@ -10,6 +10,8 @@ import (
 
 type Documentation struct{}
 
+func (r Documentation) SetReportURL(stringified string) error { return nil }
+
 func (r Documentation) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	testCount := 0
 	var failedOrSkipped [][]resource.TestResult

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -1,0 +1,22 @@
+package outputs
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+func postReport(json []byte, u *url.URL) error {
+	resp, err := http.Post(
+		u.String(),
+		"application/json",
+		bytes.NewBuffer(json))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("status code from report URL %s: %s\n", resp.Request.URL.String(), resp.Status)
+
+	return nil
+}

--- a/outputs/json_oneline.go
+++ b/outputs/json_oneline.go
@@ -12,6 +12,8 @@ import (
 
 type JsonOneline struct{}
 
+func (r JsonOneline) SetReportURL(stringified string) error { return nil }
+
 func (r JsonOneline) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	color.NoColor = true
 	testCount := 0

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -14,6 +14,8 @@ import (
 
 type JUnit struct{}
 
+func (r JUnit) SetReportURL(stringified string) error { return nil }
+
 func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	color.NoColor = true
 	var testCount, failed, skipped int

--- a/outputs/nagios.go
+++ b/outputs/nagios.go
@@ -10,6 +10,8 @@ import (
 
 type Nagios struct{}
 
+func (r Nagios) SetReportURL(stringified string) error { return nil }
+
 func (r Nagios) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	var testCount, failed, skipped int
 	for resultGroup := range results {

--- a/outputs/nagios_verbose.go
+++ b/outputs/nagios_verbose.go
@@ -11,6 +11,8 @@ import (
 
 type NagiosVerbose struct{}
 
+func (r NagiosVerbose) SetReportURL(stringified string) error { return nil }
+
 func (r NagiosVerbose) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	var testCount, failed, skipped int
 

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -15,6 +15,7 @@ import (
 
 type Outputer interface {
 	Output(io.Writer, <-chan []resource.TestResult, time.Time) int
+	SetReportURL(string) error
 }
 
 var green = color.New(color.FgGreen).SprintfFunc()

--- a/outputs/rspecish.go
+++ b/outputs/rspecish.go
@@ -10,6 +10,8 @@ import (
 
 type Rspecish struct{}
 
+func (r Rspecish) SetReportURL(stringified string) error { return nil }
+
 func (r Rspecish) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	testCount := 0
 	var failedOrSkipped [][]resource.TestResult

--- a/outputs/silent.go
+++ b/outputs/silent.go
@@ -9,6 +9,8 @@ import (
 
 type Silent struct{}
 
+func (r Silent) SetReportURL(stringified string) error { return nil }
+
 func (r Silent) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	var failed int
 	for resultGroup := range results {

--- a/outputs/tap.go
+++ b/outputs/tap.go
@@ -11,6 +11,8 @@ import (
 
 type Tap struct{}
 
+func (r Tap) SetReportURL(stringified string) error { return nil }
+
 func (r Tap) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time) (exitCode int) {
 	testCount := 0
 	failed := 0

--- a/serve.go
+++ b/serve.go
@@ -18,12 +18,16 @@ func Serve(c *cli.Context) {
 	endpoint := c.String("endpoint")
 	color.NoColor = true
 	cache := cache.New(c.Duration("cache"), 30*time.Second)
+	o, err := getOutputer(c)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	health := healthHandler{
 		c:             c,
 		gossConfig:    getGossConfig(c),
 		sys:           system.New(c),
-		outputer:      getOutputer(c),
+		outputer:      o,
 		cache:         cache,
 		gossMu:        &sync.Mutex{},
 		maxConcurrent: c.Int("max-concurrent"),

--- a/validate.go
+++ b/validate.go
@@ -49,20 +49,31 @@ func getGossConfig(c *cli.Context) GossConfig {
 	return gossConfig
 }
 
-func getOutputer(c *cli.Context) outputs.Outputer {
+func getOutputer(c *cli.Context) (outputs.Outputer, error) {
 	if c.Bool("no-color") {
 		color.NoColor = true
 	}
 	if c.Bool("color") {
 		color.NoColor = false
 	}
-	return outputs.GetOutputer(c.String("format"))
+	o := outputs.GetOutputer(c.String("format"))
+	if len(c.String("report")) != 0 {
+		if err := o.SetReportURL(c.String("report")); err != nil {
+			return o, err
+		}
+	}
+
+	return o, nil
 }
 
 func Validate(c *cli.Context, startTime time.Time) {
 	gossConfig := getGossConfig(c)
 	sys := system.New(c)
-	outputer := getOutputer(c)
+	outputer, err := getOutputer(c)
+	if err != nil {
+		fmt.Errorf(err.Error())
+		os.Exit(1)
+	}
 
 	sleep := c.Duration("sleep")
 	retryTimeout := c.Duration("retry-timeout")


### PR DESCRIPTION
This PR suggests a way to send the validate report to a remote endpoint. I want to add this functionality so I can run `goss validate` as a systemd unit on a timer. There were several ways I could have achieved the same functionality, but my circumstances led me to push over pull method. 

The primary circumstance was hosts coming up in an AWS autoscaling group, and trying to grok their IPs and keep those IPs in sync on an aggregating service. Configuring a systemd unit/timer with configuration management to send the report output to a well known DNS entry seemed like my best and most durable option. 

If you have a better idea for how this could be implemented I'm more than happy to go down any road suggested. My main goal is to be able to send reports from goss on an interval via push method to a remote host. 

### Implementation 
#### Report Flag
I added a `-report` flag to the `validate` command. This is an optional `.StringFlag` that defaults to `localhost:9090`. 

#### Outputer Type 
I updated the [outputer type](https://github.com/aelsabbahy/goss/compare/master...malnick:malnick/report#diff-dd638c0b5108f6e96b5159e674df9106R18) with a `SetReportURL()` method that accepts a string and returns an error. 

My reasoning for doing it this way over adding a new `Outputer` implementation for `report` (which would simply push a JSON formatted POST to the URL) was the fact that I didn't want to be opinionated about the format of the POST body. JSON is an obvious choice, but in the future someone might want to add a prometheus format `Outputer` type or one of the already created `Outputer` implementations. 

In order to make sure the URL was correctly formatted I added a `error` to the return of `output.getOutputer` [signature](https://github.com/aelsabbahy/goss/compare/master...malnick:malnick/report#diff-4fbfd0840928e279693ded5ea4cde702R59). I felt like this was a good focus point for validating the URL present in the `report` flag. 

#### JSON Outputer Implementation
I [updated](https://github.com/aelsabbahy/goss/compare/master...malnick:malnick/report#diff-dedf33f690ad3522cdba12a0df204ecfR54) the `Json{}` implementation with a `makeMap()` function. This was an artifact from my original plan to make a report `Outputer` type and I didn't want to duplicate the code that created the JSON. I left it as is since it seemed like a nice consolidation of that bit of code (happy to revert it though). 

#### URL Input
Getting the URL from the CLI flag (or some other place like ENV) also affected my thinking around this implementation. I really didn't have a good plan for this and went with a "just make it work" ethos for now. 

#### Tests & Thoughts
I ran some initial manual tests, but since this was looking like a hefty change I wanted to open the PR first before dedicating time to an effort that might be rejected. 
