### PR TITLE
add filetype: character-device/block-device/pipe/socket to file test.

### DIFF
--- a/system/file.go
+++ b/system/file.go
@@ -127,6 +127,15 @@ func (f *DefFile) Filetype() (string, error) {
 	switch {
 	case fi.Mode()&os.ModeSymlink == os.ModeSymlink:
 		return "symlink", nil
+	case fi.Mode()&os.ModeDevice == os.ModeDevice:
+		if fi.Mode()&os.ModeCharDevice == os.ModeCharDevice {
+			return "character-device", nil
+		}
+		return "block-device", nil
+	case fi.Mode()&os.ModeNamedPipe == os.ModeNamedPipe:
+		return "pipe", nil
+	case fi.Mode()&os.ModeSocket == os.ModeSocket:
+		return "socket", nil
 	case fi.IsDir():
 		return "directory", nil
 	case fi.Mode().IsRegular():


### PR DESCRIPTION
Hi.

This PR add some filetype validation to `file` test. 
goss can test a file like `Unix test command`.

* character-device

```
$ ls -la /dev/random
crw-rw-rw- 1 root root 1, 8 Jun 20 04:21 /dev/random
```

```
file:
  /dev/random:
    exists: true
    filetype: character-device
    contains: []
```

* block-device

```
$ ls -la /dev/sda
brw-rw---- 1 root disk 8, 0 Jun 20 04:21 /dev/sda
```

```
file:
  /dev/sda:
    exists: true
    filetype: block-device
    contains: []
```

* pipe

```
$ mkfifo ./foo
$ ls -la ./foo
prw-r--r-- 1 vagrant vagrant 0 Oct 31 07:12 ./foo
```

```
file:
  ./foo:
    exists: true
    filetype: pipe
    contains: []
```

*  unix domain socket 

```
$ ls -la /var/run/mysqld/mysqld.sock 
srwxrwxrwx 1 mysql mysql 0 Jun 20 04:21 /var/run/mysqld/mysqld.sock
```

```
file:
  /var/run/mysqld/mysqld.sock:
    exists: true
    filetype: socket
    contains: []
```