### PR TITLE
show docker logs if container start failed

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -89,6 +89,10 @@ case "$1" in
             fi
         fi
         [[ $GOSS_SLEEP ]] && { info "Sleeping for $GOSS_SLEEP"; sleep "$GOSS_SLEEP"; }
+        info "Container health"
+        if ! docker top $id; then
+            docker logs $id
+        fi
         info "Running Tests"
         if [[ -z "${GOSS_VARS}" ]]; then
             docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml validate $GOSS_OPTS"


### PR DESCRIPTION
hi,

we had a very nasty problem to debug in that the container startup itself did not work but we where missing the docker logs.

I made a small addition to output the container logs if starting the container fails.

In the successfull case an additional output of `docker top id` is also displayed.
I've not removed this output because in the error case it displays a nice error message about why the container might have some problems (there could be other reasons than startup failures, theoretically).

Our usecase was running dgoss inside a container and testing another container with the docker socket from the host system available.

ps.: many thx for your awesome test tool :)!