### PR TITLE
[dgoss] fix info redirected to stderr

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -6,7 +6,7 @@ USAGE="USAGE: $(basename "$0") [run|edit] <docker_run_params>"
 GOSS_FILES_PATH="${GOSS_FILES_PATH:-.}"
 
 info() {
-    echo -e "INFO: $*" >&2;
+    echo -e "INFO: $*";
 }
 error() {
     echo -e "ERROR: $*" >&2;


### PR DESCRIPTION
Hey there,

When running `dgoss` I noticed `info` was redirected to `stderr`, I don't think it was the intended behavior, but I might have missed something.
Let me know.

Anyway, thank you for this great tool!

Cheers.