### PR TITLE
Make docker run interactive

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -36,7 +36,7 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        id=$(docker run -d -v "$tmp_dir:/goss" "${@:2}")
+        id=$(docker run -d -i -v "$tmp_dir:/goss" "${@:2}")
         docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
         ;;
       cp)


### PR DESCRIPTION
At the moment `dgoss` fails to keep running images that require interactive mode.
```
INFO: Starting docker container                                                                                                                                                                                                               
docker run -d -v /tmp/tmp.o2kbIGZivm:/goss example.org:4567/my/project/base-image:1.0.20180317                                                                                                           
INFO: Container ID: 1615c39b                                                                                                                                                                                                                  
INFO: Sleeping for 0.2                                                                                                                                                                                                                        
INFO: Running Tests                                                                                                    
Error response from daemon: Container 1615c39be6e5ba62e2a732f6edb99ad09011729d96cd64c09368457e305eb7e1 is not running
INFO: Deleting container    
```
The reason being is that container starts successfully and then stops imidietly. This merge request fixes the issue.
```
INFO: Starting docker container                            
INFO: Container ID: 6ed49ec7                               
INFO: Sleeping for 0.2                                     
INFO: Running Tests                                        
Package: msodbcsql: installed: matches expectation: [true] 
Package: msodbcsql: version: matches expectation: [["13.1.9.2-1"]]                                                     


Total Duration: 0.010s                                     
Count: 2, Failed: 0, Skipped: 0                            
INFO: Deleting container   
```
