### PR TITLE
Fix systemd service implementation to not fallback to sysv (#319)

### DIFF
--- a/system/service_systemd.go
+++ b/system/service_systemd.go
@@ -30,11 +30,6 @@ func (s *ServiceSystemd) Exists() (bool, error) {
 	if strings.Contains(cmd.Stdout.String(), fmt.Sprintf("%s.service", s.service)) {
 		return true, cmd.Err
 	}
-	// Fallback on sysv
-	sysv := &ServiceInit{service: s.service}
-	if e, err := sysv.Exists(); e && err == nil {
-		return true, nil
-	}
 	return false, nil
 }
 
@@ -47,11 +42,6 @@ func (s *ServiceSystemd) Enabled() (bool, error) {
 	if cmd.Status == 0 {
 		return true, cmd.Err
 	}
-	// Fallback on sysv
-	sysv := &ServiceInit{service: s.service}
-	if en, err := sysv.Enabled(); en && err == nil {
-		return true, nil
-	}
 	return false, nil
 }
 
@@ -63,11 +53,6 @@ func (s *ServiceSystemd) Running() (bool, error) {
 	cmd.Run()
 	if cmd.Status == 0 {
 		return true, cmd.Err
-	}
-	// Fallback on sysv
-	sysv := &ServiceInit{service: s.service}
-	if r, err := sysv.Running(); r && err == nil {
-		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
The current service_systemd.go implementation is falling back to use the
sysvinit one (service_init.go) when the commands give an error exit code.
This is wrong, because systemd should have either generated a service
file for those sysvinit init scripts, or itself or the admin might have
disabled or masked those services, so falling back will give the wrong
result. Because it will definitely not pay attention to those sysvinit
services outside of its compat support anyway, so either systemctl
knows about them, or for all practical purposes it does not matter at
all.