### PR TITLE
Add ability to loop n times in a template.

### DIFF
--- a/template.go
+++ b/template.go
@@ -33,6 +33,10 @@ func getEnv(key string, def ...string) string {
 	return os.Getenv(key)
 }
 
+func loop(iterations int) []struct{} {
+    return make([]struct{}, iterations)
+}
+
 func regexMatch(re, s string) (bool, error) {
 	compiled, err := regexp.Compile(re)
 	if err != nil {
@@ -46,6 +50,7 @@ var funcMap = map[string]interface{}{
 	"mkSlice":    mkSlice,
 	"readFile":   readFile,
 	"getEnv":     getEnv,
+	"loop":       loop,
 	"regexMatch": regexMatch,
 }
 


### PR DESCRIPTION
Attempt to fix #345. Incomplete.

This is based on https://stackoverflow.com/questions/28917530/golang-how-to-create-loop-function-using-html-template-package

I'm trying to enable

```yaml
{{range $idx $item := loop 8}}
service:
  foo@{{$idx}}:
    running: true
    enabled: true
{{end}}
```
... and generate 8 foo service assertions, each with 2 checks. I then want to supply that `8` from a vars file or an environment variable, but I think support for that exists already.

Happy to write tests but I think I need a steer for where to do so and how to assert?