### PR TITLE
Handle integers and boolean kernel params

### DIFF
--- a/resource/kernel_param.go
+++ b/resource/kernel_param.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"strconv"
+
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
 )
@@ -24,7 +26,18 @@ func (a *KernelParam) Validate(sys *system.System) []TestResult {
 	sysKernelParam := sys.NewKernelParam(a.Key, sys, util.Config{})
 
 	var results []TestResult
-	results = append(results, ValidateValue(a, "value", a.Value, sysKernelParam.Value, skip))
+	// Cast to string
+	var value matcher
+	switch v := a.Value.(type) {
+	case int:
+		value = strconv.Itoa(v)
+	case bool:
+		value = strconv.FormatBool(v)
+	default:
+		value = v
+	}
+
+	results = append(results, ValidateValue(a, "value", value, sysKernelParam.Value, skip))
 	return results
 }
 


### PR DESCRIPTION
This PR addresses the issue raised in #220 although we would hope that users fully understand types in YAML it's not always the case. As a defensive measure we could cast the user specified value to a string (expected type) before validating. This will allow some flexibility to the end user (I forget to add " to string values myself) giving a smoother experience. 