### PR TITLE
Prometheus output

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ package:
 * TAP
 * JUnit
 * nagios - Nagios/Sensu compatible output /w exit code 2 for failures.
+* prometheus - Prometheus compatible output /w values: 0 for successful, 1 for failed and 2 for skipped tests.
 * silent - No output. Avoids exposing system information (e.g. when serving tests as a healthcheck endpoint).
 
 ## Community Contributions

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -282,6 +282,7 @@ $ curl localhost:8080/healthz
   * `json_oneline` - Same as json, but oneliner
   * `junit`
   * `nagios` - Nagios/Sensu compatible output /w exit code 2 for failures.
+  * `prometheus` - Prometheus compatible output /w values: 0 for successful, 1 for failed and 2 for skipped tests.
   * `rspecish` **(default)** - Similar to rspec output
   * `tap`
   * `silent` - No output. Avoids exposing system information (e.g. when serving tests as a healthcheck endpoint).

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: ee9c9147007d86588eb760fe7985f4017b3798255d99b23d3240c6a0d8b33291
-updated: 2016-11-09T02:23:29.857676716Z
+hash: 2c0e923a56f3b18d2d54ca094be9cdb325b58deab93791090f06424cfaa8d1c0
+updated: 2018-06-23T21:21:04.977243+01:00
 imports:
 - name: github.com/achanda/go-sysctl
   version: 6be7678c45d2052640e72060e4f5db6165b1ecab
+- name: github.com/aelsabbahy/go-ps
+  version: 443386855ca1f4d28d990ae9e46e9bc1533de994
 - name: github.com/aelsabbahy/GOnetstat
   version: edf89f784e0876818dc19f7744a16742a0a66f16
 - name: github.com/cheekybits/genny
@@ -21,30 +23,32 @@ imports:
   version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
 - name: github.com/miekg/dns
   version: 58f52c57ce9df13460ac68200cef30a008b9c468
-- name: github.com/aelsabbahy/go-ps
-  version: 443386855ca1f4d28d990ae9e46e9bc1533de994
 - name: github.com/oleiade/reflections
   version: 0e86b3c98b2ff33e30c85cfe97d9a63d439fe7eb
 - name: github.com/onsi/gomega
   version: ff4bc6b6f9f5affa66635cd04d31d2a7ee21ffd6
   subpackages:
-  - types
+  - format
   - internal/assertion
   - internal/asyncassertion
+  - internal/oraclematcher
   - internal/testingtsupport
   - matchers
-  - internal/oraclematcher
-  - format
   - matchers/support/goraph/bipartitegraph
   - matchers/support/goraph/edge
   - matchers/support/goraph/node
   - matchers/support/goraph/util
+  - types
 - name: github.com/opencontainers/runc
   version: 8779fa57eb4a810a7360187dfa5e168a76cf5d21
   subpackages:
   - libcontainer/user
 - name: github.com/patrickmn/go-cache
   version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
+- name: github.com/prometheus/client_golang
+  version: 77e8f2ddcfed59ece3a8151879efb2304b5cbbcf
+  subpackages:
+  - prometheus
 - name: github.com/urfave/cli
   version: d86a009f5e13f83df65d0d6cee9a2e3f1445f0da
 - name: golang.org/x/sys

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,3 +22,4 @@ import:
   - pkg/mount
 - package: github.com/patrickmn/go-cache
 - package: github.com/miekg/dns
+- package: github.com/prometheus/client_golang/prometheus

--- a/integration-tests/Dockerfile_wheezy
+++ b/integration-tests/Dockerfile_wheezy
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 MAINTAINER Ahmed
 
-RUN apt-get update && apt-get install -y apache2=2.2.22-13+deb7u12 chkconfig vim-tiny ca-certificates && apt-get remove -y vim-tiny && apt-get clean
+RUN apt-get update && apt-get install -y apache2=2.2.22-13+deb7u13 chkconfig vim-tiny ca-certificates && apt-get remove -y vim-tiny && apt-get clean
 
 RUN chkconfig apache2 on
 RUN mkfifo /pipe

--- a/integration-tests/goss/vars.yaml
+++ b/integration-tests/goss/vars.yaml
@@ -12,4 +12,4 @@ precise:
     apache2: "2.2.22-1ubuntu1.11"
 wheezy:
   packages:
-    apache2: "2.2.22-13+deb7u12"
+    apache2: "2.2.22-13+deb7u13"

--- a/integration-tests/goss/wheezy/goss-aa-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-aa-expected.yaml
@@ -2,7 +2,7 @@ package:
   apache2:
     installed: true
     versions:
-    - 2.2.22-13+deb7u12
+    - 2.2.22-13+deb7u13
 port:
   tcp:80:
     listening: true

--- a/integration-tests/goss/wheezy/goss-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-expected.yaml
@@ -14,7 +14,7 @@ package:
   apache2:
     installed: true
     versions:
-    - 2.2.22-13+deb7u12
+    - 2.2.22-13+deb7u13
   foobar:
     installed: false
   vim-tiny:

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -3,7 +3,6 @@ package outputs
 import (
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/aelsabbahy/goss/resource"
@@ -65,7 +64,6 @@ func init() {
 }
 
 func mechanizeResult(r resource.TestResult) string {
-	resourceName := fmt.Sprintf("goss_%s", strings.ToLower(r.ResourceType))
-	return fmt.Sprintf("%s{resource_id=\"%s\",property=\"%s\"} %d",
-		resourceName, r.ResourceId, r.Property, int64(r.Result))
+	return fmt.Sprintf("goss{resource_type=\"%s\",resource_id=\"%s\",property=\"%s\"} %d",
+		r.ResourceType, r.ResourceId, r.Property, int64(r.Result))
 }

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -1,0 +1,71 @@
+package outputs
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aelsabbahy/goss/resource"
+	"github.com/aelsabbahy/goss/util"
+)
+
+type Prometheus struct{}
+
+func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
+	startTime time.Time, outConfig util.OutputConfig) (exitCode int) {
+
+	var testCount, success, failed, skipped int
+	testCount, success, failed, skipped = 0, 0, 0, 0
+
+	var summary map[int]string
+	summary = make(map[int]string)
+
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			switch testResult.Result {
+			case resource.SUCCESS:
+				success++
+			case resource.FAIL:
+				failed++
+			case resource.SKIP:
+				skipped++
+			default:
+				panic(fmt.Sprintf("Unexpected Result Code: %v\n", testResult.Result))
+			}
+
+			summary[testCount] = fmt.Sprintf("%s\n", mechanizeResult(testResult))
+
+			testCount++
+		}
+	}
+
+	for i := 0; i < testCount; i++ {
+		fmt.Fprintf(w, "%s", summary[i])
+	}
+
+	// Print goss run metrics
+	fmt.Fprintf(w, "goss_count %d\n", testCount)
+	fmt.Fprintf(w, "goss_success_count %d\n", success)
+	fmt.Fprintf(w, "goss_skipped_count %d\n", skipped)
+	fmt.Fprintf(w, "goss_failed_count %d\n", failed)
+
+	duration := float64(time.Since(startTime).Seconds())
+	fmt.Fprintf(w, "goss_duration_seconds %.3f\n", duration)
+
+	if failed > 0 {
+		return 1
+	}
+
+	return 0
+}
+
+func init() {
+	RegisterOutputer("prometheus", &Prometheus{}, []string{})
+}
+
+func mechanizeResult(r resource.TestResult) string {
+	resourceName := fmt.Sprintf("goss_%s", strings.ToLower(r.ResourceType))
+	return fmt.Sprintf("%s{resource_id=\"%s\",property=\"%s\"} %d",
+		resourceName, r.ResourceId, r.Property, int64(r.Result))
+}

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -33,7 +33,7 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 				panic(fmt.Sprintf("Unexpected Result Code: %v\n", testResult.Result))
 			}
 
-			summary[testCount] = fmt.Sprintf("%s\n", mechanizeResult(testResult))
+			summary[testCount] = fmt.Sprintf("%s\n", promFormat(testResult))
 
 			testCount++
 		}
@@ -63,7 +63,7 @@ func init() {
 	RegisterOutputer("prometheus", &Prometheus{}, []string{})
 }
 
-func mechanizeResult(r resource.TestResult) string {
+func promFormat(r resource.TestResult) string {
 	return fmt.Sprintf("goss{resource_type=\"%s\",resource_id=\"%s\",property=\"%s\"} %d",
 		r.ResourceType, r.ResourceId, r.Property, int64(r.Result))
 }

--- a/serve.go
+++ b/serve.go
@@ -32,6 +32,9 @@ func Serve(c *cli.Context) {
 	if c.String("format") == "json" {
 		health.contentType = "application/json"
 	}
+	if c.String("format") == "prometheus" {
+		health.contentType = "text/plain; version=0.0.4"
+	}
 	http.Handle(endpoint, health)
 	listenAddr := c.String("listen-addr")
 	log.Printf("Starting to listen on: %s", listenAddr)
@@ -84,7 +87,7 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.contentType != "" {
 		w.Header().Set("Content-Type", h.contentType)
 	}
-	if resp.exitCode == 0 {
+	if resp.exitCode == 0 || h.c.String("format") == "prometheus" {
 		resp.b.WriteTo(w)
 	} else {
 		w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
Re-creating the Prometheus output with a bit of polishing and a slightly better understanding of how PromQL works / can be used. Related to #362.

A few things to note:

1. I'm not using the prometheus golang client lib, it felt a little more pragmatic to follow all the other outputs and print results to stdout allowing it to be used with `validate` and the `serve` command. It's a lot simpler and we already take care of serving the http endpoint.

2. Previously in #175 I had created a metric_name for each resource type like `goss_user`, `goss_port` and so on. I've since learned that this isn't very friendly for searching something like all failed resource tests. Unlike other TSDB's (influx, graphite) Prometheus doesn't seem to do regex / glob searches on metric names. I've moved the resource type to be a label which makes more sense.

3. the metric value is the test result (0=success, 1=failed, 2=skipped) this makes it easier to search. For example a query of `goss > 0` will return all failed test results.

Any feedback would be appreciated!