### PR TITLE
Add support for OpenRC runlevels

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -757,8 +757,13 @@ service:
     # required attributes
     enabled: true
     running: true
+    # Optional attributes - Alpine systems
+    runlevel: default
+    # Optional attributes
     skip: false
 ```
+
+`runlevel` will default to `sysinit` if omitted.
 
 **NOTE:** this will **not** automatically check if the process is alive, it will check the status from `systemd`/`upstart`/`init`.
 

--- a/integration-tests/Dockerfile_alpine3
+++ b/integration-tests/Dockerfile_alpine3
@@ -3,7 +3,8 @@ MAINTAINER Ahmed
 
 # install apache2 and remove un-needed services
 RUN apk update && \
-  apk add openrc apache2 bash ca-certificates && \
+  apk add openrc apache2 bash ca-certificates openssh && \
   rc-update add apache2 && \
+  rc-update add sshd default && \
   rm -rf /etc/init.d/networking /etc/init.d/hwdrivers /var/cache/apk/* /tmp/*
 RUN mkfifo /pipe

--- a/integration-tests/goss/alpine3/goss.yaml
+++ b/integration-tests/goss/alpine3/goss.yaml
@@ -3,6 +3,13 @@ service:
   autofs:
     enabled: false
     running: false
+  apache2:
+    enabled: true
+    running: true
+  sshd:
+    enabled: true
+    running: true
+    runlevel: default
 user:
   apache:
     exists: true

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -45,6 +45,8 @@ echo "$out"
 
 if [[ $os == "arch" ]]; then
     egrep -q 'Count: 84, Failed: 0, Skipped: 3' <<<"$out"
+elif [[ $os == "alpine3" ]]; then
+    egrep -q 'Count: 103, Failed: 0, Skipped: 5' <<<"$out"
 else
     egrep -q 'Count: 101, Failed: 0, Skipped: 5' <<<"$out"
 fi

--- a/resource/service.go
+++ b/resource/service.go
@@ -12,7 +12,7 @@ type Service struct {
 	Enabled  matcher `json:"enabled" yaml:"enabled"`
 	Running  matcher `json:"running" yaml:"running"`
 	Skip     bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
-	RunLevel string  `json:"runlevel" yaml:"runlevel"`
+	RunLevel string  `json:"runlevel,omitempty" yaml:"runlevel,omitempty"`
 }
 
 func (s *Service) ID() string      { return s.Service }

--- a/resource/service.go
+++ b/resource/service.go
@@ -6,12 +6,13 @@ import (
 )
 
 type Service struct {
-	Title   string  `json:"title,omitempty" yaml:"title,omitempty"`
-	Meta    meta    `json:"meta,omitempty" yaml:"meta,omitempty"`
-	Service string  `json:"-" yaml:"-"`
-	Enabled matcher `json:"enabled" yaml:"enabled"`
-	Running matcher `json:"running" yaml:"running"`
-	Skip    bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
+	Title    string  `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta     meta    `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Service  string  `json:"-" yaml:"-"`
+	Enabled  matcher `json:"enabled" yaml:"enabled"`
+	Running  matcher `json:"running" yaml:"running"`
+	Skip     bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
+	RunLevel string  `json:"runlevel" yaml:"runlevel"`
 }
 
 func (s *Service) ID() string      { return s.Service }
@@ -22,7 +23,7 @@ func (s *Service) GetMeta() meta    { return s.Meta }
 
 func (s *Service) Validate(sys *system.System) []TestResult {
 	skip := false
-	sysservice := sys.NewService(s.Service, sys, util.Config{})
+	sysservice := sys.NewService(s.Service, sys, util.Config{RunLevel: s.RunLevel})
 
 	if s.Skip {
 		skip = true

--- a/util/config.go
+++ b/util/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Username          string
 	Password          string
 	LocalAddress      string
+	RunLevel          string `default:"sysinit"`
 }
 
 type OutputConfig struct {


### PR DESCRIPTION
Alpine Linux (and Gentoo) use OpenRC. Goss was hard-coded to expect a service to be at the sysinit runlevel, if the service was at a different runlevel the service check would erroneously fail.

Behaviour prior to this PR: -

```
alpine38:/tmp# service sshd status
 * status: started

alpine38:/tmp# ./goss-0.3.6-linux-amd64 -g /tmp/goss/goss.yaml v
..........F.

Failures/Skipped:

Service: sshd: enabled:
Expected
    <bool>: false
to equal
    <bool>: true

Total Duration: 0.012s
Count: 12, Failed: 1, Skipped: 0
```

With this PR the service block now supports an optional `runlevel` attribute, which defaults to `sysinit` if omitted maintaining the old behaviour.

Now it is possible to install openssh-server in Alpine linux and properly check the service is running with the following config: -

```
service:
  sshd:
    enabled: true
    running: true
    runlevel: default
```

Additionally you might have:

```
port:
  tcp:22:
    listening: true
    ip:
    - 0.0.0.0
  tcp6:22:
    listening: true
    ip:
    - '::'
user:
  sshd:
    exists: true
    groups:
    - sshd
    home: /dev/null
    shell: /sbin/nologin
group:
  sshd:
    exists: true
process:
  sshd:
    running: true
```

Post this PR:

```
alpine38:/tmp# ~/goss-berne2d -g /tmp/goss/goss.yaml v
runlevel is default
............

Total Duration: 0.012s
Count: 12, Failed: 0, Skipped: 0
```

Note: I'm quite new to reading and writing golang. I've tested the changes and the code works for me. If I have used bad constructs or poor programming please correct it or help me correct it.

Ideally I'd have written test cases but I don't know how to do that yet.