### PR TITLE
Fix debian wheezy CI

### DIFF
--- a/integration-tests/Dockerfile_wheezy
+++ b/integration-tests/Dockerfile_wheezy
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 MAINTAINER Ahmed
 
-RUN apt-get update && apt-get install -y apache2=2.2.22-13+deb7u12 chkconfig vim-tiny ca-certificates && apt-get remove -y vim-tiny && apt-get clean
+RUN apt-get update && apt-get install -y apache2=2.2.22-13+deb7u13 chkconfig vim-tiny ca-certificates && apt-get remove -y vim-tiny && apt-get clean
 
 RUN chkconfig apache2 on
 RUN mkfifo /pipe

--- a/integration-tests/goss/vars.yaml
+++ b/integration-tests/goss/vars.yaml
@@ -12,4 +12,4 @@ precise:
     apache2: "2.2.22-1ubuntu1.11"
 wheezy:
   packages:
-    apache2: "2.2.22-13+deb7u12"
+    apache2: "2.2.22-13+deb7u13"

--- a/integration-tests/goss/wheezy/goss-aa-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-aa-expected.yaml
@@ -2,7 +2,7 @@ package:
   apache2:
     installed: true
     versions:
-    - 2.2.22-13+deb7u12
+    - 2.2.22-13+deb7u13
 port:
   tcp:80:
     listening: true

--- a/integration-tests/goss/wheezy/goss-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-expected.yaml
@@ -14,7 +14,7 @@ package:
   apache2:
     installed: true
     versions:
-    - 2.2.22-13+deb7u12
+    - 2.2.22-13+deb7u13
   foobar:
     installed: false
   vim-tiny:


### PR DESCRIPTION
according to https://packages.debian.org/search?keywords=apache2 there was a security fix, so use later package

I've seen this in a couple of open PRs, so here's the fix in isolation if that's easier to merge.