### PR TITLE
Add ToUpper and ToLower to Template funcMap

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -848,6 +848,8 @@ Available functions beyond text/template [built-in functions](https://golang.org
 * `readFile "fileName"` - Reads file content into a string, trims whitespace. Useful when a file contains a token.
   * **NOTE:** Goss will error out during during the parsing phase if the file does not exist, no tests will be executed.
 * `regexMatch "(some)?reg[eE]xp"` - Tests the piped input against the regular expression argument.
+* `ToLower` - Changes piped input to lowercase
+* `ToUpper` - Changes piped input to UPPERCASE
 
 **NOTE:** gossfiles containing text/template `{{}}` controls will no longer work with `goss add/autoadd`. One way to get around this is to split your template and static goss files and use [gossfile](#gossfile) to import.
 

--- a/integration-tests/Dockerfile_wheezy
+++ b/integration-tests/Dockerfile_wheezy
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 MAINTAINER Ahmed
 
-RUN apt-get update && apt-get install -y apache2=2.2.22-13+deb7u12 chkconfig vim-tiny ca-certificates && apt-get remove -y vim-tiny && apt-get clean
+RUN apt-get update && apt-get install -y apache2=2.2.22-13+deb7u13 chkconfig vim-tiny ca-certificates && apt-get remove -y vim-tiny && apt-get clean
 
 RUN chkconfig apache2 on
 RUN mkfifo /pipe

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -11,8 +11,8 @@ command:
     stderr:
     - not found
 file:
-{{range mkSlice "/etc/passwd" "/etc/group"}}
-  {{.}}:
+{{range mkSlice "/etc/PAsswD" "/etc/group"}}
+  {{. | ToLower}}:
     exists: true
     mode: '0644'
     owner: root

--- a/integration-tests/goss/vars.yaml
+++ b/integration-tests/goss/vars.yaml
@@ -12,4 +12,4 @@ precise:
     apache2: "2.2.22-1ubuntu1.11"
 wheezy:
   packages:
-    apache2: "2.2.22-13+deb7u12"
+    apache2: "2.2.22-13+deb7u13"

--- a/integration-tests/goss/wheezy/goss-aa-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-aa-expected.yaml
@@ -2,7 +2,7 @@ package:
   apache2:
     installed: true
     versions:
-    - 2.2.22-13+deb7u12
+    - 2.2.22-13+deb7u13
 port:
   tcp:80:
     listening: true

--- a/integration-tests/goss/wheezy/goss-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-expected.yaml
@@ -14,7 +14,7 @@ package:
   apache2:
     installed: true
     versions:
-    - 2.2.22-13+deb7u12
+    - 2.2.22-13+deb7u13
   foobar:
     installed: false
   vim-tiny:

--- a/template.go
+++ b/template.go
@@ -47,6 +47,8 @@ var funcMap = map[string]interface{}{
 	"readFile":   readFile,
 	"getEnv":     getEnv,
 	"regexMatch": regexMatch,
+	"ToUpper":    strings.ToUpper,
+	"ToLower":    strings.ToLower,
 }
 
 func NewTemplateFilter(varsFile string) func([]byte) []byte {


### PR DESCRIPTION
Add basic ToUpper and ToLower support for Template pipelines by injecting functions from strings

Fixes #383 