### PR TITLE
dgoss: Fix cp strategy for existing /goss folder

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -43,7 +43,7 @@ run(){
         info "Creating docker container"
         id=$(docker create "${@:2}")
         info "Copy goss files into container"
-        docker cp $tmp_dir $id:/goss
+        docker cp $tmp_dir/. $id:/goss
         info "Starting docker container"
         docker start $id > /dev/null
         ;;


### PR DESCRIPTION
When using dgoss with the 'cp' strategy and a container image which already contains the '/goss' directory, the `docker cp` command copies the local goss folder to '/goss/goss' instead of copying the contents into '/goss'.

As preserving existing directory contents within the container can be interesting (e.g. generating goss vars during build time), this commit fixes dgoss to use `docker cp srcdir/. destdir` instead of `docker cp
srcdir destdir` - note the difference of the trailing slash and dot.

The exact behavior of the Docker cp command can be found at: https://docs.docker.com/engine/reference/commandline/cp/#extended-description

```
- SRC_PATH specifies a directory
  - DEST_PATH exists and is a directory
    - SRC_PATH does not end with /. (that is: slash followed by dot)
      the source directory is copied into this directory
    - SRC_PATH does end with /. (that is: slash followed by dot)
      the content of the source directory is copied into this directory
```