### PR TITLE
Handle invalid CLI flags

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -286,11 +287,11 @@ func main() {
 							Value: 5 * time.Second,
 						},
 						cli.StringFlag{
-							Name: "username, u",
+							Name:  "username, u",
 							Usage: "Username for basic auth",
 						},
 						cli.StringFlag{
-							Name: "password, p",
+							Name:  "password, p",
 							Usage: "Password for basic auth",
 						},
 					},
@@ -335,6 +336,9 @@ func main() {
 		},
 	}
 
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 }


### PR DESCRIPTION
Previously, the flags were not handled so the application would
Looking at the documentation for https://github.com/urfave/cli , the error is propogated up through the `app.Run` call.
Now, the error is checked before fatally logging it.

closes https://github.com/aelsabbahy/goss/issues/420