### PR TITLE
Disable dnstest

### DIFF
--- a/integration-tests/Dockerfile_alpine3.md5
+++ b/integration-tests/Dockerfile_alpine3.md5
@@ -1,1 +1,1 @@
-9cc0707454b2455422e5e8b6a6c74edb  Dockerfile_alpine3
+e2f31142f9eff4b949ecf65aea93bfb1  Dockerfile_alpine3

--- a/integration-tests/Dockerfile_arch.md5
+++ b/integration-tests/Dockerfile_arch.md5
@@ -1,1 +1,1 @@
-f73a8fa9e9c0940ce2bfc09c13c3aaf5  Dockerfile_arch
+7743af2cd089e92858eca1715db25949  Dockerfile_arch

--- a/integration-tests/Dockerfile_centos7.md5
+++ b/integration-tests/Dockerfile_centos7.md5
@@ -1,1 +1,1 @@
-4df4f4463945687a115a13b11649dfb0  Dockerfile_centos7
+4797d326767d26e936b553055a4e2f24  Dockerfile_centos7

--- a/integration-tests/Dockerfile_precise.md5
+++ b/integration-tests/Dockerfile_precise.md5
@@ -1,1 +1,1 @@
-61ff5e338511ab02b4149e2a63ff311d  Dockerfile_precise
+5de599504ae6f300201f2be6f9607500  Dockerfile_precise

--- a/integration-tests/Dockerfile_wheezy.md5
+++ b/integration-tests/Dockerfile_wheezy.md5
@@ -1,1 +1,1 @@
-fe21d74d27c0dc3a013bedadb05e75d5  Dockerfile_wheezy
+04b0e1f5616bb710145e9efd3d27d5b0  Dockerfile_wheezy

--- a/integration-tests/goss/alpine3/goss-expected-q.yaml
+++ b/integration-tests/goss/alpine3/goss-expected-q.yaml
@@ -55,38 +55,6 @@ command:
     stderr: []
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     timeout: 1000

--- a/integration-tests/goss/alpine3/goss-expected.yaml
+++ b/integration-tests/goss/alpine3/goss-expected.yaml
@@ -69,59 +69,6 @@ command:
     - 'sh: foobar: not found'
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 issue comodoca.com
-    - 0 issue letsencrypt.org
-    - 0 issuewild ;
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    addrs:
-    - a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    addrs:
-    - 10 b.dnstest.io.
-    - 5 a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    addrs:
-    - ns1.dnstest.io.
-    - ns2.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    addrs:
-    - google-public-dns-a.google.com.
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 5 443 a.dnstest.io.
-    - 10 10 443 b.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    addrs:
-    - Hello DNS
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    addrs:
-    - 2404:6800:4001:807::200e
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     addrs:

--- a/integration-tests/goss/centos7/goss-expected-q.yaml
+++ b/integration-tests/goss/centos7/goss-expected-q.yaml
@@ -55,38 +55,6 @@ command:
     stderr: []
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     timeout: 1000

--- a/integration-tests/goss/centos7/goss-expected.yaml
+++ b/integration-tests/goss/centos7/goss-expected.yaml
@@ -75,59 +75,6 @@ command:
     - 'sh: foobar: command not found'
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 issue comodoca.com
-    - 0 issue letsencrypt.org
-    - 0 issuewild ;
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    addrs:
-    - a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    addrs:
-    - 10 b.dnstest.io.
-    - 5 a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    addrs:
-    - ns1.dnstest.io.
-    - ns2.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    addrs:
-    - google-public-dns-a.google.com.
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 5 443 a.dnstest.io.
-    - 10 10 443 b.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    addrs:
-    - Hello DNS
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    addrs:
-    - 2404:6800:4001:807::200e
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     addrs:

--- a/integration-tests/goss/generate_goss.sh
+++ b/integration-tests/goss/generate_goss.sh
@@ -34,21 +34,21 @@ goss a "${args[@]}" group $user foobar
 
 goss a "${args[@]}" command "echo 'hi'" foobar
 
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 CNAME:c.dnstest.io
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 MX:dnstest.io
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 NS:dnstest.io
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 PTR:8.8.8.8
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 SRV:_https._tcp.dnstest.io
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 TXT:txt._test.dnstest.io
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 CAA:dnstest.io
-
-goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 ip6.dnstest.io
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 CNAME:c.dnstest.io
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 MX:dnstest.io
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 NS:dnstest.io
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 PTR:8.8.8.8
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 SRV:_https._tcp.dnstest.io
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 TXT:txt._test.dnstest.io
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 CAA:dnstest.io
+#
+#goss a "${args[@]}" dns --timeout 1s --server 8.8.8.8 ip6.dnstest.io
 
 goss a "${args[@]}" dns --timeout 1s localhost
 

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -68,74 +68,11 @@ group:
   foobar:
     exists: false
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 issue comodoca.com
-    - 0 issue letsencrypt.org
-    - 0 issuewild ;
-    timeout: 2000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    addrs:
-    - a.dnstest.io.
-    timeout: 2000
-    server: 8.8.8.8
-  c.dnstest.io:
-    resolvable: true
-    addrs:
-    - 192.30.252.153
-    timeout: 2000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    addrs:
-    - 10 b.dnstest.io.
-    - 5 a.dnstest.io.
-    timeout: 2000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    addrs:
-    - ns1.dnstest.io.
-    - ns2.dnstest.io.
-    timeout: 2000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    addrs:
-    - google-public-dns-a.google.com.
-    timeout: 2000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 5 443 a.dnstest.io.
-    - 10 10 443 b.dnstest.io.
-    timeout: 2000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    addrs:
-    - Hello DNS
-    timeout: 2000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    addrs:
-    - 2404:6800:4001:807::200e
-    timeout: 2000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     addrs:
     - 127.0.0.1
     - "::1"
-    timeout: 2000
-  dnstest.io:
-    resolvable: true
-    server: 8.8.8.8
     timeout: 2000
 process:
   foobar:

--- a/integration-tests/goss/precise/goss-expected-q.yaml
+++ b/integration-tests/goss/precise/goss-expected-q.yaml
@@ -55,38 +55,6 @@ command:
     stderr: []
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     timeout: 1000

--- a/integration-tests/goss/precise/goss-expected.yaml
+++ b/integration-tests/goss/precise/goss-expected.yaml
@@ -75,59 +75,6 @@ command:
     - 'sh: 1: foobar: not found'
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 issue comodoca.com
-    - 0 issue letsencrypt.org
-    - 0 issuewild ;
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    addrs:
-    - a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    addrs:
-    - 10 b.dnstest.io.
-    - 5 a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    addrs:
-    - ns1.dnstest.io.
-    - ns2.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    addrs:
-    - google-public-dns-a.google.com.
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 5 443 a.dnstest.io.
-    - 10 10 443 b.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    addrs:
-    - Hello DNS
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    addrs:
-    - 2404:6800:4001:807::200e
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     addrs:

--- a/integration-tests/goss/wheezy/goss-expected-q.yaml
+++ b/integration-tests/goss/wheezy/goss-expected-q.yaml
@@ -55,38 +55,6 @@ command:
     stderr: []
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     timeout: 1000

--- a/integration-tests/goss/wheezy/goss-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-expected.yaml
@@ -75,59 +75,6 @@ command:
     - 'sh: 1: foobar: not found'
     timeout: 10000
 dns:
-  CAA:dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 issue comodoca.com
-    - 0 issue letsencrypt.org
-    - 0 issuewild ;
-    timeout: 1000
-    server: 8.8.8.8
-  CNAME:c.dnstest.io:
-    resolvable: true
-    addrs:
-    - a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  MX:dnstest.io:
-    resolvable: true
-    addrs:
-    - 10 b.dnstest.io.
-    - 5 a.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  NS:dnstest.io:
-    resolvable: true
-    addrs:
-    - ns1.dnstest.io.
-    - ns2.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  PTR:8.8.8.8:
-    resolvable: true
-    addrs:
-    - google-public-dns-a.google.com.
-    timeout: 1000
-    server: 8.8.8.8
-  SRV:_https._tcp.dnstest.io:
-    resolvable: true
-    addrs:
-    - 0 5 443 a.dnstest.io.
-    - 10 10 443 b.dnstest.io.
-    timeout: 1000
-    server: 8.8.8.8
-  TXT:txt._test.dnstest.io:
-    resolvable: true
-    addrs:
-    - Hello DNS
-    timeout: 1000
-    server: 8.8.8.8
-  ip6.dnstest.io:
-    resolvable: true
-    addrs:
-    - 2404:6800:4001:807::200e
-    timeout: 1000
-    server: 8.8.8.8
   localhost:
     resolvable: true
     addrs:

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -44,9 +44,9 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" -g "/gos
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-  egrep -q 'Count: 74, Failed: 0' <<<"$out"
+  egrep -q 'Count: 55, Failed: 0' <<<"$out"
 else
-  egrep -q 'Count: 88, Failed: 0' <<<"$out"
+  egrep -q 'Count: 69, Failed: 0' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then


### PR DESCRIPTION
Disable failing dnstest.io tests. Need to find a good stable alternative.