### PR TITLE
Account for multiple colon's in dns key (IPv6 PTR) 

### DIFF
--- a/system/dns.go
+++ b/system/dns.go
@@ -3,6 +3,7 @@ package system
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,12 +36,15 @@ type DefDNS struct {
 func NewDefDNS(host string, system *System, config util.Config) DNS {
 	var h string
 	var t string
-	if len(strings.Split(host, ":")) > 1 {
-		h = strings.Split(host, ":")[1]
-		t = strings.Split(host, ":")[0]
+
+	splitHost := strings.SplitN(host, ":", 2)
+	if len(splitHost) == 2 && regexp.MustCompile(`^[A-Z]+$`).MatchString(splitHost[0]) {
+		h = splitHost[1]
+		t = splitHost[0]
 	} else {
 		h = host
 	}
+
 	return &DefDNS{
 		host:    h,
 		Timeout: config.Timeout,


### PR DESCRIPTION
This fixes #428 and adds a very naive check that the type part of a key is an uppercase string.

Fixed the dnstest.io NSD servers. some cron tasks had been silently failing when re-signing records 🤷‍♂ 

