### PR TITLE
Add check for mount disk usage

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -633,6 +633,8 @@ mount:
     - relatime
     source: /dev/mapper/fedora-home
     filesystem: xfs
+    usage: #% of blocks used in this mountpoint
+      lt: 95
 ```
 
 ### matching

--- a/resource/mount.go
+++ b/resource/mount.go
@@ -14,6 +14,7 @@ type Mount struct {
 	Source     matcher `json:"source,omitempty" yaml:"source,omitempty"`
 	Filesystem matcher `json:"filesystem,omitempty" yaml:"filesystem,omitempty"`
 	Skip       bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
+	Usage      matcher `json:"usage,omitempty" yaml:"usage,omitempty"`
 }
 
 func (m *Mount) ID() string      { return m.MountPoint }
@@ -44,6 +45,9 @@ func (m *Mount) Validate(sys *system.System) []TestResult {
 	}
 	if m.Filesystem != nil {
 		results = append(results, ValidateValue(m, "filesystem", m.Filesystem, sysMount.Filesystem, skip))
+	}
+	if m.Usage != nil {
+		results = append(results, ValidateValue(m, "usage", m.Usage, sysMount.Usage, skip))
 	}
 	return results
 }


### PR DESCRIPTION
This pull request extends the mount system check to also store disk usage information. It can be used with a mount resource to either check exact disk usage, or combined with the gomega matcher to ensure that disk usage is below/above a certain percent. Please let me know what tests I can add to verify this change, or if this information is out-of-scope for the mount resource checks.

Thanks