### PR TITLE
add "kgoss" kubectl wrapper to test containers in Kubernetes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ deploy:
     - release/goss-linux-386
     - release/goss-linux-arm
     - extras/dgoss/dgoss
-    - extras/kgoss/kgoss
   skip_cleanup: true
   on:
     repo: aelsabbahy/goss

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ deploy:
     - release/goss-linux-386
     - release/goss-linux-arm
     - extras/dgoss/dgoss
+    - extras/kgoss/kgoss
   skip_cleanup: true
   on:
     repo: aelsabbahy/goss

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Note:** For an even faster way of doing this, see: [autoadd](https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#autoadd-aa---auto-add-all-matching-resources-to-test-suite)
 
-**Note:** For testing docker containers see the [dgoss](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) wrapper
+**Note:** For testing docker containers see the [dgoss](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) wrapper. For testing containers in Kubernetes pods see the [kgoss](https://github.com/aelsabbahy/goss/tree/master/extras/kgoss) wrapper.
 
 **Note:** For some Docker/Kubernetes healthcheck, health endpoint, and
 container ordering examples, see my blog post

--- a/extras/kgoss/README.md
+++ b/extras/kgoss/README.md
@@ -1,0 +1,135 @@
+# kgoss
+
+kgoss is a wrapper for goss that aims to bring the simplicity of testing
+with goss to containers running in pods in Kubernetes.
+
+kgoss is a script which when invoked copies and runs goss (the binary) within a
+Linux container. goss itself is only supported on Linux, but since it need only
+run in the target container, the kgoss script can be used from any
+bash-compatible shell, including Terminal on Mac and git-bash on Windows. On
+Windows, [winpty][] is used for interactive connections to the pod under test.
+
+[winpty]: https://github.com/rprichard/winpty
+
+## Install
+
+Installing kgoss requires copying the kgoss file to a directory in your PATH
+and copying the goss file to your home folder (or a path set as `GOSS_PATH`),
+as follows.
+
+#### Manual / UI
+
+You can manually install kgoss and goss by going through the Web UI, getting
+the files and putting them in the right path. To get each of them:
+
+* **kgoss**: Run `curl -sSLO
+	https://raw.githubusercontent.com/aelsabbahy/goss/master/extras/kgoss/kgoss`.
+* **goss**: Download the `goss-linux-amd64` asset from
+  <https://github.com/aelsabbahy/goss/releases> and rename it `goss`. Place it
+  in your HOME directory, e.g. C:\\Users\\<username> on Windows; or set the
+  environment variable `GOSS_PATH` to its path.
+
+#### Automatic / CLI
+
+To install from the command line or automatically, use the following commands.
+[jq][] is required to parse the API response and find the release asset's
+download URL.
+
+[jq]: https://stedolan.github.io/jq
+
+First get a GitHub personal access token for accessing the GitHub API from
+<https://github.com/settings/tokens>. Input it in the first
+line below. Set `dest_dir` to a directory in your `PATH` env var.
+
+```
+token=<personal_access_token>
+username=$(whoami)
+dest_dir=${HOME}/bin
+
+host=raw.githubusercontent.com
+repo=aelsabbahy/goss
+# for private repos, replace:
+# host=github.yourcompany.com
+# repo=org-name/goss
+
+## install kgoss
+curl -sSL -u "${username}:${token}" -H 'Accept: application/vnd.github.v3.raw' -o "${dest_dir}/kgoss" \
+  https://${host}/api/v3/repos/${repo}/contents/extras/kgoss/kgoss
+chmod a+rx "${dest_dir}/kgoss"
+
+## install goss
+if [[ ! $(which jq) ]]; then echo "jq is required, get from https://stedolan.github.io/jq"; fi
+version=v0.3.8
+arch=amd64
+host=github.com
+# for private repos, leave `host` blank or same as above:
+# host=github.yourcompany.com
+dl_url=$(curl -sSL -u "${username}:${token}" https://${host}/api/v3/repos/${repo}/releases \
+  | jq -r ".[] | select (.name == \"${version}\") | .assets[] | select (.name == \"goss-linux-${arch}\") | .url")
+curl -sSL -u "${username}:${token}" -H 'Accept: application/octet-stream' -o "${dest_dir}/goss" $dl_url
+chmod a+rx "${dest_dir}/goss"
+
+# If `goss` is not in your path, export a GOSS_PATH variable:
+export GOSS_PATH=${dest_dir}/goss
+
+# Now you can use kgoss as described below:
+# kgoss edit ...
+# kgoss run ...
+```
+
+## Use
+
+`kgoss [run|edit] -i <image_url> [-p | -c "command to run" | -a "args to pass"] [-d "directory to include"]* [-e "k=v"]*`
+
+If none of `-p|-c|-a` are specified the container is run with its configured entry point.
+
+`-d` and `-e` can be specified multiple (or zero) times to add additional
+directories and env vars.
+
+By default kgoss copies `goss.yaml` from the current working directory and
+nothing else. You may need other files like scripts and configurations copied
+as well. Specify `-d <path_to_dir>` for each additional directory you'd like
+to recursively copy. These will be copied as directories next to `goss.yaml`
+in the target container's `GOSS_CONTAINER_PATH`.
+
+To find `goss.yaml` in another directory specify that directory's path in `GOSS_FILES_PATH`.
+
+#### Run
+
+The `run` command is used to validate a docker container. It expects a
+`./goss.yaml` file to exist in the directory it was invoked from.
+
+**Example:**
+
+`kgoss run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine`
+
+`kgoss run` will do the following:
+* Run the container with the start commands specified by `-c`, `-a`, or `-p`.
+* Run `goss` with `$GOSS_WAIT_OPTS` if `./goss_wait.yaml` file exists in the current dir.
+* Run `goss` with `$GOSS_OPTS` using `./goss.yaml` from `GOSS_FILES_PATH`.
+
+#### Edit
+
+Edit will launch a docker container, install goss, and drop the user into an
+interactive shell. Once the user quits the interactive shell, any `goss.yaml`
+or `goss_wait.yaml` are copied out into the current directory. This allows the
+user to leverage the `goss add|autoadd` commands to write tests as they would
+on a regular machine.
+
+**Example:**
+
+`kgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine`
+
+## Environment variables
+
+The following environment variables effect the behavior of kgoss.
+
+Variable | Description | Default
+---------|-------------|--------
+GOSS\_PATH | Local location of a compatible goss binary to use in container | `$(which goss)`
+GOSS\_FILES\_PATH | Location of the goss yaml files | `.`
+GOSS\_KUBECTL\_BIN | Kubenetes client tool to use | `$(which kubectl)`
+GOSS\_OPTS | Options to use for the goss test run. | `--color --format documentation`
+GOSS\_WAIT\_OPTS | Options to use for the goss wait run, when `./goss_wait.yaml` exists. | `-r 30s -s 1s > /dev/null`
+GOSS\_VARS | Variables file relative to `GOSS_FILES_PATH` to copy and use | ""
+GOSS\_CONTAINER\_PATH | Path within container to put goss binary and YAML files | `/tmp/goss`

--- a/extras/kgoss/kgoss
+++ b/extras/kgoss/kgoss
@@ -1,0 +1,281 @@
+#! /usr/bin/env bash
+
+set -eo pipefail
+
+info() {
+    echo -e "[INFO]: $*" >&2
+}
+
+error() {
+    echo -e "[ERROR]: $*" >&2
+    exit 1
+}
+
+usage() {
+>&2 cat <<-'EOF'
+Usage: $(basename $0) [command] [options]
+
+## Commands:
+
+* `run` executes goss in the pod/container with ./goss.yaml as input (by
+default).
+* `edit` opens a prompt inside the container to run `goss add ...`
+and copies out files when complete.
+
+## Options:
+
+-i="image_url:tag" - full URL of container image
+-d="additional directories to copy to container" - may be specified zero to
+    many times
+-e="envvar_key=value" - may be specified zero to many times
+-p - (flag) pause container on entry
+-c="cmd to run" - command to execute as container entry point
+-a="args to entrypoint"
+
+If -p, -c and -a are not specified, container will run its ENTRYPOINT.
+
+-e and -d can be specified multiple times.
+
+## Environment variables and default values:
+
+GOSS_KUBECTL_BIN="$(which kubectl)": location of kubectl-compatible binary
+GOSS_PATH="$(which goss)": location of goss binary
+GOSS_FILES_PATH=".": location of goss.yaml and other configuration files
+GOSS_VARS="": path to a goss.vars file
+GOSS_OPTS="--color --format documentation": options passed to goss
+GOSS_WAIT_OPTS="-r 30s -s 1s > /dev/null": options passed to goss
+GOSS_CONTAINER_PATH="/tmp/goss": path to copy files in container, and working dir for tests
+EOF
+
+exit 2
+}
+
+# GOSS_PATH
+if [[ -z "${GOSS_PATH}" ]]; then
+    if [[ $(which goss 2> /dev/null) ]]; then
+        GOSS_PATH=$(which goss 2> /dev/null)
+    elif [[ -e "${HOME}/goss" ]]; then
+        GOSS_PATH="${HOME}/goss"
+    elif [[ -e "${HOME}/bin/goss" ]]; then 
+        GOSS_PATH="${HOME}/bin/goss"
+    else
+        error "Couldn't find goss, please set GOSS_PATH to it"
+    fi
+fi
+
+# GOSS_KUBECTL_BIN
+GOSS_KUBECTL_BIN=${GOSS_KUBECTL_BIN:-$(which kubectl 2> /dev/null || true)}
+if [[ -z "$GOSS_KUBECTL_BIN" ]]; then error "kgoss requires kubectl in your PATH"; fi
+k=${GOSS_KUBECTL_BIN}
+
+GOSS_FILES_PATH="${GOSS_FILES_PATH:-.}"
+GOSS_OPTS=${GOSS_OPTS:-"--color --format documentation"}
+GOSS_WAIT_OPTS=${GOSS_WAIT_OPTS:-"-r 30s -s 1s > /dev/null"}
+GOSS_CONTAINER_PATH=${GOSS_CONTAINER_PATH:-/tmp/goss}
+
+kgoss_cmd=run
+image=
+pause=0
+cmd=''
+args=''
+to_exec=''
+envs=''
+include_goss_files_dir=0
+dirs_array=()
+
+cleanup() {
+    set +ex
+    rm -rf "$tmp_dir"
+    if [[ -n "$id" ]]; then
+        info "Deleting pod/container"
+        ${k} delete pod "$id" > /dev/null
+    fi
+}
+
+# parse checks for a bare `-d` flag and if set includes GOSS_FILES_PATH in dirs
+# to upload to pod
+parse() {
+  # handle deprecated bare `-d`
+  i=0
+  original_args=("$@")
+  new_args=()
+  re='^-'
+  for arg in "${original_args[@]}"; do
+    if [[ "${arg}" == '-d' ]]; then
+      # check if next word starts with '-'
+      if [[ "${original_args[$(($i+1))]}" =~ $re ]]; then
+        # since it does, mark to copy whole dir and remove this arg
+        include_goss_files_dir=1
+        i=$(($i+1))
+        continue
+      fi
+    fi
+    i=$(($i+1))
+    new_args+=("${arg}")
+  done
+  # end handle `-d`
+
+  # now call original parse_internal func
+  parse_internal "${new_args[@]}"
+}
+
+parse_internal() {
+  info "Parsing command line"
+  kgoss_cmd=$1; shift
+  if [[ ( ! "${kgoss_cmd}" == "run" ) && ( ! "${kgoss_cmd}" == 'edit' ) ]]; then usage; fi
+  envs_array=()
+  while getopts 'i:pc::a::d::e::' arg; do
+    case $arg in
+      i)
+        image="${OPTARG}"
+        info "using image: $image"
+        ;;
+      p)
+        pause=1
+        ;;
+      c)
+        cmd="${OPTARG}"
+        ;;
+      a)
+        args="${OPTARG}"
+        ;;
+      d)
+        dirs_array+=("${OPTARG}")
+        ;;
+      e)
+        envs_array+=("${OPTARG}")
+        ;;
+      *)
+        info "invalid option specified"
+        usage
+        ;;
+    esac
+  done
+
+  for envvar in "${envs_array[@]}"; do
+    envs+=" --env=${envvar}"
+  done
+
+  # if -p (pause) is set, then -c (command) and -a (args) should be empty and
+  # we inject a pause
+  if [[ $pause == 1 ]]; then
+    if [[ ! ( -z "$cmd" && -z "$args" ) ]]; then
+      error "cannot specify -p and -c or -a"
+    fi
+    to_exec="--command -- sleep 1h"
+  else
+    # if not -p (pause), then either:
+    #   * one of -c (command) or -a (args) should be set
+    #   * neither should be set and we default to entrypoint
+    if [[ -n "$cmd" && -n "$args" ]]; then
+      error "cannot specify both -c and -a"
+    fi
+    if [[ -n "$cmd" ]]; then
+      to_exec="--command -- $cmd"
+    fi
+    if [[ -n $"args" ]]; then
+      to_exec="-- $args"
+    fi
+  fi
+  info "going to execute (may be blank): ${to_exec}"
+}
+
+# initialize starts the pod to be tested and copies goss files into it
+initialize () {
+    info "Preparing files to copy into container"
+    cp "${GOSS_PATH}" "$tmp_dir/goss" && chmod 0775 "$tmp_dir/goss"
+    [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && cp "${GOSS_FILES_PATH}/goss.yaml" "$tmp_dir"
+    [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir"
+    [[ ! -z "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir"
+    if [[ ${include_goss_files_dir} == 1 ]]; then cp -r ${GOSS_FILES_PATH}/* "${tmp_dir}"; fi
+    for dir in "${dirs_array[@]}"; do
+      cp -r ${dir} "${tmp_dir}/"
+    done
+
+    GOSS_FILES_STRATEGY=${GOSS_FILES_STRATEGY:="cp"}
+    case "$GOSS_FILES_STRATEGY" in
+      cp)
+        info "Creating Kubernetes pod/container to test"
+        test_pod_name=kgoss-tester-${RANDOM}
+        set -x
+        id=$(${k} run $test_pod_name --image-pull-policy=Always --generator=run-pod/v1 --restart=Never \
+          --labels='app=kgoss-test' --output=jsonpath={.metadata.name} ${envs} \
+          --image=${image} ${to_exec})
+        set +x
+        info "Waiting for container to be ready"
+        ${k} wait pod/${test_pod_name} --for=condition=Ready --timeout=60s
+        info "Copying goss files into pod/container"
+        ${k} cp $tmp_dir/. ${id}:${GOSS_CONTAINER_PATH}/
+        info "Marking copied files as executable"
+        ${k} exec "$id" -- sh -c "chmod --recursive --changes a+x ${GOSS_CONTAINER_PATH}/"
+        ;;
+      *) error "Wrong kgoss files strategy used! Only \"cp\" is supported."
+    esac
+
+    info "Using pod/container: ${id}"
+}
+
+# get_pod_file copies the specified file from the pod to a local path
+get_pod_file() {
+    if ${k} exec "$id" -- sh -c "test -e ${GOSS_CONTAINER_PATH}/$1" &> /dev/null; then
+        mkdir -p "${GOSS_FILES_PATH}"
+        info "Copied '$1' from pod/container to '${GOSS_FILES_PATH}'"
+        ${k} cp "${id}:${GOSS_CONTAINER_PATH}/$1" "${GOSS_FILES_PATH}"
+    fi
+}
+
+main() {
+    kernel="$(uname -s)"
+    case "${kernel}" in
+        MINGW*) prefix="winpty" ;;
+        *)      prefix="" ;;
+    esac
+
+    tmp_dir=$(mktemp -d /tmp/tmp.XXXXXXXXXX)
+    chmod 777 "$tmp_dir"
+    trap 'ret=$?; cleanup; exit $ret' EXIT
+
+    parse "$@"
+    initialize
+
+    # execute
+    case $kgoss_cmd in
+        run)
+            # wait for goss_wait.yaml if present
+            if [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]]; then
+                info "Found goss_wait.yaml, waiting for it to pass before running tests"
+                if [[ -z "${GOSS_VARS}" ]]; then
+                    if ! ${k} exec "$id" -- sh -c "${GOSS_CONTAINER_PATH}/goss -g ${GOSS_CONTAINER_PATH}/goss_wait.yaml validate $GOSS_WAIT_OPTS"; then
+                        error "goss_wait.yaml never passed"
+                    fi
+                else
+                    if ! ${k} exec "$id" -- sh -c "${GOSS_CONTAINER_PATH}/goss -g ${GOSS_CONTAINER_PATH}/goss_wait.yaml --vars='${GOSS_CONTAINER_PATH}/${GOSS_VARS}' validate $GOSS_WAIT_OPTS"; then
+                        error "goss_wait.yaml never passed"
+                    fi
+                fi
+            fi
+
+            # running tests in pod/container
+            info "Running tests within pod/container"
+            if [[ -z "${GOSS_VARS}" ]]; then
+                ${k} exec "$id" -- sh -c "cd ${GOSS_CONTAINER_PATH}; ${GOSS_CONTAINER_PATH}/goss -g ${GOSS_CONTAINER_PATH}/goss.yaml validate $GOSS_OPTS"
+            else
+                ${k} exec "$id" -- sh -c "cd ${GOSS_CONTAINER_PATH}; ${GOSS_CONTAINER_PATH}/goss -g ${GOSS_CONTAINER_PATH}/goss.yaml --vars='${GOSS_CONTAINER_PATH}/${GOSS_VARS}' validate $GOSS_OPTS"
+            fi
+            ;;
+        edit)
+            info "When prompt appears you can run \`goss add\` to add resources"
+            ${prefix} ${k} exec -it "$id" -- sh -c "cd ${GOSS_CONTAINER_PATH}; PATH=\"${GOSS_CONTAINER_PATH}:$PATH\" exec sh" || true
+            echo "Copying goss.yaml and goss_wait.yaml files back to local dir"
+            get_pod_file "goss.yaml"
+            get_pod_file "goss_wait.yaml"
+            [[ ! -z "${GOSS_VARS}" ]] && get_pod_file "${GOSS_VARS}"
+            ;;
+        *)
+            echo "invalid kgoss command, valid commands are 'run' and 'edit'"
+            usage
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
In my environment containers must be built and run within a Kubernetes cluster so I ported dgoss to use `kubectl [run | exec | cp] ...` instead of docker and named the port "kgoss". Thought others might benefit from this too so sharing back upstream.

If you want this, would love to know what your use case is and what other features you seek.

There are refinements to be made and I'd love to add an e2e test, but it seemed a good time to get feedback on the general idea and direction. Thanks!