### PR TITLE
Fixes #412 - Junit output invalid by heathchecks

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -90,8 +90,8 @@ case "$1" in
         fi
         [[ $GOSS_SLEEP ]] && { info "Sleeping for $GOSS_SLEEP"; sleep "$GOSS_SLEEP"; }
         info "Container health"
-        if ! docker top $id; then
-            docker logs $id
+        if ! docker top $id > /dev/null; then
+            docker logs $id 2>&1 "$tmp_dir/docker_output.log"
         fi
         info "Running Tests"
         if [[ -z "${GOSS_VARS}" ]]; then


### PR DESCRIPTION
Redirects log output information about "Container health" to the docker_output.log so that exports to the junit format won't be ruined.


Current output of execution dgoss `run -it docker-image:1.0 > tests.xml`:
```
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
root                11494               11473               0                   20:36               ?                   00:00:00            node
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="goss" errors="0" tests="3" failures="0" skipped="0" time="0.002" timestamp="2019-07-22T20:36:31Z">
<testcase name="File /code/README.md exists" time="0.000">
<system-out>File: /code/README.md: exists: matches expectation: [true]</system-out>
```

new output 
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="goss" errors="0" tests="3" failures="0" skipped="0" time="0.002" timestamp="2019-07-22T20:36:31Z">
<testcase name="File /code/README.md exists" time="0.000">
<system-out>File: /code/README.md: exists: matches expectation: [true]</system-out>
```