### PR TITLE
[dgoss] Use inspect instead of top in health check

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -90,7 +90,7 @@ case "$1" in
         fi
         [[ $GOSS_SLEEP ]] && { info "Sleeping for $GOSS_SLEEP"; sleep "$GOSS_SLEEP"; }
         info "Container health"
-        if ! docker top $id; then
+        if [ "true" != "$(docker inspect -f \"{{.State.Running}}\" $id)" ]; then
             docker logs $id
         fi
         info "Running Tests"


### PR DESCRIPTION
Just started using Goss, very nice! I came across #376 trying to publish JUnit results in my CI. This change tests if the container is running without producing any output to be redirected. This change is working in my environment. Additionally tested with your dgoss-examples repo nginx goss.yaml

```bash
$ GOSS_OPTS="--format junit" dgoss run nginx:1.11.10 > junit.xml
INFO: Starting docker container
INFO: Container ID: 9ddf7dec
INFO: Sleeping for 0.2
INFO: Container health
INFO: Running Tests
INFO: Deleting container
$ head -3 junit.xml 
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="goss" errors="0" tests="13" failures="0" skipped="0" time="0.010" timestamp="2019-08-08T22:46:38Z">
<testcase name="Process nginx running" time="0.000">
```