### PR TITLE
Clarify process check usage

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -739,6 +739,7 @@ process:
     skip: false
 ```
 
+**NOTE:** this check is inspecting the name of the binary, not the name of the process. For example, a process with the name `nginx: master process /usr/sbin/nginx` would be checked with the process `nginx`. To discover the binary of a pid run `ps -p <PID> -o comm`.
 
 ### service
 Validates the state of a service.


### PR DESCRIPTION
I found out the hard way that the process check is not looking at the process name which appears in the `ps` table, and instead is looking at the name of the binary executables behind a process.

I have clarified this in the documentation, plus given a `ps` command to show the binary of a process