### PR TITLE
Fix command ID

### DIFF
--- a/resource/command.go
+++ b/resource/command.go
@@ -22,12 +22,7 @@ type Command struct {
 	Skip       bool     `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
-func (c *Command) ID() string {
-	if c.Exec != "" && c.Exec != c.Command {
-		return fmt.Sprintf("%s: %s", c.Command, c.Exec)
-	}
-	return c.Command
-}
+func (c *Command) ID() string      { return c.Command }
 func (c *Command) SetID(id string) { c.Command = id }
 
 func (c *Command) GetTitle() string { return c.Title }


### PR DESCRIPTION
@sshipway Since you were the original author of the command/exec change, I would love your feedback on this, since I don't know the rationale behind the command.ID change.

This change changes the output of the test result, so that this test file:
```yaml
command:
  python_example:
    exec: |
      python3 << EOF
      import sys
      print('example output')
      for i in range(3):
        print(i)
      sys.exit(15)
      EOF
    stdout:
      - 'example'
      - '0'
      - '1'
      - '2'
    exit-status: 15
    timeout: 10000
```

Current state:
```
$ goss v --format documentation
Command: python_example: python3 << EOF
import sys
print('example output')
for i in range(3):
  print(i)
sys.exit(15)
EOF
: exit-status: matches expectation: [15]
Command: python_example: python3 << EOF
import sys
print('example output')
for i in range(3):
  print(i)
sys.exit(15)
EOF
: stdout: matches expectation: [example 0 1 2]


Total Duration: 0.090s
Count: 2, Failed: 0, Skipped: 0
```

With this PR:
```
$ goss v --format documentation
Command: python_example: exit-status: matches expectation: [15]
Command: python_example: stdout: matches expectation: [example 0 1 2]


Total Duration: 0.045s
Count: 2, Failed: 0, Skipped: 0
```