### PR TITLE
dgoss: fix broken GOSS_FILE variable substitution

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -27,7 +27,7 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
-    [[ -e "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" ]] && cp "${GOSS_FILES_PATH}/{$GOSS_FILE:-goss.yaml}" "$tmp_dir/goss.yaml" && chmod 644 "$tmp_dir/goss.yaml"
+    [[ -e "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" "$tmp_dir/goss.yaml" && chmod 644 "$tmp_dir/goss.yaml"
     [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir" && chmod 644 "$tmp_dir/goss_wait.yaml"
     [[ ! -z "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir" && chmod 644 "$tmp_dir/${GOSS_VARS}"
 


### PR DESCRIPTION
This pull request fixes the bug mentioned down below, which I've filled out based on your issue template. While `shellcheck` mentions several warnings/issues with the script, I wanted to restrict the scope to this single bugfix, as it should be probably merged asap.

**Bug Description**
Running the newest version of dgoss from the `master` branch fails, as 6f739a5599e1c86ad6c7733dabb4d535ccd018d3 introduced an incorrect variable substitution. E.g. if `GOSS_FILES_PATH` is set to `../`, an error message like `cp: cannot stat '..//{:-goss.yaml}': No such file or directory` appears.

**How To Reproduce**
Using the newest version of dgoss (which `curl -fsSL https://goss.rocks/install | sudo sh` automatically installs) no longer works when `goss.yaml` needs to be copied. The issue itself is clearly visible in the code: https://github.com/aelsabbahy/goss/blob/6f739a5599e1c86ad6c7733dabb4d535ccd018d3/extras/dgoss/dgoss#L30
One of the newly introduced variable substitutions is `{$GOSS_FILE:-goss.yaml}` instead of `${GOSS_FILE:-goss.yaml}`, which causes the script to break.

**Environment:**
 - Version of goss: `master` (6f739a5599e1c86ad6c7733dabb4d535ccd018d3 or later)