### PR TITLE
remove cli.Context from main goss packages

### DIFF
--- a/add.go
+++ b/add.go
@@ -9,20 +9,19 @@ import (
 
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
-	"github.com/urfave/cli"
 )
 
 // Simple wrapper to add multiple resources
-func AddResources(fileName, resourceName string, keys []string, c *cli.Context) error {
+func AddResources(fileName, resourceName string, keys []string, c *RuntimeConfig) error {
 	outStoreFormat = getStoreFormatFromFileName(fileName)
 	config := util.Config{
-		IgnoreList:        c.GlobalStringSlice("exclude-attr"),
-		Timeout:           int(c.Duration("timeout") / time.Millisecond),
-		AllowInsecure:     c.Bool("insecure"),
-		NoFollowRedirects: c.Bool("no-follow-redirects"),
-		Server:            c.String("server"),
-		Username:          c.String("username"),
-		Password:          c.String("password"),
+		IgnoreList:        c.ExcludeAttributes,
+		Timeout:           int(c.Timeout / time.Millisecond),
+		AllowInsecure:     c.Insecure,
+		NoFollowRedirects: c.NoFollowRedirects,
+		Server:            c.Server,
+		Username:          c.Username,
+		Password:          c.Password,
 	}
 
 	var gossConfig GossConfig
@@ -32,19 +31,18 @@ func AddResources(fileName, resourceName string, keys []string, c *cli.Context) 
 		gossConfig = *NewGossConfig()
 	}
 
-	sys := system.New(c)
+	sys := system.New(c.PackageManager)
 
 	for _, key := range keys {
-		if err := AddResource(fileName, gossConfig, resourceName, key, c, config, sys); err != nil {
+		if err := AddResource(fileName, gossConfig, resourceName, key, config, sys); err != nil {
 			return err
 		}
 	}
-	WriteJSON(fileName, gossConfig)
 
-	return nil
+	return WriteJSON(fileName, gossConfig)
 }
 
-func AddResource(fileName string, gossConfig GossConfig, resourceName, key string, c *cli.Context, config util.Config, sys *system.System) error {
+func AddResource(fileName string, gossConfig GossConfig, resourceName, key string, config util.Config, sys *system.System) error {
 	// Need to figure out a good way to refactor this
 	switch resourceName {
 	case "Addr":
@@ -160,12 +158,8 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 }
 
 // Simple wrapper to add multiple resources
-func AutoAddResources(fileName string, keys []string, c *cli.Context) error {
+func AutoAddResources(fileName string, keys []string, c *RuntimeConfig) error {
 	outStoreFormat = getStoreFormatFromFileName(fileName)
-	config := util.Config{
-		IgnoreList: c.GlobalStringSlice("exclude-attr"),
-		Timeout:    int(c.Duration("timeout") / time.Millisecond),
-	}
 
 	var gossConfig GossConfig
 	if _, err := os.Stat(fileName); err == nil {
@@ -174,19 +168,18 @@ func AutoAddResources(fileName string, keys []string, c *cli.Context) error {
 		gossConfig = *NewGossConfig()
 	}
 
-	sys := system.New(c)
+	sys := system.New(c.PackageManager)
 
 	for _, key := range keys {
-		if err := AutoAddResource(fileName, gossConfig, key, c, config, sys); err != nil {
+		if err := AutoAddResource(fileName, gossConfig, key, sys); err != nil {
 			return err
 		}
 	}
-	WriteJSON(fileName, gossConfig)
 
-	return nil
+	return WriteJSON(fileName, gossConfig)
 }
 
-func AutoAddResource(fileName string, gossConfig GossConfig, key string, c *cli.Context, config util.Config, sys *system.System) error {
+func AutoAddResource(fileName string, gossConfig GossConfig, key string, sys *system.System) error {
 	// file
 	if strings.Contains(key, "/") {
 		if res, _, ok := gossConfig.Files.AppendSysResourceIfExists(key, sys); ok == true {

--- a/add.go
+++ b/add.go
@@ -13,7 +13,12 @@ import (
 
 // Simple wrapper to add multiple resources
 func AddResources(fileName, resourceName string, keys []string, c *RuntimeConfig) error {
-	outStoreFormat = getStoreFormatFromFileName(fileName)
+	var err error
+	outStoreFormat, err = getStoreFormatFromFileName(fileName)
+	if err != nil {
+		return err
+	}
+
 	config := util.Config{
 		IgnoreList:        c.ExcludeAttributes,
 		Timeout:           int(c.Timeout / time.Millisecond),
@@ -26,7 +31,10 @@ func AddResources(fileName, resourceName string, keys []string, c *RuntimeConfig
 
 	var gossConfig GossConfig
 	if _, err := os.Stat(fileName); err == nil {
-		gossConfig = ReadJSON(fileName)
+		gossConfig, err = ReadJSON(fileName)
+		if err != nil {
+			return err
+		}
 	} else {
 		gossConfig = *NewGossConfig()
 	}
@@ -48,110 +56,95 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 	case "Addr":
 		res, err := gossConfig.Addrs.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Command":
 		res, err := gossConfig.Commands.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "DNS":
 		res, err := gossConfig.DNS.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "File":
 		res, err := gossConfig.Files.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Group":
 		res, err := gossConfig.Groups.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Package":
 		res, err := gossConfig.Packages.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Port":
 		res, err := gossConfig.Ports.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Process":
 		res, err := gossConfig.Processes.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Service":
 		res, err := gossConfig.Services.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "User":
 		res, err := gossConfig.Users.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Gossfile":
 		res, err := gossConfig.Gossfiles.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "KernelParam":
 		res, err := gossConfig.KernelParams.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Mount":
 		res, err := gossConfig.Mounts.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "Interface":
 		res, err := gossConfig.Interfaces.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	case "HTTP":
 		res, err := gossConfig.HTTPs.AppendSysResource(key, sys, config)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 		resourcePrint(fileName, res)
 	default:
-		panic("Undefined resource name: " + resourceName)
+		return fmt.Errorf("undefined resource name: %s", resourceName)
 	}
 
 	return nil
@@ -159,11 +152,18 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 
 // Simple wrapper to add multiple resources
 func AutoAddResources(fileName string, keys []string, c *RuntimeConfig) error {
-	outStoreFormat = getStoreFormatFromFileName(fileName)
+	var err error
+	outStoreFormat, err = getStoreFormatFromFileName(fileName)
+	if err != nil {
+		return err
+	}
 
 	var gossConfig GossConfig
-	if _, err := os.Stat(fileName); err == nil {
-		gossConfig = ReadJSON(fileName)
+	if _, err = os.Stat(fileName); err == nil {
+		gossConfig, err = ReadJSON(fileName)
+		if err != nil {
+			return err
+		}
 	} else {
 		gossConfig = *NewGossConfig()
 	}
@@ -203,7 +203,11 @@ func AutoAddResource(fileName string, gossConfig GossConfig, key string, sys *sy
 	}
 
 	// process
-	if res, sysres, ok := gossConfig.Processes.AppendSysResourceIfExists(key, sys); ok == true {
+	res, sysres, ok, err := gossConfig.Processes.AppendSysResourceIfExists(key, sys)
+	if err != nil {
+		return err
+	}
+	if ok {
 		resourcePrint(fileName, res)
 		ports := system.GetPorts(true)
 		pids, _ := sysres.Pids()

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -46,7 +46,7 @@ func newRuntimeConfigFromCLI(c *cli.Context) *goss.RuntimeConfig {
 	}
 
 	if c.Bool("color") {
-		cfg.NoColor = bp(true)
+		cfg.NoColor = bp(false)
 	}
 
 	return cfg

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -14,7 +14,8 @@ import (
 
 var version string
 
-func NewRuntimeConfigFromCLI(c *cli.Context) *goss.RuntimeConfig {
+// converts a cli context into a goss RuntimeConfig
+func newRuntimeConfigFromCLI(c *cli.Context) *goss.RuntimeConfig {
 	bp := func(b bool) *bool { return &b }
 
 	cfg := &goss.RuntimeConfig{
@@ -127,7 +128,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				code, err := goss.Validate(NewRuntimeConfigFromCLI(c), startTime)
+				code, err := goss.Validate(newRuntimeConfigFromCLI(c), startTime)
 				if err != nil {
 					color.Red(fmt.Sprintf("Error: %v\n", err))
 				}
@@ -178,7 +179,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				goss.Serve(NewRuntimeConfigFromCLI(c))
+				goss.Serve(newRuntimeConfigFromCLI(c))
 				return nil
 			},
 		},
@@ -193,7 +194,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				fmt.Print(goss.RenderJSON(NewRuntimeConfigFromCLI(c)))
+				fmt.Print(goss.RenderJSON(newRuntimeConfigFromCLI(c)))
 				return nil
 			},
 		},
@@ -202,7 +203,7 @@ func main() {
 			Aliases: []string{"aa"},
 			Usage:   "automatically add all matching resource to the test suite",
 			Action: func(c *cli.Context) error {
-				goss.AutoAddResources(c.GlobalString("gossfile"), c.Args(), NewRuntimeConfigFromCLI(c))
+				goss.AutoAddResources(c.GlobalString("gossfile"), c.Args(), newRuntimeConfigFromCLI(c))
 				return nil
 			},
 		},
@@ -221,7 +222,7 @@ func main() {
 					Name:  "package",
 					Usage: "add new package",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -229,7 +230,7 @@ func main() {
 					Name:  "file",
 					Usage: "add new file",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -243,7 +244,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -251,7 +252,7 @@ func main() {
 					Name:  "port",
 					Usage: "add new listening [protocol]:port - ex: 80 or udp:123",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -259,7 +260,7 @@ func main() {
 					Name:  "service",
 					Usage: "add new service",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -267,7 +268,7 @@ func main() {
 					Name:  "user",
 					Usage: "add new user",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -275,7 +276,7 @@ func main() {
 					Name:  "group",
 					Usage: "add new group",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -289,7 +290,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -307,7 +308,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -315,7 +316,7 @@ func main() {
 					Name:  "process",
 					Usage: "add new process name",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -343,7 +344,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -351,7 +352,7 @@ func main() {
 					Name:  "goss",
 					Usage: "add new goss file, it will be imported from this one",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -359,7 +360,7 @@ func main() {
 					Name:  "kernel-param",
 					Usage: "add new goss kernel param",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -367,7 +368,7 @@ func main() {
 					Name:  "mount",
 					Usage: "add new mount",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -375,7 +376,7 @@ func main() {
 					Name:  "interface",
 					Usage: "add new interface",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), NewRuntimeConfigFromCLI(c))
+						goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), newRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -8,10 +8,48 @@ import (
 
 	"github.com/aelsabbahy/goss"
 	"github.com/aelsabbahy/goss/outputs"
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 
 var version string
+
+func NewRuntimeConfigFromCLI(c *cli.Context) *goss.RuntimeConfig {
+	bp := func(b bool) *bool { return &b }
+
+	cfg := &goss.RuntimeConfig{
+		FormatOptions:     c.StringSlice("format-options"),
+		Vars:              c.GlobalString("vars"),
+		VarsInline:        c.GlobalString("vars-inline"),
+		Spec:              c.GlobalString("gossfile"),
+		Sleep:             c.Duration("sleep"),
+		RetryTimeout:      c.Duration("retry-timeout"),
+		Timeout:           c.Duration("timeout"),
+		Cache:             c.Duration("cache"),
+		MaxConcurrent:     c.Int("max-concurrent"),
+		OutputFormat:      c.String("format"),
+		PackageManager:    c.GlobalString("package"),
+		Endpoint:          c.String("endpoint"),
+		ListenAddress:     c.String("listen-addr"),
+		ExcludeAttributes: c.GlobalStringSlice("exclude-attr"),
+		Insecure:          c.Bool("insecure"),
+		NoFollowRedirects: c.Bool("no-follow-redirects"),
+		Server:            c.String("server"),
+		Username:          c.String("username"),
+		Password:          c.String("password"),
+		Debug:             c.Bool("debug"),
+	}
+
+	if c.Bool("no-color") {
+		cfg.NoColor = bp(true)
+	}
+
+	if c.Bool("color") {
+		cfg.NoColor = bp(true)
+	}
+
+	return cfg
+}
 
 func main() {
 	startTime := time.Now()
@@ -89,7 +127,12 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				goss.Validate(c, startTime)
+				code, err := goss.Validate(NewRuntimeConfigFromCLI(c), startTime)
+				if err != nil {
+					color.Red(fmt.Sprintf("Error: %v\n", err))
+				}
+				os.Exit(code)
+
 				return nil
 			},
 		},
@@ -135,7 +178,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				goss.Serve(c)
+				goss.Serve(NewRuntimeConfigFromCLI(c))
 				return nil
 			},
 		},
@@ -150,7 +193,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				fmt.Print(goss.RenderJSON(c))
+				fmt.Print(goss.RenderJSON(NewRuntimeConfigFromCLI(c)))
 				return nil
 			},
 		},
@@ -159,7 +202,7 @@ func main() {
 			Aliases: []string{"aa"},
 			Usage:   "automatically add all matching resource to the test suite",
 			Action: func(c *cli.Context) error {
-				goss.AutoAddResources(c.GlobalString("gossfile"), c.Args(), c)
+				goss.AutoAddResources(c.GlobalString("gossfile"), c.Args(), NewRuntimeConfigFromCLI(c))
 				return nil
 			},
 		},
@@ -178,7 +221,7 @@ func main() {
 					Name:  "package",
 					Usage: "add new package",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -186,7 +229,7 @@ func main() {
 					Name:  "file",
 					Usage: "add new file",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -200,7 +243,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -208,7 +251,7 @@ func main() {
 					Name:  "port",
 					Usage: "add new listening [protocol]:port - ex: 80 or udp:123",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -216,7 +259,7 @@ func main() {
 					Name:  "service",
 					Usage: "add new service",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -224,7 +267,7 @@ func main() {
 					Name:  "user",
 					Usage: "add new user",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -232,7 +275,7 @@ func main() {
 					Name:  "group",
 					Usage: "add new group",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -246,7 +289,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -264,7 +307,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -272,7 +315,7 @@ func main() {
 					Name:  "process",
 					Usage: "add new process name",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -300,7 +343,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -308,7 +351,7 @@ func main() {
 					Name:  "goss",
 					Usage: "add new goss file, it will be imported from this one",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -316,7 +359,7 @@ func main() {
 					Name:  "kernel-param",
 					Usage: "add new goss kernel param",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -324,7 +367,7 @@ func main() {
 					Name:  "mount",
 					Usage: "add new mount",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},
@@ -332,7 +375,7 @@ func main() {
 					Name:  "interface",
 					Usage: "add new interface",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), c)
+						goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), NewRuntimeConfigFromCLI(c))
 						return nil
 					},
 				},

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -194,7 +194,13 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				fmt.Print(goss.RenderJSON(newRuntimeConfigFromCLI(c)))
+				j, err := goss.RenderJSON(newRuntimeConfigFromCLI(c))
+				if err != nil {
+					return err
+				}
+
+				fmt.Print(j)
+
 				return nil
 			},
 		},
@@ -203,8 +209,7 @@ func main() {
 			Aliases: []string{"aa"},
 			Usage:   "automatically add all matching resource to the test suite",
 			Action: func(c *cli.Context) error {
-				goss.AutoAddResources(c.GlobalString("gossfile"), c.Args(), newRuntimeConfigFromCLI(c))
-				return nil
+				return goss.AutoAddResources(c.GlobalString("gossfile"), c.Args(), newRuntimeConfigFromCLI(c))
 			},
 		},
 		{
@@ -222,16 +227,14 @@ func main() {
 					Name:  "package",
 					Usage: "add new package",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "file",
 					Usage: "add new file",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
@@ -244,40 +247,35 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "port",
 					Usage: "add new listening [protocol]:port - ex: 80 or udp:123",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "service",
 					Usage: "add new service",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "user",
 					Usage: "add new user",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "group",
 					Usage: "add new group",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
@@ -290,8 +288,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
@@ -308,16 +305,14 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "process",
 					Usage: "add new process name",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
@@ -344,40 +339,36 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "goss",
 					Usage: "add new goss file, it will be imported from this one",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), newRuntimeConfigFromCLI(c))
+
 					},
 				},
 				{
 					Name:  "kernel-param",
 					Usage: "add new goss kernel param",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "mount",
 					Usage: "add new mount",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
 					Name:  "interface",
 					Usage: "add new interface",
 					Action: func(c *cli.Context) error {
-						goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), newRuntimeConfigFromCLI(c))
-						return nil
+						return goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 			},

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -3,7 +3,6 @@ package outputs
 import (
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -125,12 +124,11 @@ func FormatOptions() []string {
 	return list
 }
 
-func GetOutputer(name string) Outputer {
+func GetOutputer(name string) (Outputer, error) {
 	if _, ok := outputers[name]; !ok {
-		fmt.Println("goss: Bad output format: " + name)
-		os.Exit(1)
+		return nil, fmt.Errorf("bad output format: " + name)
 	}
-	return outputers[name]
+	return outputers[name], nil
 }
 
 func subtractSlice(x, y []string) []string {

--- a/resource/process.go
+++ b/resource/process.go
@@ -20,15 +20,24 @@ func (p *Process) GetTitle() string { return p.Title }
 func (p *Process) GetMeta() meta    { return p.Meta }
 
 func (p *Process) Validate(sys *system.System) []TestResult {
+	var results []TestResult
 	skip := false
-	sysProcess := sys.NewProcess(p.Executable, sys, util.Config{})
+
+	runningf := func() (bool, error) {
+		sysProcess, err := sys.NewProcess(p.Executable, sys, util.Config{})
+		if err != nil {
+			return false, err
+		}
+
+		return sysProcess.Running()
+	}
 
 	if p.Skip {
 		skip = true
 	}
 
-	var results []TestResult
-	results = append(results, ValidateValue(p, "running", p.Running, sysProcess.Running, skip))
+	results = append(results, ValidateValue(p, "running", p.Running, runningf, skip))
+
 	return results
 }
 

--- a/serve.go
+++ b/serve.go
@@ -26,11 +26,18 @@ func Serve(c *RuntimeConfig) {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	output, err := getOutputer(c.NoColor, c.OutputFormat)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	health := healthHandler{
 		c:             c,
 		gossConfig:    *cfg,
 		sys:           system.New(c.PackageManager),
-		outputer:      getOutputer(c.NoColor, c.OutputFormat),
+		outputer:      output,
 		cache:         cache,
 		gossMu:        &sync.Mutex{},
 		maxConcurrent: c.MaxConcurrent,

--- a/serve.go
+++ b/serve.go
@@ -2,8 +2,10 @@ package goss
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -12,30 +14,34 @@ import (
 	"github.com/aelsabbahy/goss/util"
 	"github.com/fatih/color"
 	"github.com/patrickmn/go-cache"
-	"github.com/urfave/cli"
 )
 
-func Serve(c *cli.Context) {
-	endpoint := c.String("endpoint")
+func Serve(c *RuntimeConfig) {
+	endpoint := c.Endpoint
 	color.NoColor = true
-	cache := cache.New(c.Duration("cache"), 30*time.Second)
+	cache := cache.New(c.Cache, 30*time.Second)
 
+	cfg, err := getGossConfig(c.Vars, c.VarsInline, c.Spec)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
 	health := healthHandler{
 		c:             c,
-		gossConfig:    getGossConfig(c),
-		sys:           system.New(c),
-		outputer:      getOutputer(c),
+		gossConfig:    *cfg,
+		sys:           system.New(c.PackageManager),
+		outputer:      getOutputer(c.NoColor, c.OutputFormat),
 		cache:         cache,
 		gossMu:        &sync.Mutex{},
-		maxConcurrent: c.Int("max-concurrent"),
+		maxConcurrent: c.MaxConcurrent,
 	}
-	if c.String("format") == "json" {
+	if c.OutputFormat == "json" {
 		health.contentType = "application/json"
 	}
 	http.Handle(endpoint, health)
-	listenAddr := c.String("listen-addr")
+	listenAddr := c.ListenAddress
 	log.Printf("Starting to listen on: %s", listenAddr)
-	log.Fatal(http.ListenAndServe(c.String("listen-addr"), nil))
+	log.Fatal(http.ListenAndServe(c.ListenAddress, nil))
 }
 
 type res struct {
@@ -43,7 +49,7 @@ type res struct {
 	b        bytes.Buffer
 }
 type healthHandler struct {
-	c             *cli.Context
+	c             *RuntimeConfig
 	gossConfig    GossConfig
 	sys           *system.System
 	outputer      outputs.Outputer
@@ -56,7 +62,7 @@ type healthHandler struct {
 func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	outputConfig := util.OutputConfig{
-		FormatOptions: h.c.StringSlice("format-options"),
+		FormatOptions: h.c.FormatOptions,
 	}
 
 	log.Printf("%v: requesting health probe", r.RemoteAddr)
@@ -71,7 +77,7 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if found {
 			resp = tmp.(res)
 		} else {
-			h.sys = system.New(h.c)
+			h.sys = system.New(h.c.PackageManager)
 			log.Printf("%v: Stale cache, running tests", r.RemoteAddr)
 			iStartTime := time.Now()
 			out := validate(h.sys, h.gossConfig, h.maxConcurrent)

--- a/store.go
+++ b/store.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/aelsabbahy/goss/resource"
-	"github.com/urfave/cli"
 )
 
 const (
@@ -151,22 +150,19 @@ func ReadJSONData(data []byte, detectFormat bool) GossConfig {
 	return *gossConfig
 }
 
-// RenderJSON Reads json file recursively returning string
-func RenderJSON(c *cli.Context) string {
-	filePath := c.GlobalString("gossfile")
-	varsFile := c.GlobalString("vars")
-	varsInline := c.GlobalString("vars-inline")
-	debug = c.Bool("debug")
-	currentTemplateFilter = NewTemplateFilter(varsFile, varsInline)
-	path := filepath.Dir(filePath)
-	outStoreFormat = getStoreFormatFromFileName(filePath)
-	gossConfig := mergeJSONData(ReadJSON(filePath), 0, path)
+// RenderJSON reads json file recursively returning string
+func RenderJSON(c *RuntimeConfig) (string, error) {
+	debug = c.Debug
+	currentTemplateFilter = NewTemplateFilter(c.Vars, c.VarsInline)
+	outStoreFormat = getStoreFormatFromFileName(c.Spec)
+	gossConfig := mergeJSONData(ReadJSON(c.Spec), 0, filepath.Dir(c.Spec))
 
 	b, err := marshal(gossConfig)
 	if err != nil {
-		log.Fatalf("Error rendering: %v\n", err)
+		return "", err
 	}
-	return string(b)
+
+	return string(b), err
 }
 
 func mergeJSONData(gossConfig GossConfig, depth int, path string) GossConfig {

--- a/store.go
+++ b/store.go
@@ -184,7 +184,7 @@ func RenderJSON(c *RuntimeConfig) (string, error) {
 
 	b, err := marshal(gossConfig)
 	if err != nil {
-		log.Fatalf("Error rendering: %v\n", err)
+		return "", fmt.Errorf("rendering failed: %v", err)
 	}
 
 	return string(b), nil
@@ -241,14 +241,14 @@ func mergeJSONData(gossConfig GossConfig, depth int, path string) (GossConfig, e
 func WriteJSON(filePath string, gossConfig GossConfig) error {
 	jsonData, err := marshal(gossConfig)
 	if err != nil {
-		log.Fatalf("Error writing: %v\n", err)
+		return fmt.Errorf("failed to write %s: %s", filePath, err)
 	}
 
 	// check if the auto added json data is empty before writing to file.
 	emptyConfig := *NewGossConfig()
 	emptyData, err := marshal(emptyConfig)
 	if err != nil {
-		log.Fatalf("Error writing: %v\n", err)
+		return fmt.Errorf("failed to write %s: %s", filePath, err)
 	}
 
 	if string(emptyData) == string(jsonData) {
@@ -257,7 +257,7 @@ func WriteJSON(filePath string, gossConfig GossConfig) error {
 	}
 
 	if err := ioutil.WriteFile(filePath, jsonData, 0644); err != nil {
-		log.Fatalf("Error writing: %v\n", err)
+		return fmt.Errorf("failed to write %s: %s", filePath, err)
 	}
 
 	return nil

--- a/system/process.go
+++ b/system/process.go
@@ -1,9 +1,6 @@
 package system
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/aelsabbahy/go-ps"
 	"github.com/aelsabbahy/goss/util"
 )
@@ -20,11 +17,16 @@ type DefProcess struct {
 	procMap    map[string][]ps.Process
 }
 
-func NewDefProcess(executable string, system *System, config util.Config) Process {
+func NewDefProcess(executable string, system *System, config util.Config) (Process, error) {
+	pmap, err := system.ProcMap()
+	if err != nil {
+		return nil, err
+	}
+
 	return &DefProcess{
 		executable: executable,
-		procMap:    system.ProcMap(),
-	}
+		procMap:    pmap,
+	}, nil
 }
 
 func (p *DefProcess) Executable() string {
@@ -48,16 +50,15 @@ func (p *DefProcess) Running() (bool, error) {
 	return false, nil
 }
 
-func GetProcs() map[string][]ps.Process {
+func GetProcs() (map[string][]ps.Process, error) {
 	pmap := make(map[string][]ps.Process)
 	processes, err := ps.Processes()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return pmap, err
 	}
 	for _, p := range processes {
 		pmap[p.Executable()] = append(pmap[p.Executable()], p)
 	}
 
-	return pmap
+	return pmap, nil
 }

--- a/system/system.go
+++ b/system/system.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aelsabbahy/GOnetstat"
 	// This needs a better name
 	"github.com/aelsabbahy/go-ps"
+
 	util2 "github.com/aelsabbahy/goss/util"
-	"github.com/urfave/cli"
 )
 
 type Resource interface {
@@ -55,7 +55,7 @@ func (s *System) ProcMap() map[string][]ps.Process {
 	return s.procMap
 }
 
-func New(c *cli.Context) *System {
+func New(packageManager string) *System {
 	sys := &System{
 		NewFile:        NewDefFile,
 		NewAddr:        NewDefAddr,
@@ -71,14 +71,15 @@ func New(c *cli.Context) *System {
 		NewInterface:   NewDefInterface,
 		NewHTTP:        NewDefHTTP,
 	}
+
 	sys.detectService()
-	sys.detectPackage(c)
+	sys.detectPackage(packageManager)
+
 	return sys
 }
 
 // detectPackage adds the correct package creation function to a System struct
-func (sys *System) detectPackage(c *cli.Context) {
-	p := c.GlobalString("package")
+func (sys *System) detectPackage(p string) {
 	if p != "dpkg" && p != "apk" && p != "pacman" && p != "rpm" {
 		p = DetectPackageManager()
 	}

--- a/system/system.go
+++ b/system/system.go
@@ -29,7 +29,7 @@ type System struct {
 	NewGroup       func(string, *System, util2.Config) Group
 	NewCommand     func(string, *System, util2.Config) Command
 	NewDNS         func(string, *System, util2.Config) DNS
-	NewProcess     func(string, *System, util2.Config) Process
+	NewProcess     func(string, *System, util2.Config) (Process, error)
 	NewGossfile    func(string, *System, util2.Config) Gossfile
 	NewKernelParam func(string, *System, util2.Config) KernelParam
 	NewMount       func(string, *System, util2.Config) Mount
@@ -48,11 +48,14 @@ func (s *System) Ports() map[string][]GOnetstat.Process {
 	return s.ports
 }
 
-func (s *System) ProcMap() map[string][]ps.Process {
+func (s *System) ProcMap() (map[string][]ps.Process, error) {
+	var err error
+
 	s.procOnce.Do(func() {
-		s.procMap = GetProcs()
+		s.procMap, err = GetProcs()
 	})
-	return s.procMap
+
+	return s.procMap, err
 }
 
 func New(packageManager string) *System {

--- a/validate.go
+++ b/validate.go
@@ -9,30 +9,51 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/aelsabbahy/goss/outputs"
 	"github.com/aelsabbahy/goss/resource"
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
-	"github.com/fatih/color"
-	"github.com/urfave/cli"
 )
 
-func getGossConfig(c *cli.Context) GossConfig {
+type RuntimeConfig struct {
+	FormatOptions     []string
+	Vars              string
+	VarsInline        string
+	Spec              string
+	Sleep             time.Duration
+	RetryTimeout      time.Duration
+	Cache             time.Duration
+	Timeout           time.Duration
+	MaxConcurrent     int
+	NoColor           *bool
+	OutputFormat      string
+	PackageManager    string
+	Endpoint          string
+	ListenAddress     string
+	ExcludeAttributes []string
+	Insecure          bool
+	NoFollowRedirects bool
+	Server            string
+	Username          string
+	Password          string
+	Debug             bool
+}
+
+func getGossConfig(vars string, varsInline string, specFile string) (cfg *GossConfig, err error) {
 	// handle stdin
 	var fh *os.File
 	var path, source string
 	var gossConfig GossConfig
-	varsFile := c.GlobalString("vars")
-	varsInline := c.GlobalString("vars-inline")
-	currentTemplateFilter = NewTemplateFilter(varsFile, varsInline)
-	specFile := c.GlobalString("gossfile")
+	currentTemplateFilter = NewTemplateFilter(vars, varsInline)
+
 	if specFile == "-" {
 		source = "STDIN"
 		fh = os.Stdin
 		data, err := ioutil.ReadAll(fh)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			return nil, err
 		}
 		outStoreFormat = getStoreFormatFromData(data)
 		gossConfig = ReadJSONData(data, true)
@@ -46,50 +67,52 @@ func getGossConfig(c *cli.Context) GossConfig {
 	gossConfig = mergeJSONData(gossConfig, 0, path)
 
 	if len(gossConfig.Resources()) == 0 {
-		fmt.Printf("Error: found 0 tests, source: %v\n", source)
-		os.Exit(1)
+		return nil, fmt.Errorf("found 0 tests, source: %v", source)
 	}
-	return gossConfig
+
+	return &gossConfig, nil
 }
 
-func getOutputer(c *cli.Context) outputs.Outputer {
-	if c.Bool("no-color") {
+func getOutputer(c *bool, format string) outputs.Outputer {
+	if c != nil && *c {
 		color.NoColor = true
 	}
-	if c.Bool("color") {
+	if c != nil && !*c {
 		color.NoColor = false
 	}
-	return outputs.GetOutputer(c.String("format"))
+	return outputs.GetOutputer(format)
 }
 
-func Validate(c *cli.Context, startTime time.Time) {
-
+func Validate(c *RuntimeConfig, startTime time.Time) (code int, err error) {
 	outputConfig := util.OutputConfig{
-		FormatOptions: c.StringSlice("format-options"),
+		FormatOptions: c.FormatOptions,
 	}
 
-	gossConfig := getGossConfig(c)
-	sys := system.New(c)
-	outputer := getOutputer(c)
+	gossConfig, err := getGossConfig(c.Vars, c.VarsInline, c.Spec)
+	if err != nil {
+		return 1, err
+	}
 
-	sleep := c.Duration("sleep")
-	retryTimeout := c.Duration("retry-timeout")
+	sys := system.New(c.PackageManager)
+	outputer := getOutputer(c.NoColor, c.OutputFormat)
+
+	sleep := c.Sleep
+	retryTimeout := c.RetryTimeout
 	i := 1
 	for {
 		iStartTime := time.Now()
-		out := validate(sys, gossConfig, c.Int("max-concurrent"))
+		out := validate(sys, *gossConfig, c.MaxConcurrent)
 		exitCode := outputer.Output(os.Stdout, out, iStartTime, outputConfig)
 		if retryTimeout == 0 || exitCode == 0 {
-			os.Exit(exitCode)
+			return exitCode, nil
 		}
 		elapsed := time.Since(startTime)
 		if elapsed+sleep > retryTimeout {
-			color.Red("\nERROR: Timeout of %s reached before tests entered a passing state", retryTimeout)
-			os.Exit(3)
+			return 3, fmt.Errorf("timeout of %s reached before tests entered a passing state", retryTimeout)
 		}
 		color.Red("Retrying in %s (elapsed/timeout time: %.3fs/%s)\n\n\n", sleep, elapsed.Seconds(), retryTimeout)
 		// Reset cache
-		sys = system.New(c)
+		sys = system.New(c.PackageManager)
 		time.Sleep(sleep)
 		i++
 		fmt.Printf("Attempt #%d:\n", i)

--- a/validate.go
+++ b/validate.go
@@ -17,6 +17,9 @@ import (
 	"github.com/aelsabbahy/goss/util"
 )
 
+// RuntimeConfig is configuration for various aspects of the goss system and
+// is modeled on the cli context used in the cli tooling.  Mainly the translation
+// into this format is there to support making the system usable as a package
 type RuntimeConfig struct {
 	FormatOptions     []string
 	Vars              string


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this

### Description of change

This turns the cli.Context into a plain struct and passes the
struct, or fields from the struct, into all the various goss
internals. We then remove use of cli.Context everywhere
but in cmd/goss

This is a step one towards being able to use goss as a package
without requiring the CLI stuff

This is a one of several smaller PRs that I will send over the next
while towards resolving #544 