### PR TITLE
create helpers for using goss as a package

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -4,49 +4,52 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aelsabbahy/goss"
 	"github.com/aelsabbahy/goss/outputs"
+	"github.com/aelsabbahy/goss/system"
+	"github.com/aelsabbahy/goss/util"
+
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 
 var version string
 
-// converts a cli context into a goss RuntimeConfig
-func newRuntimeConfigFromCLI(c *cli.Context) *goss.RuntimeConfig {
-	bp := func(b bool) *bool { return &b }
-
-	cfg := &goss.RuntimeConfig{
-		FormatOptions:     c.StringSlice("format-options"),
-		Vars:              c.GlobalString("vars"),
-		VarsInline:        c.GlobalString("vars-inline"),
-		Spec:              c.GlobalString("gossfile"),
-		Sleep:             c.Duration("sleep"),
-		RetryTimeout:      c.Duration("retry-timeout"),
-		Timeout:           c.Duration("timeout"),
+// converts a cli context into a goss Config
+func newRuntimeConfigFromCLI(c *cli.Context) *util.Config {
+	cfg := &util.Config{
+		AllowInsecure:     c.Bool("insecure"),
+		AnnounceToCLI:     true,
 		Cache:             c.Duration("cache"),
+		Debug:             c.Bool("debug"),
+		Endpoint:          c.String("endpoint"),
+		FormatOptions:     c.StringSlice("format-options"),
+		IgnoreList:        c.GlobalStringSlice("exclude-attr"),
+		ListenAddress:     c.String("listen-addr"),
 		MaxConcurrent:     c.Int("max-concurrent"),
+		NoFollowRedirects: c.Bool("no-follow-redirects"),
 		OutputFormat:      c.String("format"),
 		PackageManager:    c.GlobalString("package"),
-		Endpoint:          c.String("endpoint"),
-		ListenAddress:     c.String("listen-addr"),
-		ExcludeAttributes: c.GlobalStringSlice("exclude-attr"),
-		Insecure:          c.Bool("insecure"),
-		NoFollowRedirects: c.Bool("no-follow-redirects"),
-		Server:            c.String("server"),
-		Username:          c.String("username"),
 		Password:          c.String("password"),
-		Debug:             c.Bool("debug"),
+		RetryTimeout:      c.Duration("retry-timeout"),
+		Server:            c.String("server"),
+		Sleep:             c.Duration("sleep"),
+		Spec:              c.GlobalString("gossfile"),
+		Timeout:           c.Duration("timeout"),
+		Username:          c.String("username"),
+		Vars:              c.GlobalString("vars"),
+		VarsInline:        c.GlobalString("vars-inline"),
 	}
 
 	if c.Bool("no-color") {
-		cfg.NoColor = bp(true)
+		util.WithNoColor()(cfg)
 	}
 
 	if c.Bool("color") {
-		cfg.NoColor = bp(false)
+		util.WithColor()(cfg)
 	}
 
 	return cfg
@@ -78,7 +81,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "package",
-			Usage: "Package type to use [rpm, deb, apk, pacman]",
+			Usage: fmt.Sprintf("Package type to use [%s]", strings.Join(system.SupportedPackageManagers(), ", ")),
 		},
 	}
 	app.Commands = []cli.Command{

--- a/goss_test.go
+++ b/goss_test.go
@@ -1,0 +1,84 @@
+package goss
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aelsabbahy/goss/outputs"
+	"github.com/aelsabbahy/goss/util"
+)
+
+func checkErr(t *testing.T, err error, format string, a ...interface{}) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+
+	t.Fatalf(format+": "+err.Error(), a...)
+}
+
+func TestUseAsPackage(t *testing.T) {
+	output := &bytes.Buffer{}
+
+	// temp spec file
+	fh, err := ioutil.TempFile("", "*.yaml")
+	checkErr(t, err, "temp file failed")
+	fh.Close()
+
+	// new config that doesnt spam output etc
+	cfg, err := util.NewConfig(util.WithFormatOptions("pretty"), util.WithResultWriter(output), util.WithSpecFile(fh.Name()))
+	checkErr(t, err, "new config failed")
+
+	// adds the os tmp dir to the goss spec file
+	err = AddResources(fh.Name(), "File", []string{os.TempDir()}, cfg)
+	checkErr(t, err, "could not add resource %q", os.TempDir())
+
+	// validate and sanity check, compare structured vs direct results etc
+	results, err := ValidateResults(cfg)
+	checkErr(t, err, "check failed")
+
+	found := 0
+	passed := 0
+	for rg := range results {
+		for _, r := range rg {
+			found++
+
+			if r.Successful {
+				passed++
+			}
+		}
+	}
+
+	code, err := Validate(cfg, time.Now())
+	checkErr(t, err, "check failed")
+	if code != 0 {
+		t.Fatalf("check failed, expected 0 got %d", code)
+	}
+
+	res := &outputs.StructuredOutput{}
+	err = json.Unmarshal(output.Bytes(), res)
+	checkErr(t, err, "unmarshal failed")
+
+	if res.Summary.Failed != 0 {
+		t.Fatalf("expected 0 failed, got %d", res.Summary.Failed)
+	}
+
+	if len(res.Results) != found {
+		t.Fatalf("expected %d results for %d", found, len(res.Results))
+	}
+
+	okcount := 0
+	for _, r := range res.Results {
+		if r.Successful {
+			okcount++
+		}
+	}
+
+	if okcount != passed {
+		t.Fatalf("expected %d passed but got %d", passed, okcount)
+	}
+}

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -109,6 +109,7 @@ func Outputers() []string {
 	return list
 }
 
+// FormatOptions are all the valid options formatters accept
 func FormatOptions() []string {
 	outputersMu.Lock()
 	defer outputersMu.Unlock()
@@ -122,6 +123,28 @@ func FormatOptions() []string {
 	}
 	sort.Strings(list)
 	return list
+}
+
+// IsValidFormat determines if f is a valid format name based on Outputers()
+func IsValidFormat(f string) bool {
+	for _, o := range Outputers() {
+		if o == f {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsValidFormatOption determines if o is a valid format option based on FormatOptions()
+func IsValidFormatOption(o string) bool {
+	for _, p := range FormatOptions() {
+		if p == o {
+			return true
+		}
+	}
+
+	return false
 }
 
 func GetOutputer(name string) (Outputer, error) {

--- a/outputs/outputs_test.go
+++ b/outputs/outputs_test.go
@@ -1,0 +1,25 @@
+package outputs
+
+import (
+	"testing"
+)
+
+func TestIsValidFormat(t *testing.T) {
+	if IsValidFormat("ne") {
+		t.Fatal("'ne' should not be a valid output format")
+	}
+
+	if !IsValidFormat("json") {
+		t.Fatal("'json' should be a valid output format")
+	}
+}
+
+func TestIsValidFormatOption(t *testing.T) {
+	if IsValidFormatOption("ne") {
+		t.Fatal("'ne' should not be a valid output format option")
+	}
+
+	if !IsValidFormatOption("verbose") {
+		t.Fatal("'verbose' should be a valid output format option")
+	}
+}

--- a/outputs/structured.go
+++ b/outputs/structured.go
@@ -1,0 +1,83 @@
+package outputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/aelsabbahy/goss/resource"
+	"github.com/aelsabbahy/goss/util"
+)
+
+// Structured is a output formatter that logs into a StructuredOutput structure
+type Structured struct{}
+
+// StructuredTestResult is an individual test result with additional human friendly summary
+type StructuredTestResult struct {
+	resource.TestResult
+	SummaryLine string `json:"summary-line"`
+}
+
+// StructureTestSummary holds summary information about a test run
+type StructureTestSummary struct {
+	TestCount     int           `json:"test-count"`
+	Failed        int           `json:"failed-count"`
+	TotalDuration time.Duration `json:"total-duration"`
+}
+
+// StructuredOutput is the full output structure for the structured output format
+type StructuredOutput struct {
+	Results     []StructuredTestResult `json:"results"`
+	Summary     StructureTestSummary   `json:"summary"`
+	SummaryLine string                 `json:"summary-line"`
+}
+
+// String represents human friendly representation of the test summary
+func (s *StructureTestSummary) String() string {
+	return fmt.Sprintf("Count: %d, Failed: %d, Duration: %.3fs", s.TestCount, s.Failed, s.TotalDuration.Seconds())
+}
+
+// Output processes output from tests into StructuredOutput written to w as a string
+func (r Structured) Output(w io.Writer, results <-chan []resource.TestResult, startTime time.Time, outConfig util.OutputConfig) (exitCode int) {
+	result := &StructuredOutput{
+		Results: []StructuredTestResult{},
+		Summary: StructureTestSummary{},
+	}
+
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			r := StructuredTestResult{
+				TestResult:  testResult,
+				SummaryLine: humanizeResult(testResult),
+			}
+
+			if !testResult.Successful {
+				result.Summary.Failed++
+			}
+
+			result.Summary.TestCount++
+
+			result.Results = append(result.Results, r)
+		}
+	}
+
+	result.Summary.TotalDuration = time.Since(startTime)
+	result.SummaryLine = result.Summary.String()
+
+	var j []byte
+
+	if util.IsValueInList("pretty", outConfig.FormatOptions) {
+		j, _ = json.MarshalIndent(result, "", "  ")
+	} else {
+		j, _ = json.Marshal(result)
+	}
+
+	fmt.Fprintln(w, string(j))
+
+	return 0
+}
+
+func init() {
+	RegisterOutputer("structured", &Structured{}, []string{})
+}

--- a/resource/addr.go
+++ b/resource/addr.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"time"
+
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
 )
@@ -27,7 +29,7 @@ func (a *Addr) Validate(sys *system.System) []TestResult {
 		a.Timeout = 500
 	}
 
-	sysAddr := sys.NewAddr(a.Address, sys, util.Config{Timeout: a.Timeout, LocalAddress: a.LocalAddress})
+	sysAddr := sys.NewAddr(a.Address, sys, util.Config{Timeout: time.Duration(a.Timeout) * time.Millisecond, LocalAddress: a.LocalAddress})
 
 	var results []TestResult
 	results = append(results, ValidateValue(a, "reachable", a.Reachable, sysAddr.Reachable, skip))
@@ -40,7 +42,7 @@ func NewAddr(sysAddr system.Addr, config util.Config) (*Addr, error) {
 	a := &Addr{
 		Address:      address,
 		Reachable:    reachable,
-		Timeout:      config.Timeout,
+		Timeout:      config.TimeOutMilliSeconds(),
 		LocalAddress: config.LocalAddress,
 	}
 	return a, err

--- a/resource/command.go
+++ b/resource/command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
@@ -44,7 +45,7 @@ func (c *Command) Validate(sys *system.System) []TestResult {
 	}
 
 	var results []TestResult
-	sysCommand := sys.NewCommand(c.GetExec(), sys, util.Config{Timeout: c.Timeout})
+	sysCommand := sys.NewCommand(c.GetExec(), sys, util.Config{Timeout: time.Duration(c.Timeout) * time.Millisecond})
 
 	cExitStatus := deprecateAtoI(c.ExitStatus, fmt.Sprintf("%s: command.exit-status", c.Command))
 	results = append(results, ValidateValue(c, "exit-status", cExitStatus, sysCommand.ExitStatus, skip))
@@ -65,7 +66,7 @@ func NewCommand(sysCommand system.Command, config util.Config) (*Command, error)
 		ExitStatus: exitStatus,
 		Stdout:     []string{},
 		Stderr:     []string{},
-		Timeout:    config.Timeout,
+		Timeout:    config.TimeOutMilliSeconds(),
 	}
 
 	if !contains(config.IgnoreList, "stdout") {

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"strings"
+	"time"
 
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
@@ -34,7 +35,7 @@ func (d *DNS) Validate(sys *system.System) []TestResult {
 		skip = true
 	}
 
-	sysDNS := sys.NewDNS(d.Host, sys, util.Config{Timeout: d.Timeout, Server: d.Server})
+	sysDNS := sys.NewDNS(d.Host, sys, util.Config{Timeout: time.Duration(d.Timeout) * time.Millisecond, Server: d.Server})
 
 	var results []TestResult
 	// Backwards copatibility hack for now
@@ -65,7 +66,7 @@ func NewDNS(sysDNS system.DNS, config util.Config) (*DNS, error) {
 	d := &DNS{
 		Host:       host,
 		Resolvable: resolvable,
-		Timeout:    config.Timeout,
+		Timeout:    config.TimeOutMilliSeconds(),
 		Server:     server,
 	}
 	if !contains(config.IgnoreList, "addrs") {

--- a/resource/http.go
+++ b/resource/http.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"time"
+
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
 )
@@ -35,7 +37,7 @@ func (u *HTTP) Validate(sys *system.System) []TestResult {
 	}
 	sysHTTP := sys.NewHTTP(u.HTTP, sys, util.Config{
 		AllowInsecure: u.AllowInsecure, NoFollowRedirects: u.NoFollowRedirects,
-		Timeout: u.Timeout, Username: u.Username, Password: u.Password,
+		Timeout: time.Duration(u.Timeout) * time.Millisecond, Username: u.Username, Password: u.Password,
 		RequestHeader: u.RequestHeader})
 	sysHTTP.SetAllowInsecure(u.AllowInsecure)
 	sysHTTP.SetNoFollowRedirects(u.NoFollowRedirects)
@@ -70,7 +72,7 @@ func NewHTTP(sysHTTP system.HTTP, config util.Config) (*HTTP, error) {
 		Body:              []string{},
 		AllowInsecure:     config.AllowInsecure,
 		NoFollowRedirects: config.NoFollowRedirects,
-		Timeout:           config.Timeout,
+		Timeout:           config.TimeOutMilliSeconds(),
 		Username:          config.Username,
 		Password:          config.Password,
 	}

--- a/serve.go
+++ b/serve.go
@@ -16,7 +16,7 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-func Serve(c *RuntimeConfig) {
+func Serve(c *util.Config) {
 	endpoint := c.Endpoint
 	color.NoColor = true
 	cache := cache.New(c.Cache, 30*time.Second)
@@ -56,7 +56,7 @@ type res struct {
 	b        bytes.Buffer
 }
 type healthHandler struct {
-	c             *RuntimeConfig
+	c             *util.Config
 	gossConfig    GossConfig
 	sys           *system.System
 	outputer      outputs.Outputer

--- a/store.go
+++ b/store.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/aelsabbahy/goss/resource"
+	"github.com/aelsabbahy/goss/util"
 )
 
 const (
@@ -158,8 +159,8 @@ func ReadJSONData(data []byte, detectFormat bool) (GossConfig, error) {
 	return *gossConfig, nil
 }
 
-// Reads json file recursively returning string
-func RenderJSON(c *RuntimeConfig) (string, error) {
+// RenderJSON reads json file recursively returning string
+func RenderJSON(c *util.Config) (string, error) {
 	var err error
 	debug = c.Debug
 	currentTemplateFilter, err = NewTemplateFilter(c.Vars, c.VarsInline)
@@ -263,14 +264,16 @@ func WriteJSON(filePath string, gossConfig GossConfig) error {
 	return nil
 }
 
-func resourcePrint(fileName string, res resource.ResourceRead) {
+func resourcePrint(fileName string, res resource.ResourceRead, announce bool) {
 	resMap := map[string]resource.ResourceRead{res.ID(): res}
 
 	oj, _ := marshal(resMap)
 	typ := reflect.TypeOf(res)
 	typs := strings.Split(typ.String(), ".")[1]
 
-	fmt.Printf("Adding %s to '%s':\n\n%s\n\n", typs, fileName, string(oj))
+	if announce {
+		fmt.Printf("Adding %s to '%s':\n\n%s\n\n", typs, fileName, string(oj))
+	}
 }
 
 func marshal(gossConfig interface{}) ([]byte, error) {

--- a/system/addr.go
+++ b/system/addr.go
@@ -25,7 +25,7 @@ func NewDefAddr(address string, system *System, config util.Config) Addr {
 	return &DefAddr{
 		address:      addr,
 		LocalAddress: config.LocalAddress,
-		Timeout:      config.Timeout,
+		Timeout:      config.TimeOutMilliSeconds(),
 	}
 }
 

--- a/system/command.go
+++ b/system/command.go
@@ -31,7 +31,7 @@ type DefCommand struct {
 func NewDefCommand(command string, system *System, config util.Config) Command {
 	return &DefCommand{
 		command: command,
-		Timeout: config.Timeout,
+		Timeout: config.TimeOutMilliSeconds(),
 	}
 }
 

--- a/system/dns.go
+++ b/system/dns.go
@@ -47,7 +47,7 @@ func NewDefDNS(host string, system *System, config util.Config) DNS {
 
 	return &DefDNS{
 		host:    h,
-		Timeout: config.Timeout,
+		Timeout: config.TimeOutMilliSeconds(),
 		server:  config.Server,
 		qtype:   t,
 	}

--- a/system/http.go
+++ b/system/http.go
@@ -45,7 +45,7 @@ func NewDefHTTP(httpStr string, system *System, config util.Config) HTTP {
 		allowInsecure:     config.AllowInsecure,
 		noFollowRedirects: config.NoFollowRedirects,
 		RequestHeader:     headers,
-		Timeout:           config.Timeout,
+		Timeout:           config.TimeOutMilliSeconds(),
 		Username:          config.Username,
 		Password:          config.Password,
 	}

--- a/system/package_test.go
+++ b/system/package_test.go
@@ -1,0 +1,15 @@
+package system
+
+import (
+	"testing"
+)
+
+func TestIsSupportedPackageManager(t *testing.T) {
+	if IsSupportedPackageManager("na") {
+		t.Fatal("na should not be a valid package manager")
+	}
+
+	if !IsSupportedPackageManager("rpm") {
+		t.Fatal("rpm should be a valid package manager")
+	}
+}

--- a/system/system.go
+++ b/system/system.go
@@ -114,6 +114,22 @@ func (sys *System) detectService() {
 	}
 }
 
+// SupportedPackageManagers is a list of package managers we support
+func SupportedPackageManagers() []string {
+	return []string{"apk", "dpkg", "pacman", "rpm"}
+}
+
+// IsSupportedPackageManager determines if p is a supported package manager
+func IsSupportedPackageManager(p string) bool {
+	for _, m := range SupportedPackageManagers() {
+		if m == p {
+			return true
+		}
+	}
+
+	return false
+}
+
 // DetectPackageManager attempts to detect whether or not the system is using
 // "dpkg", "rpm", "apk", or "pacman" package managers. It first attempts to
 // detect the distro. If that fails, it falls back to finding package manager

--- a/util/config.go
+++ b/util/config.go
@@ -2,22 +2,198 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/oleiade/reflections"
 )
 
+// ConfigOption manipulates Config
+type ConfigOption func(c *Config) error
+
+// Config is the runtime configuration for the goss system, the cli.Context gets
+// converted to this and it allows other packages to embed goss by creating this
+// structure and using it when adding, validating etc.
+//
+// NewConfig can be used to create this which will default to what the CLI assumes
+// and allow manipulation via ConfigOption functions
 type Config struct {
-	IgnoreList        []string
-	RequestHeader     []string
-	Timeout           int
 	AllowInsecure     bool
-	NoFollowRedirects bool
-	Server            string
-	Username          string
-	Password          string
+	AnnounceToCLI     bool
+	Cache             time.Duration
+	Debug             bool
+	Endpoint          string
+	FormatOptions     []string
+	IgnoreList        []string
+	ListenAddress     string
 	LocalAddress      string
+	MaxConcurrent     int
+	NoColor           *bool
+	NoFollowRedirects bool
+	OutputFormat      string
+	OutputWriter      io.Writer
+	PackageManager    string
+	Password          string
+	RequestHeader     []string
+	RetryTimeout      time.Duration
+	Server            string
+	Sleep             time.Duration
+	Spec              string
+	Timeout           time.Duration
+	Username          string
+	Vars              string
+	VarsInline        string
+}
+
+// TimeOutMilliSeconds is the timeout as milliseconds
+func (c *Config) TimeOutMilliSeconds() int {
+	return int(c.Timeout / time.Millisecond)
+}
+
+// NewConfig creates a default configuration modeled on the defaults the CLI sets, modified using opts
+func NewConfig(opts ...ConfigOption) (rc *Config, err error) {
+	rc = &Config{
+		AllowInsecure:     false,
+		AnnounceToCLI:     false,
+		Cache:             5 * time.Second,
+		Debug:             false,
+		Endpoint:          "/healthz",
+		FormatOptions:     []string{},
+		IgnoreList:        []string{},
+		ListenAddress:     ":8080",
+		LocalAddress:      "",
+		MaxConcurrent:     50,
+		NoColor:           nil,
+		NoFollowRedirects: false,
+		OutputFormat:      "structured", // most appropriate for package usage
+		PackageManager:    "",
+		Password:          "",
+		RequestHeader:     nil,
+		RetryTimeout:      0,
+		Server:            "",
+		Sleep:             time.Second,
+		Spec:              "",
+		Timeout:           0,
+		Username:          "",
+		Vars:              "",
+		VarsInline:        "",
+	}
+
+	// NewConfig() is likely to be used when embedding goss or using as a package
+	// so assuming no color seems like a sane departure from CLI defaults
+	WithNoColor()(rc)
+
+	for _, opt := range opts {
+		err = opt(rc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rc, nil
+}
+
+// WithSpecFile sets the path to the file holding spec contents
+func WithSpecFile(f string) ConfigOption {
+	return func(c *Config) error {
+		c.Spec = f
+		return nil
+	}
+}
+
+// WithOutputFormat is the formatter to use for output
+func WithOutputFormat(f string) ConfigOption {
+	return func(c *Config) error {
+		c.OutputFormat = f
+
+		return nil
+	}
+}
+
+// WithFormatOptions sets options used by the output format plugins, valid options are output.WithFormatOptions
+func WithFormatOptions(opts ...string) ConfigOption {
+	return func(c *Config) error {
+		for _, o := range opts {
+			c.FormatOptions = append(c.FormatOptions, o)
+		}
+
+		return nil
+	}
+}
+
+// WithResultWriter sets the writer to write output format to when validating
+func WithResultWriter(w io.Writer) ConfigOption {
+	return func(c *Config) error {
+		c.OutputWriter = w
+		return nil
+	}
+}
+
+// WithSleep sets the time to sleep between retries when WithRetryTimeout is set
+func WithSleep(d time.Duration) ConfigOption {
+	return func(c *Config) error {
+		c.Sleep = d
+		return nil
+	}
+}
+
+// WithRetryTimeout sets the maximum amount of time checks can be retried, it's runtime + WithSleep
+func WithRetryTimeout(d time.Duration) ConfigOption {
+	return func(c *Config) error {
+		c.RetryTimeout = d
+		return nil
+	}
+}
+
+// WithCache sets how long results may be cached for
+func WithCache(d time.Duration) ConfigOption {
+	return func(c *Config) error {
+		c.Cache = d
+		return nil
+	}
+}
+
+// WithMaxConcurrency is the maximum concurrent test that can be run
+func WithMaxConcurrency(mc int) ConfigOption {
+	return func(c *Config) error {
+		c.MaxConcurrent = mc
+		return nil
+	}
+}
+
+// WithNoColor disables colored output
+func WithNoColor() ConfigOption {
+	return func(c *Config) error {
+		c.NoColor = func(b bool) *bool { return &b }(true)
+		return nil
+	}
+}
+
+// WithColor enables colored output
+func WithColor() ConfigOption {
+	return func(c *Config) error {
+		c.NoColor = func(b bool) *bool { return &b }(false)
+		return nil
+	}
+}
+
+// WithPackageManager overrides the package manager to use
+func WithPackageManager(p string) ConfigOption {
+	return func(c *Config) error {
+		c.PackageManager = p
+
+		return nil
+	}
+}
+
+// WithDebug enables debug output
+func WithDebug() ConfigOption {
+	return func(c *Config) error {
+		c.Debug = true
+		return nil
+	}
 }
 
 type OutputConfig struct {
@@ -44,7 +220,7 @@ func ValidateSections(unmarshal func(interface{}) error, i interface{}, whitelis
 	for id, v := range toValidate {
 		for k, _ := range v {
 			if !whitelist[k] {
-				return fmt.Errorf("Invalid Attribute for %s:%s: %s", typs, id, k)
+				return fmt.Errorf("invalid Attribute for %s:%s: %s", typs, id, k)
 			}
 		}
 	}


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

### Description of change

This creates a way to make a goss Config programatically with defaults
suitable to use as a package.

This also merges the RuntimeConfig with Config as these had overlapping
uses, simplify some timeout handling and optionally surpress output when 
adding resources to a goss file
    
This stops short of overhauling all std output and instead just focus
on the things package users are likely to want to do - programatically
add resources and validate them.
    
Additionally a new output format 'structured' is added that has a
matching data type that defines it's output which makes it easier
to use the result sets from goss programatically, this is handy when
one wants to write tooling to process CI output from goss in go
