### PR TITLE
Fix invalid junit output for dcgoss

### DIFF
--- a/extras/dcgoss/dcgoss
+++ b/extras/dcgoss/dcgoss
@@ -21,7 +21,6 @@ cleanup() {
     [ "$DEBUG" ] || rm -rf "$tmp_dir"
     if [[ -n "$service" ]]; then
         info "Stopping container"
-        echo "Deleting $(docker rm -f "$service")"
         docker-compose stop > /dev/null
     fi
 }
@@ -39,11 +38,11 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        docker-compose run -d -T --name "$service" -v "$tmp_dir:/goss" "$service"
+        docker-compose run -d -T --name "$service" -v "$tmp_dir:/goss" --rm "$service"
         ;;
       cp)
         info "Creating docker container"
-        docker-compose run -d -T --name "$service" "$service"
+        docker-compose run -d -T --name "$service" --rm "$service"
         info "Copy goss files into container"
         docker cp "$tmp_dir/." "$service:/goss"
         ;;

--- a/extras/dcgoss/dcgoss
+++ b/extras/dcgoss/dcgoss
@@ -106,7 +106,7 @@ case "$1" in
             fi
         fi
         info "Container health"
-        if ! docker top "$service"; then
+        if [ "true" != "$(docker inspect -f '{{.State.Running}}' $service)" ]; then
             error "The container failed to start"
         fi
         info "Running Tests"

--- a/extras/dcgoss/dcgoss
+++ b/extras/dcgoss/dcgoss
@@ -42,7 +42,7 @@ run(){
         ;;
       cp)
         info "Creating docker container"
-        docker-compose run -d -T --name "$service" --rm "$service"
+        docker-compose run -d -T --name "$service" --rm "$service" > /dev/null
         info "Copy goss files into container"
         docker cp "$tmp_dir/." "$service:/goss"
         ;;


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)


### Description of change
extras/dcgoss/dcgoss was changed to:
- automatically remove started containers to make sure line "Deleting service" is not present in output
- suppress logging of docker-compose run command
- use docker inspect instead of docker top conform dcgoss

I created bug #549 for this issue which this PR should fix.