### PR TITLE
add Vars related configuration options

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -192,6 +193,41 @@ func WithPackageManager(p string) ConfigOption {
 func WithDebug() ConfigOption {
 	return func(c *Config) error {
 		c.Debug = true
+		return nil
+	}
+}
+
+// WithVarsFile is a json or yaml file containing variables to pass to the validator
+func WithVarsFile(file string) ConfigOption {
+	return func(c *Config) error {
+		c.Vars = file
+		return nil
+	}
+}
+
+// WithVarsData uses v as variables to pass to the Validator
+func WithVarsData(v interface{}) ConfigOption {
+	return func(c *Config) error {
+		jv, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+
+		c.VarsInline = string(jv)
+
+		return nil
+	}
+}
+
+// WithVarBytes is a yaml or json byte stream to use as variables passed to the Validator
+func WithVarsBytes(v []byte) ConfigOption {
+	return WithVarsString(string(v))
+}
+
+// WithVarString is a yaml or json string to use as variables passed to the Validator
+func WithVarsString(v string) ConfigOption {
+	return func(c *Config) error {
+		c.VarsInline = v
 		return nil
 	}
 }

--- a/util/config.go
+++ b/util/config.go
@@ -219,12 +219,12 @@ func WithVarsData(v interface{}) ConfigOption {
 	}
 }
 
-// WithVarBytes is a yaml or json byte stream to use as variables passed to the Validator
+// WithVarsBytes is a yaml or json byte stream to use as variables passed to the Validator
 func WithVarsBytes(v []byte) ConfigOption {
 	return WithVarsString(string(v))
 }
 
-// WithVarString is a yaml or json string to use as variables passed to the Validator
+// WithVarsString is a yaml or json string to use as variables passed to the Validator
 func WithVarsString(v string) ConfigOption {
 	return func(c *Config) error {
 		c.VarsInline = v

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestWithVarsBytes(t *testing.T) {
+	vs := `{"hello":"world"}`
+	c, err := NewConfig(WithVarsBytes([]byte(vs)))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if c.VarsInline != vs {
+		t.Fatalf("expected %q got %q", vs, c.VarsInline)
+	}
+}
+
+func TestWithVarsString(t *testing.T) {
+	vs := `{"hello":"world"}`
+	c, err := NewConfig(WithVarsString(vs))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if c.VarsInline != vs {
+		t.Fatalf("expected %q got %q", vs, c.VarsInline)
+	}
+}
+
+func TestWithVarsFile(t *testing.T) {
+	c, err := NewConfig(WithVarsFile("/nonexisting"))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if c.Vars != "/nonexisting" {
+		t.Fatalf("expected '/nonexisting' got %q", c.Vars)
+	}
+}
+
+func TestWithVarsData(t *testing.T) {
+	c, err := NewConfig(WithVarsData(map[string]string{"hello": "world"}))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if c.VarsInline != `{"hello":"world"}` {
+		t.Fatalf("expected %q got %q", `{"hello":"world"}`, c.VarsInline)
+	}
+}


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] documentation is changed or added (if applicable)

### Description of change

Follow up on previous PRs related to using goss as a package, this adds some helpers to configure the `Vars` behaviour