### PR TITLE
Code breaks when resource_list is generated from genny

### DIFF
--- a/resource/resource_list.go
+++ b/resource/resource_list.go
@@ -820,11 +820,7 @@ func (ret *PortMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 type ProcessMap map[string]*Process
 
 func (r ProcessMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Process, error) {
-	sysres, err := sys.NewProcess(sr, sys, config)
-	if err != nil {
-		return nil, err
-	}
-
+	sysres := sys.NewProcess(sr, sys, config)
 	res, err := NewProcess(sysres, config)
 	if err != nil {
 		return nil, err
@@ -837,24 +833,19 @@ func (r ProcessMap) AppendSysResource(sr string, sys *system.System, config util
 	return res, nil
 }
 
-func (r ProcessMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Process, system.Process, bool, error) {
-	sysres, err := sys.NewProcess(sr, sys, util.Config{})
-	if err != nil {
-		return nil, nil, false, err
-	}
-
+func (r ProcessMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Process, system.Process, bool) {
+	sysres := sys.NewProcess(sr, sys, util.Config{})
 	// FIXME: Do we want to be silent about errors?
 	res, _ := NewProcess(sysres, util.Config{})
 	if e, _ := sysres.Exists(); e != true {
-		return res, sysres, false, nil
+		return res, sysres, false
 	}
 	if old_res, ok := r[res.ID()]; ok {
 		res.Title = old_res.Title
 		res.Meta = old_res.Meta
 	}
 	r[res.ID()] = res
-
-	return res, sysres, true, nil
+	return res, sysres, true
 }
 
 func (ret *ProcessMap) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

This isn't really a PR. But it shows what got changed/broken with #546

This is just a commit of resource_list.go after running `make gen`.

@ripienaar The resouce_list.go is a generated file from resource_list_genny.go. It seems the PR linked above breaks development since it modified the file directly.

When you get a chance, can you please take a look at this since it will block any new resources from being added without the code being reverted.