### PR TITLE
DGOSS: Honor ${GOSS_FILE} when copying back from container to host

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -60,8 +60,8 @@ run(){
 get_docker_file() {
     if docker exec "$id" sh -c "test -e $1" > /dev/null;then
         mkdir -p "${GOSS_FILES_PATH}"
-        info "Copied '$1' from container to '${GOSS_FILES_PATH}'"
-        docker cp "$id:$1" "${GOSS_FILES_PATH}"
+        info "Copied '$1' from container to '${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}'"
+        docker cp "$id:$1" "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}"
     fi
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

While testing docker images with a custom `GOSS_FILE` setting, I found _dgoss_ was copying the modified file back to `goss.yaml` instead of `${GOSS_FILE}`.

Additionally the images I was testing were derived from a minimal Alpine linux image, which basically just has `/bin/sh` and `/bin/ash` as symlinks to busybox, so I also changed the shell spec so dgoss would run there and didn't encounter any POSIX compatibility issues.
