### PR TITLE
Add some bash helpers

### DIFF
--- a/ci/lib/log.sh
+++ b/ci/lib/log.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# comment out the unused-ones so far until they're needed. Otherwise it's a google search to find them again.
+NOCOLOUR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+ORANGE='\033[0;33m'
+# BLUE='\033[0;34m'
+# PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+# LIGHTGRAY='\033[0;37m'
+# DARKGRAY='\033[1;30m'
+LIGHTRED='\033[1;31m'
+LIGHTGREEN='\033[1;32m'
+# YELLOW='\033[1;33m'
+# LIGHTBLUE='\033[1;34m'
+# LIGHTPURPLE='\033[1;35m'
+LIGHTCYAN='\033[1;36m'
+# WHITE='\033[1;37m'
+
+is_ci() {
+  if [[ "${CI:-}" == "true" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+log_action() {
+  echo -e "${LIGHTGREEN}${*}${NOCOLOUR}" >&2
+}
+log_warn() {
+  echo -e "${ORANGE}${*}${NOCOLOUR}" >&2
+}
+log_error() {
+  echo -e "${LIGHTRED}${*}${NOCOLOUR}" >&2
+}
+log_debug() {
+  if [[ -n "${SCRIPT_LOG_LEVEL:-}" && "${SCRIPT_LOG_LEVEL}" == "debug" ]]; then
+    echo -e "${CYAN}${*}${NOCOLOUR}" >&2
+  fi
+}
+log_info() {
+  echo -e "${LIGHTCYAN}${*}${NOCOLOUR}" >&2
+}
+log_success() {
+  echo -e "${GREEN}${*}${NOCOLOUR}" >&2
+}
+log_fatal() {
+  echo -e "${RED}${*}${NOCOLOUR}" >&2
+  exit "${2:-"1"}"
+}

--- a/ci/lib/setup.sh
+++ b/ci/lib/setup.sh
@@ -1,0 +1,81 @@
+# configure cwd, vars and logging
+_setup_env() {
+  # -ET: propagate DEBUG/RETURN/ERR traps to functions and subshells
+  set -ET
+  # exit on unhandled error
+  set -o errexit
+  # exit on unset variable
+  set -o nounset
+  # pipefail: any failure in a pipe causes the pipe to fail
+  set -o pipefail
+
+  if [[ -n "${SCRIPT_DEBUG:-}" ]]; then
+    set -o xtrace
+    # http://www.skybert.net/bash/debugging-bash-scripts-on-the-command-line/
+    export PS4='# ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:-}() - [${SHLVL},${BASH_SUBSHELL},$?] '
+  fi
+  trap _err_trap ERR
+  # shellcheck disable=SC2034
+  # START_DIR is used elsewhere.
+  START_DIR="${PWD}"
+  export START_DIR
+  readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[2]}")" && pwd)"
+  readonly TOP_SCRIPT="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[2]}")"
+  if [[ -z "${SCRIPT_DIR}" ]]; then
+    echo >&2 -e "setup.sh:\tFailed to determine directory containing executed script."
+    return 1
+  fi
+  if ! cd "$(dirname "${BASH_SOURCE[0]}")/../.."; then
+    echo >&2 -e "setup.sh:\tFailed to cd to repository root"
+    return 1
+  fi
+  REPO_ROOT="$(pwd)"
+  export REPO_ROOT
+  if ! source ci/lib/log.sh; then
+    echo >&2 -e "setup.sh:\tFailed to source logging library"
+    return 1
+  fi
+}
+
+_err_trap() {
+  local err=$?
+  local cmd="${BASH_COMMAND:-}"
+  # Disable echoing all commands as this makes the traceback really hard to follow
+  set +x
+  if [[ -n "${SKIP_BASH_STACKTRACE:-}" ]]; then
+    log_debug "SKIP_BASH_STACKTRACE was set to something; silencing bash stack-trace."
+    exit "${err}"
+  fi
+
+  echo >&2 "panic: uncaught error" 1>&2
+  print_traceback 1
+  echo >&2 "${cmd} exited ${err}" 1>&2
+}
+
+_setup_constants() {
+  export EXIT_SUCCESS=0
+  export EXIT_INVALID_ARGUMENT=66
+  export EXIT_FAILED_TO_SOURCE=67
+  export EXIT_FAILED_TO_CD=68
+  export EXIT_FAILED_AFTER_RETRY=69
+  export EXIT_NOT_FOUND=70
+}
+
+# Print traceback of call stack, starting from the call location.
+# An optional argument can specify how many additional stack frames to skip.
+print_traceback() {
+  local skip=${1:-0}
+  local start=$((skip + 1))
+  local end=${#BASH_SOURCE[@]}
+  local curr=0
+  echo >&2 "Traceback (most recent call first):" 1>&2
+  for ((curr = start; curr < end; curr++)); do
+    local prev=$((curr - 1))
+    local func="${FUNCNAME[$curr]}"
+    local file="${BASH_SOURCE[$curr]}"
+    local line="${BASH_LINENO[$prev]}"
+    echo >&2 "  at ${file}:${line} in ${func}()" 1>&2
+  done
+}
+
+_setup_env || exit $?

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
+# shellcheck source=../ci/lib/setup.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../ci/lib/setup.sh" || exit 67
+# preserve current behaviour
+set -x
 
-set -xeu
+os="${1:?"Need OS as 1st arg. e.g. alpine arch centos7 precise wheezy"}"
+arch="${2:?"Need arch as 2nd arg. e.g. amd64 386"}"
 
-os=$1
-arch=$2
 vars_inline="{inline: bar, overwrite: bar}"
 
 seccomp_opts() {
@@ -14,6 +17,9 @@ seccomp_opts() {
     echo '--security-opt seccomp:unconfined'
   fi
 }
+
+# setup places us inside repo-root; this preserves current behaviour with least change.
+cd integration-tests
 
 cp "../release/goss-linux-$arch" "goss/$os/"
 # Run build if Dockerfile has changed but hasn't been pushed to dockerhub


### PR DESCRIPTION
This is aimed at making the integration-test script (and other scripts) easier to work with by giving them some consistent baseline behaviour

* automatic bash strict mode - sets options for -e -u and -o pipefail
* places execution inside repo-root, to avoid the reader needing to keep track of current working directory. Side benefit - scripts will be runnable from any directory
* adds some logging helpers
* adds a traceback function so it's possible to see which line an error came from

The intention of this PR:
* [x] Migrate each script to use this standard include
* [x] Replace `set -x` where found in existing scripts with 
    * `log_*` usage
    * `trap` usage that will record error output and place it centre stage

I may also refactor `integration-tests/test.sh` to separate the docker-environment-setup part from the run-tests part, so that's clearer. I don't know whether that would "fit" inside this PR; this PR is more about standardising behaviour inside scripts.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->