### PR TITLE
Remove 'release/' from checksum file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,12 @@ bench:
 	$(info INFO: Starting build $@)
 	go test -bench=.
 
-
-
 # Pattern rule for platform builds.
 # `subst` substitutes space for -, thus making an array
 # firstword, and word select indexes from said array.
 release/goss-%: $(GO_FILES)
 	CGO_ENABLED=0 GOOS=$(firstword $(subst -, ,$*)) GOARCH=$(word 2, $(subst -, ,$*)) go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o $@ $(exe)
-	sha256sum $@ | sed 's/release\/goss/goss/g' > $@.sha256
+	cd $(@D) && sha256sum $(@F) > $(@F).sha256sum
 
 release:
 	$(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ bench:
 # firstword, and word select indexes from said array.
 release/goss-%: $(GO_FILES)
 	CGO_ENABLED=0 GOOS=$(firstword $(subst -, ,$*)) GOARCH=$(word 2, $(subst -, ,$*)) go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o $@ $(exe)
-	sha256sum $@ > $@.sha256
+	sha256sum $@ | sed 's/release\/goss/goss/g' > $@.sha256
 
 release:
 	$(MAKE) clean


### PR DESCRIPTION
By having `<sha256> release/goss...` this prevents from automating the
check between the sha and the file, since sha256sum will try to find the
goss file within the `release` directory and usually, while automating goss
installation, we have them both in the same path and run the check from
this path, not from outside a release directory.

Relates to: #447 