### PR TITLE
Fix typo in manual installation instructions in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ chmod +rx /usr/local/bin/goss
 
 # (optional) dgoss docker wrapper (use 'master' for latest version)
 VERSION=v0.3.10
-curl -L "https://github.com/aelsabbahy/goss/releases/download/${VERSION}/dgoss" -o /usr/local/bin/goss
+curl -L "https://github.com/aelsabbahy/goss/releases/download/${VERSION}/dgoss" -o /usr/local/bin/dgoss
 chmod +rx /usr/local/bin/dgoss
 ```
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed

### Description of change

Fix typo making dgoss script overwriting goss binary in manual installation instructions