### PR TITLE
Validate checksums in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,16 +7,15 @@ LATEST_URL="https://github.com/aelsabbahy/goss/releases/latest"
 LATEST_EFFECTIVE=$(curl -s -L -o /dev/null ${LATEST_URL} -w '%{url_effective}')
 LATEST=${LATEST_EFFECTIVE##*/}
 
-DGOSS_VER=$GOSS_VER
 
 if [ -z "$GOSS_VER" ]; then
     GOSS_VER=${GOSS_VER:-$LATEST}
-    DGOSS_VER='master'
 fi
 if [ -z "$GOSS_VER" ]; then
     echo "ERROR: Could not automatically detect latest version, set GOSS_VER env var and re-run"
     exit 1
 fi
+
 GOSS_DST=${GOSS_DST:-/usr/local/bin}
 INSTALL_LOC="${GOSS_DST%/}/goss"
 DGOSS_INSTALL_LOC="${GOSS_DST%/}/dgoss"
@@ -35,14 +34,16 @@ url="https://github.com/aelsabbahy/goss/releases/download/$GOSS_VER/goss-linux-$
 
 echo "Downloading $url"
 curl -L "$url" -o "$INSTALL_LOC"
+curl -sSL "${url}.sha256" | sed "s#goss-linux-${arch}#${INSTALL_LOC}#" | sha256sum -c -
 chmod +rx "$INSTALL_LOC"
 echo "Goss $GOSS_VER has been installed to $INSTALL_LOC"
 echo "goss --version"
 "$INSTALL_LOC" --version
 
-dgoss_url="https://raw.githubusercontent.com/aelsabbahy/goss/$DGOSS_VER/extras/dgoss/dgoss"
+dgoss_url="https://github.com/aelsabbahy/goss/releases/download/$GOSS_VER/dgoss"
 echo "Downloading $dgoss_url"
 curl -L "$dgoss_url" -o "$DGOSS_INSTALL_LOC"
+curl -sSL "${dgoss_url}.sha256" | sed "s#dgoss#${DGOSS_INSTALL_LOC}#" | sha256sum -c -
 chmod +rx "$DGOSS_INSTALL_LOC"
-echo "dgoss $DGOSS_VER has been installed to $DGOSS_INSTALL_LOC"
+echo "dgoss $GOSS_VER has been installed to $DGOSS_INSTALL_LOC"
 }


### PR DESCRIPTION
There exist checksums for both `goss` and `dgoss` since version 0.3.11,
so those should also be used to validate the downloads.
This only works since 0.3.13 though, as the filename in the checksum
file changed.

Also use the same version for dgoss than for goss, instead of always
latest master for dgoss.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

_The checklist does not apply, since this is installer code_
