### PR TITLE
Make dgoss support gossfile directives

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -30,9 +30,7 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
-    [[ -e "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" "$tmp_dir/goss.yaml" && chmod 644 "$tmp_dir/goss.yaml"
-    [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir" && chmod 644 "$tmp_dir/goss_wait.yaml"
-    [[ ! -z "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir" && chmod 644 "$tmp_dir/${GOSS_VARS}"
+    cp -r "${GOSS_FILES_PATH}" "$tmp_dir/test_files"
 
     # Switch between mount or cp files strategy
     GOSS_FILES_STRATEGY=${GOSS_FILES_STRATEGY:="mount"}
@@ -82,12 +80,12 @@ case "$1" in
         if [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]]; then
             info "Found goss_wait.yaml, waiting for it to pass before running tests"
             if [[ -z "${GOSS_VARS}" ]]; then
-                if ! docker exec "$id" sh -c "/goss/goss -g /goss/goss_wait.yaml validate $GOSS_WAIT_OPTS"; then
+                if ! docker exec "$id" sh -c "/goss/goss -g /goss/test_files/goss_wait.yaml validate $GOSS_WAIT_OPTS"; then
                     docker logs $id >&2
                     error "goss_wait.yaml never passed"
                 fi
             else
-                if ! docker exec "$id" sh -c "/goss/goss -g /goss/goss_wait.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_WAIT_OPTS"; then
+                if ! docker exec "$id" sh -c "/goss/goss -g /goss/test_files/goss_wait.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_WAIT_OPTS"; then
                     docker logs $id >&2
                     error "goss_wait.yaml never passed"
                 fi
@@ -101,18 +99,18 @@ case "$1" in
         fi
         info "Running Tests"
         if [[ -z "${GOSS_VARS}" ]]; then
-            docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml validate $GOSS_OPTS"
+            docker exec "$id" sh -c "/goss/goss -g /goss/test_files/goss.yaml validate $GOSS_OPTS"
         else
-            docker exec "$id" sh -c "/goss/goss -g /goss/goss.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_OPTS"
+            docker exec "$id" sh -c "/goss/goss -g /goss/test_files/goss.yaml --vars='/goss/${GOSS_VARS}' validate $GOSS_OPTS"
         fi
         ;;
     edit)
         run "$@"
         info "Run goss add/autoadd to add resources"
         docker exec -it "$id" sh -c 'cd /goss; PATH="/goss:$PATH" exec sh'
-        get_docker_file "/goss/goss.yaml"
-        get_docker_file "/goss/goss_wait.yaml"
-        [[ ! -z "${GOSS_VARS}" ]] && get_docker_file "/goss/${GOSS_VARS}"
+        get_docker_file "/goss/test_files/goss.yaml"
+        get_docker_file "/goss/test_files/goss_wait.yaml"
+        [[ ! -z "${GOSS_VARS}" ]] && get_docker_file "/goss/test_files/${GOSS_VARS}"
         ;;
     *)
         error "$USAGE"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

`dgoss` does not support gossfile directives out of the box since it only copies `goss.yaml` and `goss-wait.yaml` into the container. It currently does _not_ copy in any of the other `.yaml` files that could be "imported" with the gossfile directive. 

We can fix this with very little changes by copying the entire directory's contents into the container so that all test files will be present in the container. This is useful to reduce code replication, since it allows test authors to logically partition test cases based on particular OSs/ tools/frameworks and then mix and match the smaller, compose-able test suites based on what each final image is supposed to contain. Besides, if `goss` allows it, `dgoss` should support it.