### PR TITLE
Add some test coverage to the goss serve command.

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -192,8 +192,7 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				fatalAlphaIfNeeded(c)
-				goss.Serve(newRuntimeConfigFromCLI(c))
-				return nil
+				return goss.Serve(newRuntimeConfigFromCLI(c))
 			},
 		},
 		{

--- a/outputs/structured.go
+++ b/outputs/structured.go
@@ -75,10 +75,6 @@ func (r Structured) Output(w io.Writer, results <-chan []resource.TestResult, st
 
 	fmt.Fprintln(w, string(j))
 
-	if result.Summary.Failed > 0 {
-		return 1
-	}
-
 	return 0
 }
 

--- a/outputs/structured.go
+++ b/outputs/structured.go
@@ -75,6 +75,10 @@ func (r Structured) Output(w io.Writer, results <-chan []resource.TestResult, st
 
 	fmt.Fprintln(w, string(j))
 
+	if result.Summary.Failed > 0 {
+		return 1
+	}
+
 	return 0
 }
 

--- a/serve.go
+++ b/serve.go
@@ -14,15 +14,15 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-func Serve(c *util.Config) {
+func Serve(c *util.Config) error {
 	endpoint := c.Endpoint
 	health, err := newHealthHandler(c)
 	if err != nil {
-		log.Fatalf("Error: %v", err)
+		return err
 	}
 	http.Handle(endpoint, health)
 	log.Printf("Starting to listen on: %s", c.ListenAddress)
-	log.Fatal(http.ListenAndServe(c.ListenAddress, nil))
+	return http.ListenAndServe(c.ListenAddress, nil)
 }
 
 func newHealthHandler(c *util.Config) (*healthHandler, error) {

--- a/serve.go
+++ b/serve.go
@@ -2,10 +2,8 @@ package goss
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -18,22 +16,30 @@ import (
 
 func Serve(c *util.Config) {
 	endpoint := c.Endpoint
+	health, err := newHealthHandler(c)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	http.Handle(endpoint, health)
+	log.Printf("Starting to listen on: %s", c.ListenAddress)
+	log.Fatal(http.ListenAndServe(c.ListenAddress, nil))
+}
+
+func newHealthHandler(c *util.Config) (*healthHandler, error) {
 	color.NoColor = true
 	cache := cache.New(c.Cache, 30*time.Second)
 
 	cfg, err := getGossConfig(c.Vars, c.VarsInline, c.Spec)
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
 	output, err := getOutputer(c.NoColor, c.OutputFormat)
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	health := healthHandler{
+	health := &healthHandler{
 		c:             c,
 		gossConfig:    *cfg,
 		sys:           system.New(c.PackageManager),
@@ -45,10 +51,7 @@ func Serve(c *util.Config) {
 	if c.OutputFormat == "json" {
 		health.contentType = "application/json"
 	}
-	http.Handle(endpoint, health)
-	listenAddr := c.ListenAddress
-	log.Printf("Starting to listen on: %s", listenAddr)
-	log.Fatal(http.ListenAndServe(c.ListenAddress, nil))
+	return health, nil
 }
 
 type res struct {
@@ -67,7 +70,6 @@ type healthHandler struct {
 }
 
 func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
 	outputConfig := util.OutputConfig{
 		FormatOptions: h.c.FormatOptions,
 	}

--- a/serve_test.go
+++ b/serve_test.go
@@ -36,6 +36,7 @@ func TestServe(t *testing.T) {
 
 			config, err := util.NewConfig(util.WithSpecFile(tc.specFile))
 			require.NoError(t, err)
+			t.Logf("Config: %v", config)
 
 			hh, err := newHealthHandler(config)
 			require.NoError(t, err)

--- a/serve_test.go
+++ b/serve_test.go
@@ -21,11 +21,11 @@ func TestServe(t *testing.T) {
 	}{
 		"passing": {
 			specFile:           filepath.Join("testdata", "passing.goss.yaml"),
-			expectedHTTPStatus: 200,
+			expectedHTTPStatus: http.StatusOK,
 		},
 		"failing": {
 			specFile:           filepath.Join("testdata", "failing.goss.yaml"),
-			expectedHTTPStatus: 503,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
 		},
 	}
 	for testName := range tests {

--- a/serve_test.go
+++ b/serve_test.go
@@ -1,0 +1,57 @@
+package goss
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/aelsabbahy/goss/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServe(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		specFile           string
+		expectedHTTPStatus int
+	}{
+		"passing": {
+			specFile:           filepath.Join("testdata", "passing.goss.yaml"),
+			expectedHTTPStatus: 200,
+		},
+		"failing": {
+			specFile:           filepath.Join("testdata", "failing.goss.yaml"),
+			expectedHTTPStatus: 503,
+		},
+	}
+	for testName := range tests {
+		tc := tests[testName]
+		t.Run(testName, func(t *testing.T) {
+			var logOutput bytes.Buffer
+			log.SetOutput(&logOutput)
+
+			config, err := util.NewConfig(util.WithSpecFile(tc.specFile))
+			require.NoError(t, err)
+
+			hh, err := newHealthHandler(config)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("GET", config.Endpoint, nil)
+			if err != nil {
+				require.NoError(t, err)
+			}
+			rr := httptest.NewRecorder()
+
+			handler := http.HandlerFunc(hh.ServeHTTP)
+
+			handler.ServeHTTP(rr, req)
+
+			t.Logf("testName %q log output:\n%s", testName, logOutput.String())
+			assert.Equal(t, tc.expectedHTTPStatus, rr.Code)
+		})
+	}
+}

--- a/serve_test.go
+++ b/serve_test.go
@@ -35,7 +35,7 @@ func TestServe(t *testing.T) {
 			expectedContentType: "application/json",
 		},
 		"failing-default-output": {
-			outputFormat:        "structured",
+			outputFormat:        "rspecish",
 			specFile:            filepath.Join("testdata", "failing.goss.yaml"),
 			expectedHTTPStatus:  http.StatusServiceUnavailable,
 			expectedContentType: "",

--- a/testdata/failing.goss.yaml
+++ b/testdata/failing.goss.yaml
@@ -1,0 +1,9 @@
+---
+command:
+  hello world:
+    exit-status: 1
+    exec: "echo hello world"
+    stdout:
+    - did not echo this
+    stderr: []
+    timeout: 10000

--- a/testdata/passing.goss.yaml
+++ b/testdata/passing.goss.yaml
@@ -1,0 +1,9 @@
+---
+command:
+  hello world:
+    exit-status: 0
+    exec: "echo hello world"
+    stdout:
+    - hello world
+    stderr: []
+    timeout: 10000


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
  - [x] 200 OK on passing tests
  - [x] 503 Service Unavailable on failing tests
  - [x] response content-type == application/json when json is chosen as the process-level output format
  - [x] caching works as expected
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)
  - n/a

### Description of change

I'm adding some test-coverage to the `goss serve` sub-command, to act as a safety net ahead of a change I'd like to make to it.

(I'd like to make the output format be possible to choose via the request's content-type header, because in the future I'd like to add a prometheus metrics endpoint in addition to a health-check endpoint. At the moment with output format being process-level rather than request-level, I'd need to run two goss serve processes to achieve that, and I'd prefer to avoid that)