### PR TITLE
Add blackbox tests for serve command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ alpha-test-%: release/goss-%
 	$(info INFO: Starting build $@)
 	./integration-tests/run-tests-alpha.sh $*
 
-test-serve-%: release/goss-%
+test-int-serve-%: release/goss-%
 	$(info INFO: Starting build $@)
 	./integration-tests/run-serve-tests.sh $*
 # shim to account for linux being not in alpha
-test-int-serve-linux-amd64: test-serve-alpha-linux-amd64
+test-int-serve-linux-amd64: test-int-serve-alpha-linux-amd64
 
 release/goss-%: $(GO_FILES)
 	./release-build.sh $*

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ bench:
 	$(info INFO: Starting build $@)
 	go test -bench=.
 
+alpha-test-%: release/goss-%
+	$(info INFO: Starting build $@)
+	./integration-tests/run-tests-alpha.sh $*
+
+test-serve-%: release/goss-%
+	$(info INFO: Starting build $@)
+	./integration-tests/run-serve-tests.sh $*
+
 release/goss-%: $(GO_FILES)
 	./release-build.sh $*
 

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,9 @@ push-images:
 	$(info INFO: Starting build $@)
 	development/push_images.sh
 
-test-int-64: centos7 wheezy precise alpine3 arch
+test-int-64: centos7 wheezy precise alpine3 arch test-int-serve-linux-amd64
 test-int-32: centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
-test-int-all: test-int-32 test-int-64 test-int-serve-$(CURRENT_OS)-amd64
+test-int-all: test-int-32 test-int-64
 
 centos7-32: build
 	$(info INFO: Starting build $@)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ pkgs = $(shell ./novendor.sh)
 cmd = goss
 GO111MODULE=on
 GO_FILES = $(shell git ls-files -- '*.go' ':!:*vendor*_test.go')
+CURRENT_OS = $(shell go env GOOS)
 
 .PHONY: all build install test release bench fmt lint vet test-int-all gen centos7 wheezy precise alpine3 arch test-int32 centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
 
@@ -43,6 +44,8 @@ alpha-test-%: release/goss-%
 test-serve-%: release/goss-%
 	$(info INFO: Starting build $@)
 	./integration-tests/run-serve-tests.sh $*
+# shim to account for linux being not in alpha
+test-int-serve-linux-amd64: test-serve-alpha-linux-amd64
 
 release/goss-%: $(GO_FILES)
 	./release-build.sh $*
@@ -71,7 +74,7 @@ push-images:
 
 test-int-64: centos7 wheezy precise alpine3 arch
 test-int-32: centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
-test-int-all: test-int-32 test-int-64
+test-int-all: test-int-32 test-int-64 test-int-serve-$(CURRENT_OS)-amd64
 
 centos7-32: build
 	$(info INFO: Starting build $@)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ pkgs = $(shell ./novendor.sh)
 cmd = goss
 GO111MODULE=on
 GO_FILES = $(shell git ls-files -- '*.go' ':!:*vendor*_test.go')
-CURRENT_OS = $(shell go env GOOS)
 
 .PHONY: all build install test release bench fmt lint vet test-int-all gen centos7 wheezy precise alpine3 arch test-int32 centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
 
@@ -72,8 +71,15 @@ push-images:
 	$(info INFO: Starting build $@)
 	development/push_images.sh
 
+test-darwin-all: test-short-all test-int-darwin-all
+# linux _does_ have the docker-style testing, but does _not_ currently have the same style integration tests darwin+windows do, _because_ of the docker-style testing.
+test-linux-all: test-short-all test-int-64 test-int-32
+test-windows-all: test-short-all test-int-windows-all
+
 test-int-64: centos7 wheezy precise alpine3 arch test-int-serve-linux-amd64
 test-int-32: centos7-32 wheezy-32 precise-32 alpine3-32 arch-32
+test-int-darwin-all: alpha-test-alpha-darwin-amd64 test-int-serve-alpha-darwin-amd64
+test-int-windows-all: alpha-test-alpha-windows-amd64 test-int-serve-alpha-windows-amd64
 test-int-all: test-int-32 test-int-64
 
 centos7-32: build

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,9 +5,11 @@ os_name="$(go env GOOS)"
 
 # darwin & windows do not support integration-testing approach via docker, so on those, just run fast tests.
 if [[ "${os_name}" == "darwin" || "${os_name}" == "windows" ]]; then
-  make test-short-all release/goss-alpha-${os_name}-amd64
-  integration-tests/run-tests-alpha.sh "${os_name}"
+  make "test-short-all" "release/goss-alpha-${os_name}-amd64"
+  make "alpha-test-alpha-${os_name}-amd64"
+  make "test-serve-alpha-${os_name}-amd64"
 else
   # linux runs all tests; unit and integration.
   make all
+  make "test-serve-${os_name}-amd64"
 fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,7 +5,7 @@ os_name="$(go env GOOS)"
 
 # darwin & windows do not support integration-testing approach via docker, so on those, just run fast tests.
 if [[ "${os_name}" == "darwin" || "${os_name}" == "windows" ]]; then
-  make "test-short-all" "test-serve-alpha-${os_name}-amd64" "release/goss-alpha-${os_name}-amd64"
+  make "test-short-all" "test-int-serve-alpha-${os_name}-amd64" "release/goss-alpha-${os_name}-amd64"
   make "alpha-test-alpha-${os_name}-amd64"
 else
   # linux runs all tests; unit and integration.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,7 +5,7 @@ os_name="$(go env GOOS)"
 
 # darwin & windows do not support integration-testing approach via docker, so on those, just run fast tests.
 if [[ "${os_name}" == "darwin" || "${os_name}" == "windows" ]]; then
-  make "test-short-all" "test-int-serve-${os_name}-amd64" "release/goss-alpha-${os_name}-amd64"
+  make "test-short-all" "test-serve-alpha-${os_name}-amd64" "release/goss-alpha-${os_name}-amd64"
   make "alpha-test-alpha-${os_name}-amd64"
 else
   # linux runs all tests; unit and integration.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 os_name="$(go env GOOS)"
 
-# darwin & windows do not support integration-testing approach via docker, so on those, just run fast tests.
+# darwin & windows do not support integration-testing approach via docker.
+# platform support is coupled to the travis CI environment, which is stable 'enough'.
 if [[ "${os_name}" == "darwin" || "${os_name}" == "windows" ]]; then
-  make "test-short-all" "test-int-serve-alpha-${os_name}-amd64" "release/goss-alpha-${os_name}-amd64"
-  make "alpha-test-alpha-${os_name}-amd64"
+  make "test-${os_name}-all"
 else
   # linux runs all tests; unit and integration.
   make all

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,7 +5,7 @@ os_name="$(go env GOOS)"
 
 # darwin & windows do not support integration-testing approach via docker, so on those, just run fast tests.
 if [[ "${os_name}" == "darwin" || "${os_name}" == "windows" ]]; then
-  make "test-short-all" "release/goss-alpha-${os_name}-amd64"
+  make "test-short-all" "test-int-serve-${os_name}-amd64" "release/goss-alpha-${os_name}-amd64"
   make "alpha-test-alpha-${os_name}-amd64"
 else
   # linux runs all tests; unit and integration.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -7,9 +7,7 @@ os_name="$(go env GOOS)"
 if [[ "${os_name}" == "darwin" || "${os_name}" == "windows" ]]; then
   make "test-short-all" "release/goss-alpha-${os_name}-amd64"
   make "alpha-test-alpha-${os_name}-amd64"
-  make "test-serve-alpha-${os_name}-amd64"
 else
   # linux runs all tests; unit and integration.
   make all
-  make "test-serve-${os_name}-amd64"
 fi

--- a/docs/platform-feature-parity.md
+++ b/docs/platform-feature-parity.md
@@ -131,43 +131,27 @@ You can find goss-files that are used to populate this matrix within `integratio
 
 ### `command` testing notes
 
-### Command: `add`
+Run all of the `darwin`/`windows` integration tests:
 
-#### Windows `add`
-
-```powershell
-.\release\goss-alpha-windows-amd64.exe add command 'echo hello'
-exec: "sh": executable file not found in %PATH%
+```bash
+make alpha-test-alpha-darwin-amd64
+make alpha-test-alpha-windows-amd64
 ```
 
-### Command: `autoadd`
-
-Not yet tested.
-
-### Command: `help`
-
-Not yet tested.
-
-### Command: `render`
-
-Not yet tested.
+The script finds all goss spec files within `integration-tests` then filters to just ones matching the passed OS-name, then runs `validate` against them.
 
 ### Command: `serve`
 
-macOS:
+This is a special-case test since it requires a persistent process, then to make the http request, then to tear down the process.
+
+#### macOS `serve`
 
 ```bash
-make build
-trap 'killall goss-alpha-darwin-amd64' EXIT
-release/goss-alpha-darwin-amd64 -g integration-tests/goss/goss-serve.yaml serve &
-curl http://localhost:9100/healthz | grep 'Count: 2, Failed: 0, Skipped: 0'
+make "test-serve-alpha-darwin-amd64"
 ```
 
-### Command: `validate`
-
-macOS:
+#### Windows `serve`
 
 ```bash
-make build
-release/goss-alpha-darwin-amd64 -g integration-tests/goss/goss-serve.yaml validate | grep 'Count: 2, Failed: 0, Skipped: 0'
+make "test-serve-alpha-windows-amd64"
 ```

--- a/integration-tests/run-serve-tests.sh
+++ b/integration-tests/run-serve-tests.sh
@@ -22,7 +22,7 @@ find_open_port() {
   # ss doesn't exist on Windows, so fall back on just choosing a random number inside the range (since netstat is _slow_).
   comm -23 \
     <(seq "${from}" "${to}" | sort) \
-    <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) |
+    <(ss -tan | tail -n +2 | awk '{print $4}' | cut -d':' -f2 | sort -u) |
     shuf -n "${how_many}" ||
     shuf -i "${from}-${to}" -n "${how_many}"
 }

--- a/integration-tests/run-serve-tests.sh
+++ b/integration-tests/run-serve-tests.sh
@@ -39,6 +39,7 @@ cleanup() {
       awk "/${binary_name}/,NF=1" |
       xargs kill
   fi
+  exit "${ret:-0}"
 }
 trap cleanup EXIT
 
@@ -60,4 +61,5 @@ if curl --silent "http://127.0.0.1:${open_port}/healthz" | grep 'Count: 2, Faile
   echo "passed"
 else
   echo "failed, exit code $?"
+  ret=1
 fi

--- a/integration-tests/run-serve-tests.sh
+++ b/integration-tests/run-serve-tests.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform_spec="${1:?Must supply name of release binary to build e.g. goss-linux-amd64}"
+
+# Split platform_spec into platform/arch segments
+IFS='- ' read -r -a segments <<< "${platform_spec}"
+
+os="${segments[0]}"
+arch="${segments[1]}"
+if [[ "${segments[0]}" == "alpha" ]]; then
+  os="${segments[1]}"
+  arch="${segments[2]}"
+fi
+
+find_open_port() {
+  local from="${1:?"Supply start of port range"}"
+  local to="${2:?"Supply end of port range"}"
+  local how_many="${3:-"1"}"
+
+  # Thanks to https://unix.stackexchange.com/questions/55913/whats-the-easiest-way-to-find-an-unused-local-port
+  # ss doesn't exist on Windows, so fall back on just choosing a random number inside the range (since netstat is _slow_).
+  comm -23 \
+    <(seq "${from}" "${to}" | sort) \
+    <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) |
+    shuf -n "${how_many}" ||
+    shuf -i "${from}-${to}" -n "${how_many}"
+}
+
+cleanup() {
+  # Can't use killall, doesn't exist on Windows. Also would interfere with concurrent runs.
+  binary_name="$(basename "${GOSS_BINARY}")"
+  ps -W |
+    awk "/${binary_name}/,NF=1" |
+    xargs kill
+}
+trap cleanup EXIT
+
+repo_root="$(git rev-parse --show-toplevel)"
+export GOSS_BINARY="${repo_root}/release/goss-${platform_spec}"
+echo "Using: '${GOSS_BINARY}', cwd: '$(pwd)'"
+
+export GOSS_USE_ALPHA=1
+open_port="$(find_open_port 1025 65335)"
+args=(
+  "-g=${repo_root}/integration-tests/goss/goss-serve.yaml"
+  "serve"
+  "--listen-addr=127.0.0.1:${open_port}"
+)
+echo -e "\nTesting \`${GOSS_BINARY} ${args[*]}\` ...\n"
+
+"${GOSS_BINARY}" "${args[@]}" &
+if curl --silent "http://127.0.0.1:${open_port}/healthz" | grep 'Count: 2, Failed: 0, Skipped: 0' ; then
+  echo "passed"
+else
+  echo "failed, exit code $?"
+fi

--- a/integration-tests/run-serve-tests.sh
+++ b/integration-tests/run-serve-tests.sh
@@ -28,11 +28,17 @@ find_open_port() {
 }
 
 cleanup() {
-  # Can't use killall, doesn't exist on Windows. Also would interfere with concurrent runs.
   binary_name="$(basename "${GOSS_BINARY}")"
-  ps -W |
-    awk "/${binary_name}/,NF=1" |
-    xargs kill
+  if [[ "${os}" == "darwin" ]]; then
+    killall "${binary_name}"
+  elif [[ "${os}" == "linux" ]]; then
+    killall "${binary_name}"
+  elif [[ "${os}" == "windows" ]]; then
+    # Can't use killall, doesn't exist on Windows. Also would interfere with concurrent runs.
+    ps -W |
+      awk "/${binary_name}/,NF=1" |
+      xargs kill
+  fi
 }
 trap cleanup EXIT
 

--- a/integration-tests/run-tests-alpha.sh
+++ b/integration-tests/run-tests-alpha.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# shellcheck source=../ci/lib/setup.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../ci/lib/setup.sh" || exit 67
 
 platform_spec="${1:?"Must supply name of release binary to build e.g. goss-linux-amd64"}"
 # Split platform_spec into platform/arch segments
@@ -14,7 +15,7 @@ fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 export GOSS_BINARY="${repo_root}/release/goss-${platform_spec}"
-echo "Using: '${GOSS_BINARY}', cwd: '$(pwd)', os: ${os}"
+log_info "Using: '${GOSS_BINARY}', cwd: '$(pwd)', os: ${os}"
 readarray -t goss_test_files < <(find integration-tests -type f -name "*.goss.yaml" | grep "${os}" | sort | uniq)
 
 export GOSS_USE_ALPHA=1
@@ -23,6 +24,6 @@ for file in "${goss_test_files[@]}"; do
     "-g=${file}"
     "validate"
   )
-  echo -e "\nTesting \`${GOSS_BINARY} ${args[*]}\` ...\n"
+  log_action -e "\nTesting \`${GOSS_BINARY} ${args[*]}\` ...\n"
   "${GOSS_BINARY}" "${args[@]}"
 done

--- a/integration-tests/run-tests-alpha.sh
+++ b/integration-tests/run-tests-alpha.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-os_name="${1:?Enter the OS name you want to run (windows|darwin)}"
+platform_spec="${1:?"Must supply name of release binary to build e.g. goss-linux-amd64"}"
+# Split platform_spec into platform/arch segments
+IFS='- ' read -r -a segments <<< "${platform_spec}"
+
+os="${segments[0]}"
+arch="${segments[1]}"
+if [[ "${segments[0]}" == "alpha" ]]; then
+  os="${segments[1]}"
+  arch="${segments[2]}"
+fi
 
 repo_root="$(git rev-parse --show-toplevel)"
-export GOSS_BINARY="${repo_root}/release/goss-alpha-${os_name}-amd64"
-echo "Using: '${GOSS_BINARY}', cwd: '$(pwd)'"
-readarray -t goss_test_files < <(find integration-tests -type f -name "*.goss.yaml" | grep "${os_name}" | sort | uniq)
+export GOSS_BINARY="${repo_root}/release/goss-${platform_spec}"
+echo "Using: '${GOSS_BINARY}', cwd: '$(pwd)', os: ${os}"
+readarray -t goss_test_files < <(find integration-tests -type f -name "*.goss.yaml" | grep "${os}" | sort | uniq)
 
 export GOSS_USE_ALPHA=1
 for file in "${goss_test_files[@]}"; do

--- a/release-build.sh
+++ b/release-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-platform_spec="${1:?Must supply name of release binary to build e.g. goss-linux-amd64}"
+platform_spec="${1:?"Must supply name of release binary to build e.g. goss-linux-amd64"}"
 version_stamp="${TRAVIS_TAG:-"0.0.0"}"
 
 # Split platform_spec into platform/arch segments


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

### Description of change

Added a cross-platform blackbox test for `goss serve` to give some outside in safety to #606 and incoming output-format-via-http-content-negotiation change.

Also integrated the alpha testing into the `Makefile` for coherence with the others. I'm _not_ a comfortable make-r, so please critique brutally if I've done things poorly?