### PR TITLE
Manage dependencies via github's dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+# https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    assignees:
+      - "aelsabbahy"
+    reviewers:
+      - "aelsabbahy"


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

### Description of change

Start to use github's dependabot to keep up to date with dependencies.

Periodically, it will look at the package manager file(s) (here, `go.mod`) and then see whether there are newer versions. If there are, it will open a beautifully generated PR containing links to release-notes, changelog, and diff between current version and the version it thinks to upgrade.

If CI is green, it's _possible_ to get the PR to auto-merge - that's obviously an appetite-for-risk/confidence-in-test-coverage question to answer.

Blog post announcing it - https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

I've linked to the documentation within the comment in the file itself.