### PR TITLE
Add support for native windows commands

### DIFF
--- a/integration-tests/goss/windows/commands/add.goss.yaml
+++ b/integration-tests/goss/windows/commands/add.goss.yaml
@@ -3,7 +3,7 @@
 command:
   "add addr 127.0.0.1":
     exit-status: 0
-    exec: release/goss-alpha-windows-amd64 --use-alpha=1 add addr 127.0.0.1
+    exec: release\goss-alpha-windows-amd64 --use-alpha=1 add addr 127.0.0.1
     stdout:
     - "timeout: 500"
     stderr: []

--- a/integration-tests/goss/windows/commands/autoadd.goss.yaml
+++ b/integration-tests/goss/windows/commands/autoadd.goss.yaml
@@ -2,7 +2,7 @@
 command:
   "autoadd Administrator":
     exit-status: 0
-    exec: "release/goss-alpha-windows-amd64 --use-alpha=1 autoadd Administrator"
+    exec: release\goss-alpha-windows-amd64 --use-alpha=1 autoadd Administrator
     stdout:
       - 'user:'
       - '  name: Administrator'

--- a/integration-tests/goss/windows/commands/help.goss.yaml
+++ b/integration-tests/goss/windows/commands/help.goss.yaml
@@ -2,7 +2,7 @@
 command:
   help:
     exit-status: 0
-    exec: "release/goss-alpha-windows-amd64 help"
+    exec: release\goss-alpha-windows-amd64 help
     stdout:
       - alpha
     stderr: []

--- a/integration-tests/goss/windows/commands/validate.goss.yaml
+++ b/integration-tests/goss/windows/commands/validate.goss.yaml
@@ -3,7 +3,7 @@
 command:
   "validate":
     exit-status: 0
-    exec: "release/goss-alpha-windows-amd64 --use-alpha=1 -g integration-tests/goss/windows/commands/validate-input.yaml validate"
+    exec: "release\\goss-alpha-windows-amd64 --use-alpha=1 -g integration-tests/goss/windows/commands/validate-input.yaml validate"
     stdout:
       - 'Count: 1'
       - 'Failed: 0'

--- a/system/command.go
+++ b/system/command.go
@@ -41,7 +41,7 @@ func (c *DefCommand) setup() error {
 	}
 	c.loaded = true
 
-	cmd := util.NewCommand("sh", "-c", c.command)
+	cmd := commandWrapper(c.command)
 	err := runCommand(cmd, c.Timeout)
 
 	// We don't care about ExitError since it's covered by status

--- a/system/command_posix.go
+++ b/system/command_posix.go
@@ -4,6 +4,8 @@ package system
 
 import "github.com/aelsabbahy/goss/util"
 
+const linuxShell string = "sh"
+
 func commandWrapper(cmd string) *util.Command {
-	return util.NewCommand("sh", "-c", cmd)
+	return util.NewCommand(linuxShell, "-c", cmd)
 }

--- a/system/command_posix.go
+++ b/system/command_posix.go
@@ -1,0 +1,9 @@
+// +build linux darwin !windows
+
+package system
+
+import "github.com/aelsabbahy/goss/util"
+
+func commandWrapper(cmd string) *util.Command {
+	return util.NewCommand("sh", "-c", cmd)
+}

--- a/system/command_posix_test.go
+++ b/system/command_posix_test.go
@@ -1,0 +1,18 @@
+// +build linux darwin !windows
+
+package system
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestCommandWrapper(t *testing.T) {
+	t.Parallel()
+
+	c := commandWrapper("echo hello world")
+	cmdPath, _ := exec.LookPath(linuxShell)
+	if c.Cmd.Path != cmdPath {
+		t.Errorf("Command not wrapped properly for OS. got %s, want: %s", c.Cmd.Path, cmdPath)
+	}
+}

--- a/system/command_windows.go
+++ b/system/command_windows.go
@@ -4,6 +4,8 @@ package system
 
 import "github.com/aelsabbahy/goss/util"
 
+const windowsShell string = "cmd"
+
 func commandWrapper(cmd string) *util.Command {
-	return util.NewCommand("cmd", "/c", cmd)
+	return util.NewCommand(windowsShell, "/c", cmd)
 }

--- a/system/command_windows.go
+++ b/system/command_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package system
+
+import "github.com/aelsabbahy/goss/util"
+
+func commandWrapper(cmd string) *util.Command {
+	return util.NewCommand("cmd", "/c", cmd)
+}

--- a/system/command_windows_test.go
+++ b/system/command_windows_test.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package system
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestCommandWrapper(t *testing.T) {
+	t.Parallel()
+
+	c := commandWrapper("echo hello world")
+	cmdPath, _ := exec.LookPath(windowsShell)
+	if c.Cmd.Path != cmdPath {
+		t.Errorf("Command not wrapped properly for Windows os. got %s, want: %s", c.Cmd.Path, cmdPath)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable) 
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
Fixes #632 

Uses Native tools to execute commands on the host machine which enables better support for windows.   This requires the paths for the command files to be in correct format with `\` instead of `/`.