### PR TITLE
Refactor serve toward caching results instead of rendered

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -54,10 +54,18 @@ func newHealthHandler(c *util.Config) (*healthHandler, error) {
 	return health, nil
 }
 
-type res struct {
-	body       bytes.Buffer
-	statusCode int
+type runResult struct {
+	body     bytes.Buffer
+	exitCode int
 }
+
+func (rr runResult) toHTTPStatus() int {
+	if rr.exitCode == 0 {
+		return http.StatusOK
+	}
+	return http.StatusServiceUnavailable
+}
+
 type healthHandler struct {
 	c             *util.Config
 	gossConfig    GossConfig
@@ -80,20 +88,23 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("%v: requesting health probe", r.RemoteAddr)
 	resp := h.processAndEnsureCached(negotiatedContentType, outputer)
 	w.Header().Set(http.CanonicalHeaderKey("Content-Type"), negotiatedContentType)
-	w.WriteHeader(resp.statusCode)
+	statusCode := resp.toHTTPStatus()
+	w.WriteHeader(statusCode)
 	logBody := ""
-	if resp.statusCode != http.StatusOK {
+	if statusCode != http.StatusOK {
+		// if there are any test failures, log all the details since machine state is volatile
+		// and highly subject to intermittent failures compared to unit-tests.
 		logBody = " - " + resp.body.String()
 	}
 	resp.body.WriteTo(w)
-	log.Printf("%v: status %d%s", r.RemoteAddr, resp.statusCode, logBody)
+	log.Printf("%v: status %d%s", r.RemoteAddr, statusCode, logBody)
 }
 
-func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outputer outputs.Outputer) res {
-	cacheKey := fmt.Sprintf("res:%s", negotiatedContentType)
+func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outputer outputs.Outputer) runResult {
+	cacheKey := fmt.Sprintf("runResult:%s", negotiatedContentType)
 	tmp, found := h.cache.Get(cacheKey)
 	if found {
-		return tmp.(res)
+		return tmp.(runResult)
 	}
 
 	h.gossMu.Lock()
@@ -101,33 +112,20 @@ func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outp
 	tmp, found = h.cache.Get(cacheKey)
 	if found {
 		log.Printf("Returning cached[%s].", cacheKey)
-		return tmp.(res)
+		return tmp.(runResult)
 	}
 
 	log.Printf("Stale cache[%s], running tests", cacheKey)
-	resp := h.runValidate(outputer)
-	h.cache.SetDefault(cacheKey, resp)
-	return resp
+	rr := h.runValidate(outputer)
+	h.cache.SetDefault(cacheKey, rr)
+	return rr
 }
 
-func (h healthHandler) runValidate(outputer outputs.Outputer) res {
+func (h healthHandler) runValidate(outputer outputs.Outputer) runResult {
 	h.sys = system.New(h.c.PackageManager)
 	iStartTime := time.Now()
-	out := validate(h.sys, h.gossConfig, h.maxConcurrent)
-	var b bytes.Buffer
-	outputConfig := util.OutputConfig{
-		FormatOptions: h.c.FormatOptions,
-	}
-	exitCode := outputer.Output(&b, out, iStartTime, outputConfig)
-	resp := res{
-		body: b,
-	}
-	if exitCode == 0 {
-		resp.statusCode = http.StatusOK
-	} else {
-		resp.statusCode = http.StatusServiceUnavailable
-	}
-	return resp
+	validateResult := validate(h.sys, h.gossConfig, h.maxConcurrent)
+	return h.renderBody(validateResult, outputer, iStartTime)
 }
 
 const (
@@ -168,11 +166,15 @@ func (h healthHandler) responseContentType(outputName string) string {
 	return fmt.Sprintf("%s%s", mediaTypePrefix, outputName)
 }
 
-func (h healthHandler) renderBody(results <-chan []resource.TestResult, outputer outputs.Outputer) (int, bytes.Buffer) {
+func (h healthHandler) renderBody(results <-chan []resource.TestResult, outputer outputs.Outputer, startTime time.Time) runResult {
 	outputConfig := util.OutputConfig{
 		FormatOptions: h.c.FormatOptions,
 	}
 	var b bytes.Buffer
-	exitCode := outputer.Output(&b, results, time.Now(), outputConfig)
-	return exitCode, b
+	exitCode := outputer.Output(&b, results, startTime, outputConfig)
+	rr := runResult{
+		body:     b,
+		exitCode: exitCode,
+	}
+	return rr
 }


### PR DESCRIPTION
Aims at #612. Incomplete.

Step 1: Handle `http` parts completely within the handler func.
Step 2: Rename `res` -> `runResult` for clarity

@aelsabbahy I'm stopping at this point because I think going deeper is going to require a breaking change.

I'll also say up-front that I'm not so familiar with go channels and concurrency, so perhaps I'm ignorant of where a non-breaking-change might be made; happy to take advice there. 

Or perhaps I've misunderstood the nested loops in the outputs themselves, and this is how one unwraps the chan array to actual values? Either way, I'm a little lost and would appreciate a steer.

Here's my train of thought
* For `serve` to be able to cache the test-results, I need to "unwrap" the chan []resource.TestResult to a []resource.TestResult and cache that.
* To do that, I need to add another return value to `outputs.Outputer` so it becomes `(int, []resource.TestResult)`
* I'd then be able to throw away the bytes buffer during the "`serve` needs to cache data" use-case, since now I have an array of TestResult I can...
* ... feed to a new func on each Outputer that takes data rather than chan, and renders that

My intuition says to separate the test-running from the output-generation (i.e. outputs.Outputer#Output doesn't shove data into a buffer, but instead returns results for something else to do that part) - but I'm not really sure how best to achieve _how_

All the above aside, I think this single commit could probably be merged as-is, since I think it makes the code slightly clearer - what do you think? (If you agree, please lets discuss within the issue itself, so the next iteration can understand the context I've now gained any anything we talk about here. In that case, the comment above should get copied/quoted over there to avoid fragmenting)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
