### PR TITLE
Expose service ports when running dcgoos

### DIFF
--- a/extras/dcgoss/dcgoss
+++ b/extras/dcgoss/dcgoss
@@ -38,11 +38,11 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        docker-compose run -d -T --name "$service" -v "$tmp_dir:/goss" --rm "$service"
+        docker-compose run --service-ports -d -T --name "$service" -v "$tmp_dir:/goss" --rm "$service"
         ;;
       cp)
         info "Creating docker container"
-        docker-compose run -d -T --name "$service" --rm "$service" > /dev/null
+        docker-compose run --service-ports -d -T --name "$service" --rm "$service" > /dev/null
         info "Copy goss files into container"
         docker cp "$tmp_dir/." "$service:/goss"
         ;;

--- a/extras/dcgoss/dcgoss
+++ b/extras/dcgoss/dcgoss
@@ -38,11 +38,11 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        docker-compose run --service-ports -d -T --name "$service" -v "$tmp_dir:/goss" --rm "$service"
+        docker-compose run -d -T --name "$service" -v "$tmp_dir:/goss" --rm "$service" "${@:2}"
         ;;
       cp)
         info "Creating docker container"
-        docker-compose run --service-ports -d -T --name "$service" --rm "$service" > /dev/null
+        docker-compose run -d -T --name "$service" --rm "$service" "${@:2}" > /dev/null
         info "Copy goss files into container"
         docker cp "$tmp_dir/." "$service:/goss"
         ;;


### PR DESCRIPTION
I'd like [gliderlabs/registrator ](https://github.com/gliderlabs/registrator) to pick up services from my `docker-compose.yml` file and register the service in consul. Then it is required to have ports exposed.