### PR TITLE
Fix for invalid PR #662

### DIFF
--- a/extras/dcgoss/dcgoss
+++ b/extras/dcgoss/dcgoss
@@ -38,11 +38,11 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        docker-compose run -d -T --name "$service" -v "$tmp_dir:/goss" --rm "$service" "${@:2}"
+        docker-compose run -d -T --name "$service" -v "$tmp_dir:/goss" --rm "${@:2}"
         ;;
       cp)
         info "Creating docker container"
-        docker-compose run -d -T --name "$service" --rm "$service" "${@:2}" > /dev/null
+        docker-compose run -d -T --name "$service" --rm "${@:2}" > /dev/null
         info "Copy goss files into container"
         docker cp "$tmp_dir/." "$service:/goss"
         ;;


### PR DESCRIPTION
The service name should be left out from the command as it is included in `"${@:2}"`. Sorry for the invalid PR before.