### PR TITLE
Fix windows cmd quoting

### DIFF
--- a/integration-tests/goss/windows/tests/command.goss.yaml
+++ b/integration-tests/goss/windows/tests/command.goss.yaml
@@ -14,3 +14,17 @@ command:
     - 0
     stderr: []
     timeout: 10000
+  wrap a powershell with quotes - expect 0 because travis does not restrict anonymous logins:
+    exec: powershell -noprofile -noninteractive -command "(get-itemproperty -path 'HKLM:/SYSTEM/CurrentControlSet/Control/Lsa/').restrictanonymous"
+    exit-status: 0
+    stdout:
+    - 0
+    stderr: []
+    timeout: 10000
+  powershell with quotes:
+    exec: powershell /c "(echo '{"b":2, "a":1}' | ConvertFrom-json).a"
+    exit-status: 0
+    stdout:
+    - "1"
+    stderr: []
+    timeout: 10000

--- a/system/command_windows.go
+++ b/system/command_windows.go
@@ -7,5 +7,5 @@ import "github.com/aelsabbahy/goss/util"
 const windowsShell string = "cmd"
 
 func commandWrapper(cmd string) *util.Command {
-	return util.NewCommand(windowsShell, "/c", cmd)
+	return util.NewCommandForWindowsCmd(windowsShell, "/c", cmd)
 }

--- a/system/command_windows_test.go
+++ b/system/command_windows_test.go
@@ -15,4 +15,12 @@ func TestCommandWrapper(t *testing.T) {
 	if c.Cmd.Path != cmdPath {
 		t.Errorf("Command not wrapped properly for Windows os. got %s, want: %s", c.Cmd.Path, cmdPath)
 	}
+
+	if c.Cmd.SysProcAttr.CmdLine != "/c echo hello world" {
+		t.Errorf("Command not wrapped properly for Windows cmd.exe. got %s, want: %s", c.Cmd.SysProcAttr.CmdLine, "/c echo hello world")
+	}
+
+	if len(c.Cmd.Args) != 1 {
+		t.Errorf("Args length should be blank. got: %d, want: %d", len(c.Cmd.Args), 1)
+	}
 }

--- a/util/command.go
+++ b/util/command.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+
 	//"fmt"
 	"os/exec"
 	"syscall"
@@ -20,6 +21,7 @@ func NewCommand(name string, arg ...string) *Command {
 	command := new(Command)
 	command.name = name
 	command.Cmd = exec.Command(name, arg...)
+
 	return command
 }
 

--- a/util/command_windows.go
+++ b/util/command_windows.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package util
+
+import (
+	"strings"
+
+	//"fmt"
+	"os/exec"
+	"syscall"
+)
+
+func NewCommandForWindowsCmd(name string, arg ...string) *Command {
+	//fmt.Println(arg)
+	command := new(Command)
+	command.name = name
+
+	// cmd.exe has a unique unquoting algorithm
+	// provide the full command line in SysProcAttr.CmdLine, leaving Args empty.
+	// more information: https://golang.org/pkg/os/exec/#Command
+	command.Cmd = exec.Command(name)
+	command.Cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    false,
+		CmdLine:       strings.Join(arg, " "),
+		CreationFlags: 0,
+	}
+
+	return command
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make test-all` (UNIX) passes. CI will also test this
- [X] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
In #651 we found that quoting was not working properly.  The following would fail:

```
 wrap a powershell with quotes - expect 0 because travis does not restrict anonymous logins:
    exec: powershell -noprofile -noninteractive -command "(get-itemproperty -path 'HKLM:/SYSTEM/CurrentControlSet/Control/Lsa/').restrictanonymous"
```

Not using quotes worked for that use case but for more complex scenarios quoting is necessary. Digging into it a bit more I found https://golang.org/pkg/os/exec/#Command:

> On Windows, processes receive the whole command line as a single string and do their own parsing. Command combines and quotes Args into a command line string with an algorithm compatible with applications using CommandLineToArgvW (which is the most common way). Notable exceptions are msiexec.exe and cmd.exe (and thus, all batch files), which have a different unquoting algorithm. In these or other similar cases, you can do the quoting yourself and provide the full command line in SysProcAttr.CmdLine, leaving Args empty.   

This PR uses the second approach.

cc: @petemounce 