### PR TITLE
Rename binaries to strip '-alpha'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,16 @@ deploy:
   token:
     secure: hEHCC4EN7iHz7pIWKRn2qw22NTqUxnuBp59wfAlLBtV26j5rHMzSu8mlxkJInusDUGLJiNLrZPRWN0mzOdIXalbUeLhlX7EflJgEj6Q0MchUR69LzCAp0KMIFL1Sfq0v81VgujRLUUy5utxDL8Er4tZknn2PpXAMzpO+ozjNRDhhSEM4iMXfY3bcOIMnx6XRgCjFCb036wlBgOfdgv5fwm2PP638DTKar4W6ZZbqCQByhJ5RyL3BMDPTT0moA/tYbG+FA6p6Rme1OcBkMnpsiJZoB3u8gxsNiEJ43/C2RcULW/18qqp2UVD5FipSDYP7GQ5ugKCbgpWXb0Ctl8o4hv1UsNl0XoyJhAt0PRp6vqnyy6LWB2FzX30Xj/vGIhO/IfiJvspHxpatTk7Esjr46K4u9ao/x63LX6F6yI1ZTfbzt2MhRYRjwh4ORNfqhysuzXChftX1S9hj6s6gO0/zqoOsRK/PK8DProbUn4bxrGOBzi16P0GEk4agWWUm74Pis9qCThXNW8MXEV936KvE1wb1RxTACYvFBtO2IM5eQ26t2Y7mGJd7FJup9LR4oUtUTSbYo5P2Sal6xntBKH5P4nwEtM+TtHoeSCKQ3X5i1VSdvAH7soEAly6rP5d5wwPhqqx9mgUPYO/3ulvxLJOYHamrbj6nlHDXnCEoj1ZMxX4=
   file:
-    - release/goss-alpha-darwin-amd64
-    - release/goss-alpha-darwin-amd64.sha256
+    - release/goss-darwin-amd64
+    - release/goss-darwin-amd64.sha256
     - release/goss-linux-amd64
     - release/goss-linux-amd64.sha256
     - release/goss-linux-386
     - release/goss-linux-386.sha256
     - release/goss-linux-arm
     - release/goss-linux-arm.sha256
-    - release/goss-alpha-windows-amd64.exe
-    - release/goss-alpha-windows-amd64.exe.sha256
+    - release/goss-windows-amd64.exe
+    - release/goss-windows-amd64.exe.sha256
     - extras/dgoss/dgoss
     - extras/dgoss/dgoss.sha256
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,13 @@ bench:
 	$(info INFO: Starting build $@)
 	go test -bench=.
 
-alpha-test-%: release/goss-%
+test-int-validate-%: release/goss-%
 	$(info INFO: Starting build $@)
-	./integration-tests/run-tests-alpha.sh $*
+	./integration-tests/run-validate-tests.sh $*
 
 test-int-serve-%: release/goss-%
 	$(info INFO: Starting build $@)
 	./integration-tests/run-serve-tests.sh $*
-# shim to account for linux being not in alpha
-test-int-serve-linux-amd64: test-int-serve-alpha-linux-amd64
 
 release/goss-%: $(GO_FILES)
 	./release-build.sh $*
@@ -53,7 +51,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-alpha-darwin-amd64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-alpha-windows-amd64
+build: release/goss-darwin-amd64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-windows-amd64
 
 gen:
 	$(info INFO: Starting build $@)
@@ -78,8 +76,8 @@ test-windows-all: test-short-all test-int-windows-all
 
 test-int-64: centos7 wheezy trusty alpine3 arch test-int-serve-linux-amd64
 test-int-32: centos7-32 wheezy-32 trusty-32 alpine3-32 arch-32
-test-int-darwin-all: alpha-test-alpha-darwin-amd64 test-int-serve-alpha-darwin-amd64
-test-int-windows-all: alpha-test-alpha-windows-amd64 test-int-serve-alpha-windows-amd64
+test-int-darwin-all: test-int-validate-darwin-amd64 test-int-serve-darwin-amd64
+test-int-windows-all: test-int-validate-windows-amd64 test-int-serve-windows-amd64
 test-int-all: test-int-32 test-int-64
 
 centos7-32: build

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -408,14 +408,14 @@ func addAlphaFlagIfNeeded(app *cli.App) {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		app.Flags = append(app.Flags, cli.StringFlag{
 			Name:   "use-alpha",
-			Usage:  fmt.Sprintf("goss is alpha-quality. Set to 1 to use anyway."),
+			Usage:  fmt.Sprintf("goss on macOS/Windows is alpha-quality. Set to 1 to use anyway."),
 			EnvVar: "GOSS_USE_ALPHA",
 			Value:  "0",
 		})
 	}
 }
 
-const msgFormat string = `WARNING: goss for this platform (%q) is alpha-quality, work-in-progress, and not yet exercised within continuous integration.
+const msgFormat string = `WARNING: goss for this platform (%q) is alpha-quality, work-in-progress and community-supported.
 
 You should not expect everything to work. Treat linux as the canonical behaviour to expect.
 

--- a/docs/platform-feature-parity.md
+++ b/docs/platform-feature-parity.md
@@ -141,8 +141,8 @@ You can find goss-files that are used to populate this matrix within `integratio
 Run all of the `darwin`/`windows` integration tests:
 
 ```bash
-make test-darwin-amd64
-make test-windows-amd64
+make test-int-validate-darwin-amd64
+make test-int-validate-windows-amd64
 ```
 
 The script finds all goss spec files within `integration-tests` then filters to just ones matching the passed OS-name, then runs `validate` against them.
@@ -154,11 +154,11 @@ This is a special-case test since it requires a persistent process, then to make
 #### macOS `serve`
 
 ```bash
-make "test-serve-darwin-amd64"
+make "test-int-serve-darwin-amd64"
 ```
 
 #### Windows `serve`
 
 ```bash
-make "test-serve-windows-amd64"
+make "test-int-serve-windows-amd64"
 ```

--- a/docs/platform-feature-parity.md
+++ b/docs/platform-feature-parity.md
@@ -4,7 +4,8 @@ macOS and Windows binaries are new and considered alpha-quality. Some functional
 
 To clearly signal that, goss emits a log message on every invocation saying so, linking here, then exits with a clear error.
 
-To try out the alpha functionality, you must do one of
+To try out the alpha functionality, you must do one of:
+
 * pass `--use-alpha=1` to the root command - e.g. `goss --use-alpha=1 validate`.
 * set an environment variable `GOSS_USE_ALPHA=1`.
 
@@ -140,8 +141,8 @@ You can find goss-files that are used to populate this matrix within `integratio
 Run all of the `darwin`/`windows` integration tests:
 
 ```bash
-make alpha-test-alpha-darwin-amd64
-make alpha-test-alpha-windows-amd64
+make test-darwin-amd64
+make test-windows-amd64
 ```
 
 The script finds all goss spec files within `integration-tests` then filters to just ones matching the passed OS-name, then runs `validate` against them.
@@ -153,11 +154,11 @@ This is a special-case test since it requires a persistent process, then to make
 #### macOS `serve`
 
 ```bash
-make "test-serve-alpha-darwin-amd64"
+make "test-serve-darwin-amd64"
 ```
 
 #### Windows `serve`
 
 ```bash
-make "test-serve-alpha-windows-amd64"
+make "test-serve-windows-amd64"
 ```

--- a/integration-tests/goss/darwin/commands/add.goss.yaml
+++ b/integration-tests/goss/darwin/commands/add.goss.yaml
@@ -3,7 +3,7 @@
 command:
   "add addr 127.0.0.1":
     exit-status: 0
-    exec: release/goss-alpha-darwin-amd64 --use-alpha=1 add addr 127.0.0.1
+    exec: release/goss-darwin-amd64 --use-alpha=1 add addr 127.0.0.1
     stdout:
     - "timeout: 500"
     stderr: []

--- a/integration-tests/goss/darwin/commands/autoadd.goss.yaml
+++ b/integration-tests/goss/darwin/commands/autoadd.goss.yaml
@@ -2,7 +2,7 @@
 command:
   "autoadd /Users/travis":
     exit-status: 0
-    exec: "release/goss-alpha-darwin-amd64 --use-alpha=1 autoadd /Users/travis"
+    exec: "release/goss-darwin-amd64 --use-alpha=1 autoadd /Users/travis"
     stdout:
       - 'file:'
       - '  exists: true'

--- a/integration-tests/goss/darwin/commands/help.goss.yaml
+++ b/integration-tests/goss/darwin/commands/help.goss.yaml
@@ -2,7 +2,7 @@
 command:
   help:
     exit-status: 0
-    exec: "release/goss-alpha-darwin-amd64 help"
+    exec: "release/goss-darwin-amd64 help"
     stdout:
       - alpha
     stderr: []

--- a/integration-tests/goss/darwin/commands/validate.goss.yaml
+++ b/integration-tests/goss/darwin/commands/validate.goss.yaml
@@ -3,7 +3,7 @@
 command:
   "validate":
     exit-status: 0
-    exec: "release/goss-alpha-darwin-amd64 --use-alpha=1 -g integration-tests/goss/darwin/commands/validate-input.yaml validate"
+    exec: "release/goss-darwin-amd64 --use-alpha=1 -g integration-tests/goss/darwin/commands/validate-input.yaml validate"
     stdout:
       - 'Count: 1'
       - 'Failed: 0'

--- a/integration-tests/goss/windows/commands/add.goss.yaml
+++ b/integration-tests/goss/windows/commands/add.goss.yaml
@@ -3,7 +3,7 @@
 command:
   "add addr 127.0.0.1":
     exit-status: 0
-    exec: release\goss-alpha-windows-amd64 --use-alpha=1 add addr 127.0.0.1
+    exec: release\goss-windows-amd64 --use-alpha=1 add addr 127.0.0.1
     stdout:
     - "timeout: 500"
     stderr: []

--- a/integration-tests/goss/windows/commands/autoadd.goss.yaml
+++ b/integration-tests/goss/windows/commands/autoadd.goss.yaml
@@ -2,7 +2,7 @@
 command:
   "autoadd Administrator":
     exit-status: 0
-    exec: release\goss-alpha-windows-amd64 --use-alpha=1 autoadd Administrator
+    exec: release\goss-windows-amd64 --use-alpha=1 autoadd Administrator
     stdout:
       - 'user:'
       - '  name: Administrator'

--- a/integration-tests/goss/windows/commands/help.goss.yaml
+++ b/integration-tests/goss/windows/commands/help.goss.yaml
@@ -2,7 +2,7 @@
 command:
   help:
     exit-status: 0
-    exec: release\goss-alpha-windows-amd64 help
+    exec: release\goss-windows-amd64 help
     stdout:
       - alpha
     stderr: []

--- a/integration-tests/goss/windows/commands/validate.goss.yaml
+++ b/integration-tests/goss/windows/commands/validate.goss.yaml
@@ -3,7 +3,7 @@
 command:
   "validate":
     exit-status: 0
-    exec: "release\\goss-alpha-windows-amd64 --use-alpha=1 -g integration-tests/goss/windows/commands/validate-input.yaml validate"
+    exec: "release\\goss-windows-amd64 --use-alpha=1 -g integration-tests/goss/windows/commands/validate-input.yaml validate"
     stdout:
       - 'Count: 1'
       - 'Failed: 0'

--- a/integration-tests/run-serve-tests.sh
+++ b/integration-tests/run-serve-tests.sh
@@ -9,10 +9,6 @@ IFS='- ' read -r -a segments <<< "${platform_spec}"
 
 os="${segments[0]}"
 arch="${segments[1]}"
-if [[ "${segments[0]}" == "alpha" ]]; then
-  os="${segments[1]}"
-  arch="${segments[2]}"
-fi
 
 find_open_port() {
   local startAt="${1:?"Supply start of port range"}"

--- a/integration-tests/run-validate-tests.sh
+++ b/integration-tests/run-validate-tests.sh
@@ -9,6 +9,15 @@ IFS='- ' read -r -a segments <<< "${platform_spec}"
 os="${segments[0]}"
 arch="${segments[1]}"
 
+if [[ "${os}" == "linux" ]]; then
+  echo "OS is ${os}. This script is not for running tests on the different flavours of linux."
+  echo "Linux is exercised via the integration-tests/test.sh currently, because linux can be"
+  echo "verified via docker containers; macOS and Windows cannot."
+  echo "This script is for macOS and Windows, and runs tests that are expected to pass on"
+  echo "Travis-CI provided images, running nakedly (no containerisation) on the hosts there."
+  exit 1
+fi
+
 repo_root="$(git rev-parse --show-toplevel)"
 export GOSS_BINARY="${repo_root}/release/goss-${platform_spec}"
 log_info "Using: '${GOSS_BINARY}', cwd: '$(pwd)', os: ${os}"

--- a/integration-tests/run-validate-tests.sh
+++ b/integration-tests/run-validate-tests.sh
@@ -8,10 +8,6 @@ IFS='- ' read -r -a segments <<< "${platform_spec}"
 
 os="${segments[0]}"
 arch="${segments[1]}"
-if [[ "${segments[0]}" == "alpha" ]]; then
-  os="${segments[1]}"
-  arch="${segments[2]}"
-fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 export GOSS_BINARY="${repo_root}/release/goss-${platform_spec}"

--- a/release-build.sh
+++ b/release-build.sh
@@ -9,10 +9,6 @@ IFS='- ' read -r -a segments <<< "${platform_spec}"
 
 os="${segments[0]}"
 arch="${segments[1]}"
-if [[ "${segments[0]}" == "alpha" ]]; then
-  os="${segments[1]}"
-  arch="${segments[2]}"
-fi
 
 output_dir="release/"
 output_fname="goss-${platform_spec}"


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change

As discussed in https://github.com/aelsabbahy/goss/pull/663#issuecomment-743127235; strip the -alpha naming, keep the messaging, keep the --use-alpha flag and env-var.

We're reasonably comfortable with the current situation - nothing seems to be horrendously broken in terms of the ported functionality as exercised by the added macOS & Windows integration tests, and based on Improbable's use (that I am intimately familiar with).

This change allows people to remove edge-cases from their installation, yet retains the clearly-set expectations of support being community-driven.

Fixes #651. Continues #663.

**Note:** this is aimed at `v4`.