### PR TITLE
add MacOS and Windows support to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,18 @@ else
     arch="386"
 fi
 
-url="https://github.com/aelsabbahy/goss/releases/download/$GOSS_VER/goss-linux-$arch"
+os=""
+url=""
+if [ "$(uname -s)" = "Linux" ]; then
+    os="linux"
+    url="https://github.com/aelsabbahy/goss/releases/download/$GOSS_VER/goss-linux-$arch"
+elif [ "$(uname -s)" = "Darwin" ]; then
+    os="darwin"
+    url="https://github.com/aelsabbahy/goss/releases/download/$GOSS_VER/goss-alpha-$os-$arch"
+else
+    os="windows"
+    url="https://github.com/aelsabbahy/goss/releases/download/$GOSS_VER/goss-alpha-$os-$arch.exe"
+fi
 
 echo "Downloading $url"
 curl -L "$url" -o "$INSTALL_LOC"


### PR DESCRIPTION
I wanted to be able to install goss with the install.sh script, but it always installed the Linux binary. So I have updated the script to install goss also and MacOS and Windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
