### PR TITLE
Add FreeBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-alpha-darwin-amd64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-alpha-windows-amd64
+build: release/goss-alpha-darwin-amd64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-alpha-windows-amd64 release/goss-freebsd-amd64
 
 gen:
 	$(info INFO: Starting build $@)

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Package:
 * deb
 * Alpine apk
 * pacman
+* FreeBSD pkg
 
 Service:
 

--- a/docs/platform-feature-parity.md
+++ b/docs/platform-feature-parity.md
@@ -1,6 +1,6 @@
 # Platform feature-parity
 
-macOS and Windows binaries are new and considered alpha-quality. Some functionality may be missing, some may be broken. (Enhancements and bug-reports welcome, please see [#551: Multi-OS support](https://github.com/aelsabbahy/goss/issues/551)).
+macOS, Windows and FreeBSD binaries are new and considered alpha-quality. Some functionality may be missing, some may be broken. (Enhancements and bug-reports welcome, please see [#551: Multi-OS support](https://github.com/aelsabbahy/goss/issues/551)).
 
 To clearly signal that, goss emits a log message on every invocation saying so, linking here, then exits with a clear error.
 
@@ -36,104 +36,104 @@ You can find goss-files that are used to populate this matrix within `integratio
 
 ## Matrix - tests/assertions
 
-| Test                | `linux` | `macOS` | `Windows` |
-|:--------------------|---------|---------|-----------|
-| **addr**            | x       | wp-pt   | wp-pt     |
-| reachable           | x       | wp-pt   | wp-pt     |
-| local-address       | x       |         | wp-pt     |
-| timeout             | x       | w-nt    | w-nt      |
-|                     | x       |         |           |
-| **command**         | x       | wp-pt   | wp-pt     |
-| exit-status         | x       | wp-pt   | wp-pt     |
-| stdout              | x       | wp-pt   | wp-pt     |
-| stderr              | x       | w-nt    | w-nt      |
-| timeout             | x       | w-nt    | w-nt      |
-|                     | x       |         |           |
-| **dns**             | x       | wp-pt   | wp-pt     |
-| resolvable          | x       | wp-pt   | wp-pt     |
-| addrs               | x       | wp-pt   | wp-pt     |
-| server              | x       |         | wp-pt     |
-| timeout             | x       | w-nt    | wp-pt     |
-|                     |         |         |           |
-| **file**            | x       | wp-pt   | wp-pt     |
-| exists              | x       | wp-pt   | w         |
-| mode                | x       | wp-pt   | n/a       |
-| size                | x       | wp-pt   | wp-pt     |
-| owner               | x       | broken  | n/a       |
-| group               | x       | broken  | n/a       |
-| filetype            | x       | wp-pt   | wp-pt     |
-| contains            | x       | wp-pt   | wp-pt     |
-| md5                 | x       | wp-pt   | wp-pt     |
-| sha256              | x       | wp-pt   | wp-pt     |
-| linked-to           | x       |         |           |
-|                     | x       |         |           |
-| **gossfile**        | x       | wp-pt   | wp-pt     |
-|                     | x       |         |           |
-| **group**           | x       | ni      | ni        |
-| exists              | x       | ni      | ni        |
-| gid                 | x       | ni      | n/a       |
-|                     | x       |         |           |
-| **http**            | x       | wp-pt   | wp-pt     |
-| status              | x       | wp-pt   | wp-pt     |
-| allow-insecure      | x       | wp-pt   | wp-pt     |
-| no-follow-redirects | x       | wp-pt   | wp-pt     |
-| timeout             | x       | w-nt    | wp-pt     |
-| request-headers     | x       | wp-pt   | wp-pt     |
-| headers             | x       | wp-pt   | wp-pt     |
-| body                | x       | wp-pt   | wp-pt     |
-| username            | x       | w-nt    | wp-pt     |
-| password            | x       | w-nt    | wp-pt     |
-|                     |         |         |           |
-| **interface**       | x       | ni      | ni        |
-| exists              | x       | ni      | ni        |
-| addrs               | x       | ni      | ni        |
-| mtu                 | x       | ni      | ni        |
-|                     | x       |         |           |
-| **kernel-param**    | x       | n/a     | n/a       |
-| value               | x       | n/a     | n/a       |
-|                     | x       |         |           |
-| **mount**           | x       | ni      | ni        |
-| exists              | x       | ni      | ni        |
-| opts                | x       | ni      | n/a       |
-| source              | x       | ni      | n/a       |
-| filesystem          | x       | ni      | ni        |
-| usage               | x       | ni      | ni        |
-|                     | x       |         |           |
-| **matching**        | x       |         |           |
-|                     | x       |         |           |
-| **package**         | x       | ni      | ni        |
-| installed           | x       | ni      | ni        |
-| versions            | x       | ni      | ni        |
-|                     | x       |         |           |
-| **port**            | x       | ni      | ni        |
-| listening           | x       | ni      | ni        |
-| ip                  | x       |         |           |
-|                     | x       |         |           |
-| **process**         | x       | wp-pt   | wp-pt     |
-| running             | x       | wp-pt   | wp-pt     |
-|                     | x       |         |           |
-| **service**         | x       | ni      | ni        |
-| enabled             | x       | ni      | ni        |
-| running             | x       | ni      | ni        |
-|                     | x       |         |           |
-| **user**            | x       | ni      | ni        |
-| exists              | x       | ni      | ni        |
-| uid                 | x       | ni      | n/a       |
-| gid                 | x       | ni      | n/a       |
-| groups              | x       | ni      | ni        |
-| home                | x       | ni      | ni        |
-| shell               | x       | ni      | ni        |
+| Test                | `linux` | `macOS` | `Windows` | `FreeBSD` |
+|---------------------|---------|---------|-----------|-----------|
+| **addr**            | x       | wp-pt   | wp-pt     | wp-pt     |
+| reachable           | x       | wp-pt   | wp-pt     | w         |
+| local-address       | x       |         | wp-pt     |           |
+| timeout             | x       | w-nt    | w-nt      | w         |
+|                     | x       |         |           |           |
+| **command**         | x       | wp-pt   | wp-pt     | w         |
+| exit-status         | x       | wp-pt   | wp-pt     | w         |
+| stdout              | x       | wp-pt   | wp-pt     | w         |
+| stderr              | x       | w-nt    | w-nt      | w         |
+| timeout             | x       | w-nt    | w-nt      | w         |
+|                     | x       |         |           |           |
+| **dns**             | x       | wp-pt   | wp-pt     | w         |
+| resolvable          | x       | wp-pt   | wp-pt     | w         |
+| addrs               | x       | wp-pt   | wp-pt     | w         |
+| server              | x       |         | wp-pt     | w         |
+| timeout             | x       | w-nt    | wp-pt     | w         |
+|                     |         |         |           |           |
+| **file**            | x       | wp-pt   | wp-pt     | wp-pt     |
+| exists              | x       | wp-pt   | w         | w         |
+| mode                | x       | wp-pt   | n/a       | w         |
+| size                | x       | wp-pt   | wp-pt     | w         |
+| owner               | x       | broken  | n/a       | ni        |
+| group               | x       | broken  | n/a       | ni        |
+| filetype            | x       | wp-pt   | wp-pt     | w         |
+| contains            | x       | wp-pt   | wp-pt     |           |
+| md5                 | x       | wp-pt   | wp-pt     | w         |
+| sha256              | x       | wp-pt   | wp-pt     | w         |
+| linked-to           | x       |         |           |           |
+|                     | x       |         |           |           |
+| **gossfile**        | x       | wp-pt   | wp-pt     | w         |
+|                     | x       |         |           |           |
+| **group**           | x       | ni      | ni        | w         |
+| exists              | x       | ni      | ni        | w         |
+| gid                 | x       | ni      | n/a       | w         |
+|                     | x       |         |           |           |
+| **http**            | x       | wp-pt   | wp-pt     | w         |
+| status              | x       | wp-pt   | wp-pt     | w         |
+| allow-insecure      | x       | wp-pt   | wp-pt     | w         |
+| no-follow-redirects | x       | wp-pt   | wp-pt     | w         |
+| timeout             | x       | w-nt    | wp-pt     | w         |
+| request-headers     | x       | wp-pt   | wp-pt     | w         |
+| headers             | x       | wp-pt   | wp-pt     | w         |
+| body                | x       | wp-pt   | wp-pt     | w         |
+| username            | x       | w-nt    | wp-pt     | w         |
+| password            | x       | w-nt    | wp-pt     | w         |
+|                     |         |         |           |           |
+| **interface**       | x       | ni      | ni        | w         |
+| exists              | x       | ni      | ni        | w         |
+| addrs               | x       | ni      | ni        | w         |
+| mtu                 | x       | ni      | ni        | w         |
+|                     | x       |         |           |           |
+| **kernel-param**    | x       | n/a     | n/a       | n/a       |
+| value               | x       | n/a     | n/a       | n/a       |
+|                     | x       |         |           |           |
+| **mount**           | x       | ni      | ni        | n/a       |
+| exists              | x       | ni      | ni        | n/a       |
+| opts                | x       | ni      | n/a       | n/a       |
+| source              | x       | ni      | n/a       | n/a       |
+| filesystem          | x       | ni      | ni        | n/a       |
+| usage               | x       | ni      | ni        | n/a       |
+|                     | x       |         |           |           |
+| **matching**        | x       |         |           | w         |
+|                     | x       |         |           |           |
+| **package**         | x       | ni      | ni        | w         |
+| installed           | x       | ni      | ni        | w         |
+| versions            | x       | ni      | ni        | w         |
+|                     | x       |         |           |           |
+| **port**            | x       | ni      | ni        | n/a       |
+| listening           | x       | ni      | ni        | n/a       |
+| ip                  | x       |         |           | n/a       |
+|                     | x       |         |           |           |
+| **process**         | x       | wp-pt   | wp-pt     | w         |
+| running             | x       | wp-pt   | wp-pt     | w         |
+|                     | x       |         |           |           |
+| **service**         | x       | ni      | ni        | w         |
+| enabled             | x       | ni      | ni        | w         |
+| running             | x       | ni      | ni        | w         |
+|                     | x       |         |           |           |
+| **user**            | x       | ni      | ni        | w         |
+| exists              | x       | ni      | ni        | w         |
+| uid                 | x       | ni      | n/a       | w         |
+| gid                 | x       | ni      | n/a       | w         |
+| groups              | x       | ni      | ni        | w         |
+| home                | x       | ni      | ni        | w         |
+| shell               | x       | ni      | ni        | w         |
 
 ## Matrix - `command`s
 
-| Test       | `linux` | `macOS` | `Windows` |
-|:-----------|---------|---------|-----------|
-| `add`      | x       |         | wp-pt     |
-| `autoadd`  | x       |         |           |
-| `help`     | x       |         | wp-pt     |
-| `render`   | x       |         |           |
-| `serve`    | x       | w-nt    |           |
-| `validate` | x       | w-nt    | wp-pt     |
+| Test       | `linux` | `macOS` | `Windows` | `FreeBSD` |
+|------------|---------|---------|-----------|-----------|
+| `add`      | x       |         | wp-pt     | w         |
+| `autoadd`  | x       |         |           | wp-pt     |
+| `help`     | x       |         | wp-pt     | w         |
+| `render`   | x       |         |           | w         |
+| `serve`    | x       | w-nt    |           | w         |
+| `validate` | x       | w-nt    | wp-pt     | w         |
 
 ### `command` testing notes
 

--- a/release-build.sh
+++ b/release-build.sh
@@ -28,4 +28,12 @@ GOOS="${os}" GOARCH="${arch}" CGO_ENABLED=0 go build \
 
 chmod +x "${output}"
 
-(cd "$output_dir" && sha256sum "${output_fname}" > "${output_fname}.sha256")
+SHA256="$(command -v sha256sum || true)"
+if [[ -z "$SHA256" ]]; then
+    build_host="$(uname)"
+    if [[ "$build_host" = "FreeBSD" ]]; then
+        SHA256="sha256"
+    fi
+fi
+
+(cd "$output_dir" && $SHA256 "${output_fname}" > "${output_fname}.sha256")

--- a/system/package_pkg.go
+++ b/system/package_pkg.go
@@ -1,0 +1,53 @@
+package system
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/aelsabbahy/goss/util"
+)
+
+type PkgPackage struct {
+	name      string
+	versions  []string
+	loaded    bool
+	installed bool
+}
+
+func NewPkgPackage(name string, system *System, config util.Config) Package {
+	return &PkgPackage{name: name}
+}
+
+func (p *PkgPackage) setup() {
+	if p.loaded {
+		return
+	}
+	p.loaded = true
+	cmd := util.NewCommand("pkg", "query",
+		"%v", p.name)
+	if err := cmd.Run(); err != nil {
+		return
+	}
+	p.installed = true
+	p.versions = strings.Split(strings.TrimSpace(cmd.Stdout.String()), "\n")
+}
+
+func (p *PkgPackage) Name() string {
+	return p.name
+}
+
+func (p *PkgPackage) Exists() (bool, error) { return p.Installed() }
+
+func (p *PkgPackage) Installed() (bool, error) {
+	p.setup()
+
+	return p.installed, nil
+}
+
+func (p *PkgPackage) Versions() ([]string, error) {
+	p.setup()
+	if len(p.versions) == 0 {
+		return p.versions, errors.New("Package version not found")
+	}
+	return p.versions, nil
+}

--- a/system/package_pkg.go
+++ b/system/package_pkg.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aelsabbahy/goss/util"
 )
 
+// PkgPackage is FreeBSD pkg(8) structure.
 type PkgPackage struct {
 	name      string
 	versions  []string
@@ -14,6 +15,7 @@ type PkgPackage struct {
 	installed bool
 }
 
+// NewPkgPackage returns interface to test given package information.
 func NewPkgPackage(name string, system *System, config util.Config) Package {
 	return &PkgPackage{name: name}
 }
@@ -32,18 +34,22 @@ func (p *PkgPackage) setup() {
 	p.versions = strings.Split(strings.TrimSpace(cmd.Stdout.String()), "\n")
 }
 
+// Name returns package name.
 func (p *PkgPackage) Name() string {
 	return p.name
 }
 
+// Exists returns boolean that given package is installed or not.
 func (p *PkgPackage) Exists() (bool, error) { return p.Installed() }
 
+// Installed is same as Exists.
 func (p *PkgPackage) Installed() (bool, error) {
 	p.setup()
 
 	return p.installed, nil
 }
 
+// Versions returns given package versions.
 func (p *PkgPackage) Versions() ([]string, error) {
 	p.setup()
 	if len(p.versions) == 0 {

--- a/system/service_init.go
+++ b/system/service_init.go
@@ -24,6 +24,7 @@ func NewAlpineServiceInit(service string, system *System, config util.Config) Se
 	return &ServiceInit{service: service, alpine: true}
 }
 
+// NewFreeBSDServiceInit returns ServiceInit structure for FreeBSD.
 func NewFreeBSDServiceInit(service string, system *System, config util.Config) Service {
 	return &ServiceInit{service: service, freebsd: true}
 }

--- a/system/service_init.go
+++ b/system/service_init.go
@@ -60,7 +60,12 @@ func (s *ServiceInit) Running() (bool, error) {
 	if invalidService(s.service) {
 		return false, nil
 	}
-	cmd := util.NewCommand("service", s.service, "status")
+	var cmd *util.Command
+	if s.freebsd {
+		cmd = util.NewCommand("service", s.service, "onestatus")
+	} else {
+		cmd = util.NewCommand("service", s.service, "status")
+	}
 	cmd.Run()
 	if cmd.Status == 0 {
 		return true, cmd.Err

--- a/system/system.go
+++ b/system/system.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"sync"
 
@@ -109,6 +110,8 @@ func (sys *System) detectService() {
 		sys.NewService = NewServiceSystemdLegacy
 	case "alpineinit":
 		sys.NewService = NewAlpineServiceInit
+	case "freebsd":
+		sys.NewService = NewFreeBSDServiceInit
 	default:
 		sys.NewService = NewServiceInit
 	}
@@ -174,6 +177,10 @@ func DetectService() string {
 		return "alpineinit"
 	case "arch":
 		return "systemd"
+	}
+	switch runtime.GOOS {
+	case "freebsd":
+		return "freebsd"
 	}
 	return "init"
 }

--- a/system/system.go
+++ b/system/system.go
@@ -84,7 +84,7 @@ func New(packageManager string) *System {
 
 // detectPackage adds the correct package creation function to a System struct
 func (sys *System) detectPackage(p string) {
-	if p != "dpkg" && p != "apk" && p != "pacman" && p != "rpm" {
+	if p != "dpkg" && p != "apk" && p != "pacman" && p != "rpm" && p != "pkg" {
 		p = DetectPackageManager()
 	}
 	switch p {
@@ -94,6 +94,8 @@ func (sys *System) detectPackage(p string) {
 		sys.NewPackage = NewAlpinePackage
 	case "pacman":
 		sys.NewPackage = NewPacmanPackage
+	case "pkg":
+		sys.NewPackage = NewPkgPackage
 	default:
 		sys.NewPackage = NewRpmPackage
 	}
@@ -119,7 +121,7 @@ func (sys *System) detectService() {
 
 // SupportedPackageManagers is a list of package managers we support
 func SupportedPackageManagers() []string {
-	return []string{"apk", "dpkg", "pacman", "rpm"}
+	return []string{"apk", "dpkg", "pacman", "rpm", "pkg"}
 }
 
 // IsSupportedPackageManager determines if p is a supported package manager
@@ -150,7 +152,11 @@ func DetectPackageManager() string {
 	case "debian":
 		return "dpkg"
 	}
-	for _, manager := range []string{"dpkg", "rpm", "apk", "pacman"} {
+	switch runtime.GOOS {
+	case "freebsd":
+		return "pkg"
+	}
+	for _, manager := range SupportedPackageManagers() {
 		if HasCommand(manager) {
 			return manager
 		}


### PR DESCRIPTION
* Add FreeBSD/amd64 build support into Makefile.

* Use "sha256" command instead of "sha256sum" in FreeBSD host.

* Implemented `service` test feature for FreeBSD.

* Implemented `package` test feature for FreeBSD.

Known Issue:
  * Integration test is not supported in FreeBSD because Docker.
  * `kernel-param` test is not available because `achanda/go-sysctl` does not support FreeBSD.
  * `mount` test is not available because `mount.parseMountTable` is no implemented on FreeBSD.
  * `port` test is not available because `aelsabbahy/GOnetstat` does not support FreeBSD.

This is full `gmake` build log for reference.

```
$ LC_ALL=C gmake
INFO: Starting build fmt
./ci/go-fmt.sh
/usr/local/bin/gofmt
valid gofmt
INFO: Starting build lint
golint . ./cmd/... ./matchers/... ./outputs/... ./resource/... ./system/... ./util/... || true
goss_config.go:9:6: exported type GossConfig should have comment or be unexported
goss_config.go:9:6: type name will be used as goss.GossConfig by other packages, and that stutters; consider calling this Config
goss_config.go:24:2: struct field HTTPs should be HTTPS
goss_config.go:28:1: exported function NewGossConfig should have comment or be unexported
goss_config.go:113:1: exported method GossConfig.Resources should have comment or be unexported
serve.go:20:1: exported function Serve should have comment or be unexported
store.go:21:2: exported const UNSET should have comment (or a comment on this block) or be unexported
store.go:64:6: exported type TmplVars should have comment or be unexported
store.go:68:1: exported method TmplVars.Env should have comment or be unexported
store.go:242:1: exported function WriteJSON should have comment or be unexported
matchers/semver_constraint.go:12:1: exported function BeSemverConstraint should have comment or be unexported
matchers/semver_constraint.go:18:6: exported type BeSemverConstraintMatcher should have comment or be unexported
matchers/semver_constraint.go:22:1: exported method BeSemverConstraintMatcher.Match should have comment or be unexported
matchers/semver_constraint.go:42:1: exported method BeSemverConstraintMatcher.FailureMessage should have comment or be unexported
matchers/semver_constraint.go:46:1: exported method BeSemverConstraintMatcher.NegatedFailureMessage should have comment or be unexported
outputs/documentation.go:12:6: exported type Documentation should have comment or be unexported
outputs/documentation.go:14:1: exported method Documentation.ValidOptions should have comment or be unexported
outputs/documentation.go:14:39: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/documentation.go:18:1: exported method Documentation.Output should have comment or be unexported
outputs/json.go:14:6: exported type Json should have comment or be unexported
outputs/json.go:14:6: type Json should be JSON
outputs/json.go:16:1: exported method Json.ValidOptions should have comment or be unexported
outputs/json.go:16:30: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/json.go:22:1: exported method Json.Output should have comment or be unexported
outputs/json_oneline.go:14:6: exported type JsonOneline should have comment or be unexported
outputs/json_oneline.go:14:6: type JsonOneline should be JSONOneline
outputs/json_oneline.go:16:1: exported method JsonOneline.ValidOptions should have comment or be unexported
outputs/json_oneline.go:16:37: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/json_oneline.go:20:1: exported method JsonOneline.Output should have comment or be unexported
outputs/junit.go:16:6: exported type JUnit should have comment or be unexported
outputs/junit.go:18:1: exported method JUnit.ValidOptions should have comment or be unexported
outputs/junit.go:18:31: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/junit.go:22:1: exported method JUnit.Output should have comment or be unexported
outputs/nagios.go:13:6: exported type Nagios should have comment or be unexported
outputs/nagios.go:15:1: exported method Nagios.ValidOptions should have comment or be unexported
outputs/nagios.go:15:32: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/nagios.go:22:1: exported method Nagios.Output should have comment or be unexported
outputs/outputs.go:20:6: exported type Outputer should have comment or be unexported
outputs/outputs.go:102:1: exported function RegisterOutputer should have comment or be unexported
outputs/outputs.go:156:1: exported function GetOutputer should have comment or be unexported
outputs/rspecish.go:12:6: exported type Rspecish should have comment or be unexported
outputs/rspecish.go:14:1: exported method Rspecish.ValidOptions should have comment or be unexported
outputs/rspecish.go:14:34: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/rspecish.go:18:1: exported method Rspecish.Output should have comment or be unexported
outputs/silent.go:11:6: exported type Silent should have comment or be unexported
outputs/silent.go:13:1: exported method Silent.ValidOptions should have comment or be unexported
outputs/silent.go:13:32: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/silent.go:17:1: exported method Silent.Output should have comment or be unexported
outputs/structured.go:16:1: exported method Structured.ValidOptions should have comment or be unexported
outputs/structured.go:16:36: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/tap.go:13:6: exported type Tap should have comment or be unexported
outputs/tap.go:15:1: exported method Tap.ValidOptions should have comment or be unexported
outputs/tap.go:15:29: exported method ValidOptions returns unexported type []*outputs.formatOption, which can be annoying to use
outputs/tap.go:19:1: exported method Tap.Output should have comment or be unexported
resource/addr.go:10:6: exported type Addr should have comment or be unexported
resource/addr.go:19:1: exported method Addr.ID should have comment or be unexported
resource/addr.go:20:1: exported method Addr.SetID should have comment or be unexported
resource/addr.go:22:1: comment on exported method Addr.GetTitle should be of the form "GetTitle ..."
resource/addr.go:23:1: receiver name r should be consistent with previous receiver name a for Addr
resource/addr.go:24:1: exported method Addr.GetMeta should have comment or be unexported
resource/addr.go:24:1: receiver name r should be consistent with previous receiver name a for Addr
resource/addr.go:24:26: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/addr.go:26:1: exported method Addr.Validate should have comment or be unexported
resource/addr.go:39:1: exported function NewAddr should have comment or be unexported
resource/command.go:14:6: exported type Command should have comment or be unexported
resource/command.go:26:1: exported method Command.ID should have comment or be unexported
resource/command.go:27:1: exported method Command.SetID should have comment or be unexported
resource/command.go:29:1: exported method Command.GetTitle should have comment or be unexported
resource/command.go:30:1: exported method Command.GetMeta should have comment or be unexported
resource/command.go:30:29: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/command.go:31:1: exported method Command.GetExec should have comment or be unexported
resource/command.go:38:1: exported method Command.Validate should have comment or be unexported
resource/command.go:61:1: exported function NewCommand should have comment or be unexported
resource/dns.go:11:6: exported type DNS should have comment or be unexported
resource/dns.go:23:1: exported method DNS.ID should have comment or be unexported
resource/dns.go:24:1: exported method DNS.SetID should have comment or be unexported
resource/dns.go:26:1: exported method DNS.GetTitle should have comment or be unexported
resource/dns.go:27:1: exported method DNS.GetMeta should have comment or be unexported
resource/dns.go:27:25: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/dns.go:29:1: exported method DNS.Validate should have comment or be unexported
resource/dns.go:55:1: exported function NewDNS should have comment or be unexported
resource/file.go:8:6: exported type File should have comment or be unexported
resource/file.go:26:1: exported method File.ID should have comment or be unexported
resource/file.go:27:1: exported method File.SetID should have comment or be unexported
resource/file.go:29:1: exported method File.GetTitle should have comment or be unexported
resource/file.go:30:1: exported method File.GetMeta should have comment or be unexported
resource/file.go:30:26: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/file.go:32:1: exported method File.Validate should have comment or be unexported
resource/file.go:78:1: exported function NewFile should have comment or be unexported
resource/gomega.go:128:11: should omit 2nd value from range; this loop is equivalent to `for key := range ...`
resource/gossfile.go:8:6: exported type Gossfile should have comment or be unexported
resource/gossfile.go:14:1: exported method Gossfile.ID should have comment or be unexported
resource/gossfile.go:15:1: exported method Gossfile.SetID should have comment or be unexported
resource/gossfile.go:17:1: exported method Gossfile.GetTitle should have comment or be unexported
resource/gossfile.go:18:1: exported method Gossfile.GetMeta should have comment or be unexported
resource/gossfile.go:18:30: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/gossfile.go:20:1: exported method Gossfile.Validate should have comment or be unexported
resource/gossfile.go:24:1: exported function NewGossfile should have comment or be unexported
resource/group.go:10:6: exported type Group should have comment or be unexported
resource/group.go:19:1: exported method Group.ID should have comment or be unexported
resource/group.go:20:1: exported method Group.SetID should have comment or be unexported
resource/group.go:22:1: exported method Group.GetTitle should have comment or be unexported
resource/group.go:23:1: exported method Group.GetMeta should have comment or be unexported
resource/group.go:23:27: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/group.go:25:1: exported method Group.Validate should have comment or be unexported
resource/group.go:45:1: exported function NewGroup should have comment or be unexported
resource/http.go:10:6: exported type HTTP should have comment or be unexported
resource/http.go:30:1: exported method HTTP.ID should have comment or be unexported
resource/http.go:32:1: exported method HTTP.SetID should have comment or be unexported
resource/http.go:34:1: comment on exported method HTTP.GetTitle should be of the form "GetTitle ..."
resource/http.go:35:1: receiver name r should be consistent with previous receiver name u for HTTP
resource/http.go:36:1: exported method HTTP.GetMeta should have comment or be unexported
resource/http.go:36:1: receiver name r should be consistent with previous receiver name u for HTTP
resource/http.go:36:26: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/http.go:38:1: receiver name r should be consistent with previous receiver name u for HTTP
resource/http.go:45:1: exported method HTTP.Validate should have comment or be unexported
resource/http.go:76:1: exported function NewHTTP should have comment or be unexported
resource/interface.go:8:6: exported type Interface should have comment or be unexported
resource/interface.go:18:1: exported method Interface.ID should have comment or be unexported
resource/interface.go:19:1: exported method Interface.SetID should have comment or be unexported
resource/interface.go:21:1: comment on exported method Interface.GetTitle should be of the form "GetTitle ..."
resource/interface.go:23:1: exported method Interface.GetMeta should have comment or be unexported
resource/interface.go:23:31: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/interface.go:25:1: exported method Interface.Validate should have comment or be unexported
resource/interface.go:47:1: exported function NewInterface should have comment or be unexported
resource/kernel_param.go:8:6: exported type KernelParam should have comment or be unexported
resource/kernel_param.go:15:1: exported method KernelParam.ID should have comment or be unexported
resource/kernel_param.go:16:1: exported method KernelParam.SetID should have comment or be unexported
resource/kernel_param.go:18:1: comment on exported method KernelParam.GetTitle should be of the form "GetTitle ..."
resource/kernel_param.go:19:1: receiver name r should be consistent with previous receiver name a for KernelParam
resource/kernel_param.go:20:1: exported method KernelParam.GetMeta should have comment or be unexported
resource/kernel_param.go:20:1: receiver name r should be consistent with previous receiver name a for KernelParam
resource/kernel_param.go:20:33: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/kernel_param.go:22:1: exported method KernelParam.Validate should have comment or be unexported
resource/kernel_param.go:31:1: exported function NewKernelParam should have comment or be unexported
resource/matching.go:13:6: exported type Matching should have comment or be unexported
resource/matching.go:17:2: struct field Id should be ID
resource/matching.go:21:6: exported type MatchingMap should have comment or be unexported
resource/matching.go:23:1: exported method Matching.ID should have comment or be unexported
resource/matching.go:24:1: exported method Matching.SetID should have comment or be unexported
resource/matching.go:26:1: comment on exported method Matching.GetTitle should be of the form "GetTitle ..."
resource/matching.go:27:1: receiver name r should be consistent with previous receiver name a for Matching
resource/matching.go:28:1: exported method Matching.GetMeta should have comment or be unexported
resource/matching.go:28:1: receiver name r should be consistent with previous receiver name a for Matching
resource/matching.go:28:30: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/matching.go:30:1: exported method Matching.Validate should have comment or be unexported
resource/matching.go:43:1: exported method MatchingMap.UnmarshalJSON should have comment or be unexported
resource/matching.go:80:1: exported method MatchingMap.UnmarshalYAML should have comment or be unexported
resource/mount.go:8:6: exported type Mount should have comment or be unexported
resource/mount.go:20:1: exported method Mount.ID should have comment or be unexported
resource/mount.go:21:1: exported method Mount.SetID should have comment or be unexported
resource/mount.go:23:1: comment on exported method Mount.GetTitle should be of the form "GetTitle ..."
resource/mount.go:25:1: exported method Mount.GetMeta should have comment or be unexported
resource/mount.go:25:27: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/mount.go:27:1: exported method Mount.Validate should have comment or be unexported
resource/mount.go:55:1: exported function NewMount should have comment or be unexported
resource/package.go:8:6: exported type Package should have comment or be unexported
resource/package.go:17:1: exported method Package.ID should have comment or be unexported
resource/package.go:18:1: exported method Package.SetID should have comment or be unexported
resource/package.go:20:1: exported method Package.GetTitle should have comment or be unexported
resource/package.go:21:1: exported method Package.GetMeta should have comment or be unexported
resource/package.go:21:29: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/package.go:23:1: exported method Package.Validate should have comment or be unexported
resource/package.go:42:1: exported function NewPackage should have comment or be unexported
resource/port.go:8:6: exported type Port should have comment or be unexported
resource/port.go:17:1: exported method Port.ID should have comment or be unexported
resource/port.go:18:1: exported method Port.SetID should have comment or be unexported
resource/port.go:20:1: exported method Port.GetTitle should have comment or be unexported
resource/port.go:21:1: exported method Port.GetMeta should have comment or be unexported
resource/port.go:21:26: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/port.go:23:1: exported method Port.Validate should have comment or be unexported
resource/port.go:42:1: exported function NewPort should have comment or be unexported
resource/process.go:8:6: exported type Process should have comment or be unexported
resource/process.go:16:1: exported method Process.ID should have comment or be unexported
resource/process.go:17:1: exported method Process.SetID should have comment or be unexported
resource/process.go:19:1: exported method Process.GetTitle should have comment or be unexported
resource/process.go:20:1: exported method Process.GetMeta should have comment or be unexported
resource/process.go:20:29: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/process.go:22:1: exported method Process.Validate should have comment or be unexported
resource/process.go:35:1: exported function NewProcess should have comment or be unexported
resource/resource.go:14:6: exported type Resource should have comment or be unexported
resource/resource.go:40:1: exported function Resources should have comment or be unexported
resource/resource.go:44:6: exported type ResourceRead should have comment or be unexported
resource/resource.go:44:6: type name will be used as resource.ResourceRead by other packages, and that stutters; consider calling this Read
resource/resource_list.go:20:6: exported type AddrMap should have comment or be unexported
resource/resource_list.go:22:1: exported method AddrMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:28:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:36:1: exported method AddrMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:45:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:53:1: exported method AddrMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:53:1: receiver name ret should be consistent with previous receiver name r for AddrMap
resource/resource_list.go:90:1: exported method AddrMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:90:1: receiver name ret should be consistent with previous receiver name r for AddrMap
resource/resource_list.go:122:6: exported type CommandMap should have comment or be unexported
resource/resource_list.go:124:1: exported method CommandMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:130:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:138:1: exported method CommandMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:147:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:155:1: exported method CommandMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:155:1: receiver name ret should be consistent with previous receiver name r for CommandMap
resource/resource_list.go:192:1: exported method CommandMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:192:1: receiver name ret should be consistent with previous receiver name r for CommandMap
resource/resource_list.go:224:6: exported type DNSMap should have comment or be unexported
resource/resource_list.go:226:1: exported method DNSMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:232:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:240:1: exported method DNSMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:249:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:257:1: exported method DNSMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:257:1: receiver name ret should be consistent with previous receiver name r for DNSMap
resource/resource_list.go:294:1: exported method DNSMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:294:1: receiver name ret should be consistent with previous receiver name r for DNSMap
resource/resource_list.go:326:6: exported type FileMap should have comment or be unexported
resource/resource_list.go:328:1: exported method FileMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:334:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:342:1: exported method FileMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:351:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:359:1: exported method FileMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:359:1: receiver name ret should be consistent with previous receiver name r for FileMap
resource/resource_list.go:396:1: exported method FileMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:396:1: receiver name ret should be consistent with previous receiver name r for FileMap
resource/resource_list.go:428:6: exported type GossfileMap should have comment or be unexported
resource/resource_list.go:430:1: exported method GossfileMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:436:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:444:1: exported method GossfileMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:453:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:461:1: exported method GossfileMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:461:1: receiver name ret should be consistent with previous receiver name r for GossfileMap
resource/resource_list.go:498:1: exported method GossfileMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:498:1: receiver name ret should be consistent with previous receiver name r for GossfileMap
resource/resource_list.go:530:6: exported type GroupMap should have comment or be unexported
resource/resource_list.go:532:1: exported method GroupMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:538:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:546:1: exported method GroupMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:555:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:563:1: exported method GroupMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:563:1: receiver name ret should be consistent with previous receiver name r for GroupMap
resource/resource_list.go:600:1: exported method GroupMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:600:1: receiver name ret should be consistent with previous receiver name r for GroupMap
resource/resource_list.go:632:6: exported type PackageMap should have comment or be unexported
resource/resource_list.go:634:1: exported method PackageMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:640:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:648:1: exported method PackageMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:657:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:665:1: exported method PackageMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:665:1: receiver name ret should be consistent with previous receiver name r for PackageMap
resource/resource_list.go:702:1: exported method PackageMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:702:1: receiver name ret should be consistent with previous receiver name r for PackageMap
resource/resource_list.go:734:6: exported type PortMap should have comment or be unexported
resource/resource_list.go:736:1: exported method PortMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:742:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:750:1: exported method PortMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:759:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:767:1: exported method PortMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:767:1: receiver name ret should be consistent with previous receiver name r for PortMap
resource/resource_list.go:804:1: exported method PortMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:804:1: receiver name ret should be consistent with previous receiver name r for PortMap
resource/resource_list.go:836:6: exported type ProcessMap should have comment or be unexported
resource/resource_list.go:838:1: exported method ProcessMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:844:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:852:1: exported method ProcessMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:861:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:869:1: exported method ProcessMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:869:1: receiver name ret should be consistent with previous receiver name r for ProcessMap
resource/resource_list.go:906:1: exported method ProcessMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:906:1: receiver name ret should be consistent with previous receiver name r for ProcessMap
resource/resource_list.go:938:6: exported type ServiceMap should have comment or be unexported
resource/resource_list.go:940:1: exported method ServiceMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:946:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:954:1: exported method ServiceMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:963:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:971:1: exported method ServiceMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:971:1: receiver name ret should be consistent with previous receiver name r for ServiceMap
resource/resource_list.go:1008:1: exported method ServiceMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:1008:1: receiver name ret should be consistent with previous receiver name r for ServiceMap
resource/resource_list.go:1040:6: exported type UserMap should have comment or be unexported
resource/resource_list.go:1042:1: exported method UserMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:1048:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1056:1: exported method UserMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:1065:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1073:1: exported method UserMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:1073:1: receiver name ret should be consistent with previous receiver name r for UserMap
resource/resource_list.go:1110:1: exported method UserMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:1110:1: receiver name ret should be consistent with previous receiver name r for UserMap
resource/resource_list.go:1142:6: exported type KernelParamMap should have comment or be unexported
resource/resource_list.go:1144:1: exported method KernelParamMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:1150:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1158:1: exported method KernelParamMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:1167:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1175:1: exported method KernelParamMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:1175:1: receiver name ret should be consistent with previous receiver name r for KernelParamMap
resource/resource_list.go:1212:1: exported method KernelParamMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:1212:1: receiver name ret should be consistent with previous receiver name r for KernelParamMap
resource/resource_list.go:1244:6: exported type MountMap should have comment or be unexported
resource/resource_list.go:1246:1: exported method MountMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:1252:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1260:1: exported method MountMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:1269:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1277:1: exported method MountMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:1277:1: receiver name ret should be consistent with previous receiver name r for MountMap
resource/resource_list.go:1314:1: exported method MountMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:1314:1: receiver name ret should be consistent with previous receiver name r for MountMap
resource/resource_list.go:1346:6: exported type InterfaceMap should have comment or be unexported
resource/resource_list.go:1348:1: exported method InterfaceMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:1354:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1362:1: exported method InterfaceMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:1371:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1379:1: exported method InterfaceMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:1379:1: receiver name ret should be consistent with previous receiver name r for InterfaceMap
resource/resource_list.go:1416:1: exported method InterfaceMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:1416:1: receiver name ret should be consistent with previous receiver name r for InterfaceMap
resource/resource_list.go:1448:6: exported type HTTPMap should have comment or be unexported
resource/resource_list.go:1450:1: exported method HTTPMap.AppendSysResource should have comment or be unexported
resource/resource_list.go:1456:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1464:1: exported method HTTPMap.AppendSysResourceIfExists should have comment or be unexported
resource/resource_list.go:1473:5: don't use underscores in Go names; var old_res should be oldRes
resource/resource_list.go:1481:1: exported method HTTPMap.UnmarshalJSON should have comment or be unexported
resource/resource_list.go:1481:1: receiver name ret should be consistent with previous receiver name r for HTTPMap
resource/resource_list.go:1518:1: exported method HTTPMap.UnmarshalYAML should have comment or be unexported
resource/resource_list.go:1518:1: receiver name ret should be consistent with previous receiver name r for HTTPMap
resource/service.go:8:6: exported type Service should have comment or be unexported
resource/service.go:17:1: exported method Service.ID should have comment or be unexported
resource/service.go:18:1: exported method Service.SetID should have comment or be unexported
resource/service.go:20:1: exported method Service.GetTitle should have comment or be unexported
resource/service.go:21:1: exported method Service.GetMeta should have comment or be unexported
resource/service.go:21:29: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/service.go:23:1: exported method Service.Validate should have comment or be unexported
resource/service.go:37:1: exported function NewService should have comment or be unexported
resource/user.go:10:6: exported type User should have comment or be unexported
resource/user.go:23:1: exported method User.ID should have comment or be unexported
resource/user.go:24:1: exported method User.SetID should have comment or be unexported
resource/user.go:26:1: exported method User.GetTitle should have comment or be unexported
resource/user.go:27:1: exported method User.GetMeta should have comment or be unexported
resource/user.go:27:26: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
resource/user.go:29:1: exported method User.Validate should have comment or be unexported
resource/user.go:62:1: exported function NewUser should have comment or be unexported
resource/validate.go:17:2: exported const Value should have comment (or a comment on this block) or be unexported
resource/validate.go:23:2: exported const SUCCESS should have comment (or a comment on this block) or be unexported
resource/validate.go:32:6: exported type TestResult should have comment or be unexported
resource/validate.go:34:2: struct field ResourceId should be ResourceID
resource/validate.go:62:1: exported function ValidateValue should have comment or be unexported
resource/validate.go:250:1: exported function ValidateContains should have comment or be unexported
resource/validate_test.go:19:34: exported method GetMeta returns unexported type resource.meta, which can be annoying to use
system/addr.go:11:6: exported type Addr should have comment or be unexported
system/addr.go:17:6: exported type DefAddr should have comment or be unexported
system/addr.go:23:1: exported function NewDefAddr should have comment or be unexported
system/addr.go:32:1: exported method DefAddr.ID should have comment or be unexported
system/addr.go:35:1: exported method DefAddr.Address should have comment or be unexported
system/addr.go:38:1: exported method DefAddr.Exists should have comment or be unexported
system/addr.go:40:1: exported method DefAddr.Reachable should have comment or be unexported
system/command.go:13:6: exported type Command should have comment or be unexported
system/command.go:21:6: exported type DefCommand should have comment or be unexported
system/command.go:31:1: exported function NewDefCommand should have comment or be unexported
system/command.go:58:1: exported method DefCommand.Command should have comment or be unexported
system/command.go:62:1: exported method DefCommand.ExitStatus should have comment or be unexported
system/command.go:68:1: exported method DefCommand.Stdout should have comment or be unexported
system/command.go:74:1: exported method DefCommand.Stderr should have comment or be unexported
system/command.go:80:1: comment on exported method DefCommand.Exists should be of the form "Exists ..."
system/dns.go:16:6: exported type DNS should have comment or be unexported
system/dns.go:25:6: exported type DefDNS should have comment or be unexported
system/dns.go:36:1: exported function NewDefDNS should have comment or be unexported
system/dns.go:56:1: exported method DefDNS.Host should have comment or be unexported
system/dns.go:60:1: exported method DefDNS.Server should have comment or be unexported
system/dns.go:64:1: exported method DefDNS.Qtype should have comment or be unexported
system/dns.go:95:1: exported method DefDNS.Addrs should have comment or be unexported
system/dns.go:101:1: exported method DefDNS.Resolvable should have comment or be unexported
system/dns.go:107:1: comment on exported method DefDNS.Exists should be of the form "Exists ..."
system/dns.go:112:1: exported function DNSlookup should have comment or be unexported
system/dns.go:165:1: comment on exported function LookupHost should be of the form "LookupHost ..."
system/dns.go:174:1: comment on exported function LookupA should be of the form "LookupA ..."
system/dns.go:201:1: comment on exported function LookupAAAA should be of the form "LookupAAAA ..."
system/dns.go:218:1: comment on exported function LookupCNAME should be of the form "LookupCNAME ..."
system/dns.go:235:1: comment on exported function LookupMX should be of the form "LookupMX ..."
system/dns.go:253:1: comment on exported function LookupNS should be of the form "LookupNS ..."
system/dns.go:270:1: comment on exported function LookupSRV should be of the form "LookupSRV ..."
system/dns.go:291:1: comment on exported function LookupTXT should be of the form "LookupTXT ..."
system/dns.go:308:1: comment on exported function LookupPTR should be of the form "LookupPTR ..."
system/dns.go:330:1: comment on exported function LookupCAA should be of the form "LookupCAA ..."
system/file.go:19:6: exported type File should have comment or be unexported
system/file.go:42:6: exported type DefFile should have comment or be unexported
system/file.go:50:1: exported function NewDefFile should have comment or be unexported
system/file.go:70:1: exported method DefFile.Path should have comment or be unexported
system/file.go:74:1: exported method DefFile.Exists should have comment or be unexported
system/file.go:86:1: exported method DefFile.Contains should have comment or be unexported
system/file.go:98:1: exported method DefFile.Size should have comment or be unexported
system/file.go:112:1: exported method DefFile.Filetype should have comment or be unexported
system/file.go:143:1: exported method DefFile.LinkedTo should have comment or be unexported
system/file.go:212:1: exported method DefFile.Md5 should have comment or be unexported
system/file.go:216:1: exported method DefFile.Sha256 should have comment or be unexported
system/file.go:220:1: exported method DefFile.Sha512 should have comment or be unexported
system/file.go:224:6: func getUserForUid should be getUserForUID
system/file_posix.go:12:1: exported method DefFile.Mode should have comment or be unexported
system/file_posix.go:24:1: exported method DefFile.Owner should have comment or be unexported
system/file_posix.go:39:1: exported method DefFile.Group should have comment or be unexported
system/gossfile.go:5:6: exported type Gossfile should have comment or be unexported
system/gossfile.go:10:6: exported type DefGossfile should have comment or be unexported
system/gossfile.go:14:1: exported method DefGossfile.Path should have comment or be unexported
system/gossfile.go:18:1: comment on exported method DefGossfile.Exists should be of the form "Exists ..."
system/gossfile.go:23:1: exported function NewDefGossfile should have comment or be unexported
system/group.go:8:6: exported type Group should have comment or be unexported
system/group.go:14:6: exported type DefGroup should have comment or be unexported
system/group.go:18:1: exported function NewDefGroup should have comment or be unexported
system/group.go:22:1: exported method DefGroup.Groupname should have comment or be unexported
system/group.go:26:1: exported method DefGroup.Exists should have comment or be unexported
system/group.go:34:1: exported method DefGroup.GID should have comment or be unexported
system/http.go:15:6: exported type HTTP should have comment or be unexported
system/http.go:25:6: exported type DefHTTP should have comment or be unexported
system/http.go:41:1: exported function NewDefHTTP should have comment or be unexported
system/http.go:61:1: exported function HeaderToArray should have comment or be unexported
system/http.go:121:1: exported method DefHTTP.Exists should have comment or be unexported
system/http.go:128:1: exported method DefHTTP.SetNoFollowRedirects should have comment or be unexported
system/http.go:132:1: exported method DefHTTP.SetAllowInsecure should have comment or be unexported
system/http.go:136:1: exported method DefHTTP.ID should have comment or be unexported
system/http.go:140:1: exported method DefHTTP.HTTP should have comment or be unexported
system/http.go:144:1: exported method DefHTTP.Status should have comment or be unexported
system/http.go:152:1: exported method DefHTTP.Headers should have comment or be unexported
system/http.go:161:1: exported method DefHTTP.Body should have comment or be unexported
system/interface.go:9:6: exported type Interface should have comment or be unexported
system/interface.go:16:6: exported type DefInterface should have comment or be unexported
system/interface.go:24:1: exported function NewDefInterface should have comment or be unexported
system/interface.go:47:1: exported method DefInterface.ID should have comment or be unexported
system/interface.go:51:1: exported method DefInterface.Name should have comment or be unexported
system/interface.go:55:1: exported method DefInterface.Exists should have comment or be unexported
system/interface.go:63:1: exported method DefInterface.Addrs should have comment or be unexported
system/interface.go:80:1: exported method DefInterface.MTU should have comment or be unexported
system/kernel_param.go:8:6: exported type KernelParam should have comment or be unexported
system/kernel_param.go:14:6: exported type DefKernelParam should have comment or be unexported
system/kernel_param.go:19:1: exported function NewDefKernelParam should have comment or be unexported
system/kernel_param.go:25:1: exported method DefKernelParam.ID should have comment or be unexported
system/kernel_param.go:29:1: exported method DefKernelParam.Key should have comment or be unexported
system/kernel_param.go:33:1: exported method DefKernelParam.Exists should have comment or be unexported
system/kernel_param.go:40:1: exported method DefKernelParam.Value should have comment or be unexported
system/mount.go:11:6: exported type Mount should have comment or be unexported
system/mount.go:20:6: exported type DefMount should have comment or be unexported
system/mount.go:29:1: exported function NewDefMount should have comment or be unexported
system/mount.go:60:1: exported method DefMount.ID should have comment or be unexported
system/mount.go:64:1: exported method DefMount.MountPoint should have comment or be unexported
system/mount.go:68:1: exported method DefMount.Exists should have comment or be unexported
system/mount.go:76:1: exported method DefMount.Opts should have comment or be unexported
system/mount.go:84:1: exported method DefMount.Source should have comment or be unexported
system/mount.go:92:1: exported method DefMount.Filesystem should have comment or be unexported
system/mount.go:100:1: exported method DefMount.Usage should have comment or be unexported
system/package.go:9:6: exported type Package should have comment or be unexported
system/package.go:16:5: exported var ErrNullPackage should have comment or be unexported
system/package.go:18:6: exported type NullPackage should have comment or be unexported
system/package.go:22:1: exported function NewNullPackage should have comment or be unexported
system/package.go:26:1: exported method NullPackage.Name should have comment or be unexported
system/package.go:28:1: exported method NullPackage.Exists should have comment or be unexported
system/package.go:30:1: exported method NullPackage.Installed should have comment or be unexported
system/package.go:34:1: exported method NullPackage.Versions should have comment or be unexported
system/package_alpine.go:10:6: exported type AlpinePackage should have comment or be unexported
system/package_alpine.go:17:1: exported function NewAlpinePackage should have comment or be unexported
system/package_alpine.go:43:1: exported method AlpinePackage.Name should have comment or be unexported
system/package_alpine.go:47:1: exported method AlpinePackage.Exists should have comment or be unexported
system/package_alpine.go:49:1: exported method AlpinePackage.Installed should have comment or be unexported
system/package_alpine.go:55:1: exported method AlpinePackage.Versions should have comment or be unexported
system/package_deb.go:10:6: exported type DebPackage should have comment or be unexported
system/package_deb.go:17:1: exported function NewDebPackage should have comment or be unexported
system/package_deb.go:43:1: exported method DebPackage.Name should have comment or be unexported
system/package_deb.go:47:1: exported method DebPackage.Exists should have comment or be unexported
system/package_deb.go:49:1: exported method DebPackage.Installed should have comment or be unexported
system/package_deb.go:55:1: exported method DebPackage.Versions should have comment or be unexported
system/package_pacman.go:10:6: exported type PacmanPackage should have comment or be unexported
system/package_pacman.go:17:1: exported function NewPacmanPackage should have comment or be unexported
system/package_pacman.go:37:1: exported method PacmanPackage.Name should have comment or be unexported
system/package_pacman.go:41:1: exported method PacmanPackage.Exists should have comment or be unexported
system/package_pacman.go:43:1: exported method PacmanPackage.Installed should have comment or be unexported
system/package_pacman.go:49:1: exported method PacmanPackage.Versions should have comment or be unexported
system/package_rpm.go:10:6: exported type RpmPackage should have comment or be unexported
system/package_rpm.go:17:1: exported function NewRpmPackage should have comment or be unexported
system/package_rpm.go:34:1: exported method RpmPackage.Name should have comment or be unexported
system/package_rpm.go:38:1: exported method RpmPackage.Exists should have comment or be unexported
system/package_rpm.go:40:1: exported method RpmPackage.Installed should have comment or be unexported
system/package_rpm.go:46:1: exported method RpmPackage.Versions should have comment or be unexported
system/port.go:11:6: exported type Port should have comment or be unexported
system/port.go:18:6: exported type DefPort should have comment or be unexported
system/port.go:23:1: exported function NewDefPort should have comment or be unexported
system/port.go:45:1: exported method DefPort.Port should have comment or be unexported
system/port.go:49:1: exported method DefPort.Exists should have comment or be unexported
system/port.go:51:1: exported method DefPort.Listening should have comment or be unexported
system/port.go:58:1: exported method DefPort.IP should have comment or be unexported
system/port.go:66:1: comment on exported function GetPorts should be of the form "GetPorts ..."
system/process.go:8:6: exported type Process should have comment or be unexported
system/process.go:15:6: exported type DefProcess should have comment or be unexported
system/process.go:21:1: exported function NewDefProcess should have comment or be unexported
system/process.go:30:1: exported method DefProcess.Executable should have comment or be unexported
system/process.go:34:1: exported method DefProcess.Exists should have comment or be unexported
system/process.go:36:1: exported method DefProcess.Pids should have comment or be unexported
system/process.go:47:1: exported method DefProcess.Running should have comment or be unexported
system/process.go:57:1: exported function GetProcs should have comment or be unexported
system/service.go:5:6: exported type Service should have comment or be unexported
system/service_init.go:11:6: exported type ServiceInit should have comment or be unexported
system/service_init.go:16:1: exported function NewServiceInit should have comment or be unexported
system/service_init.go:20:1: exported function NewAlpineServiceInit should have comment or be unexported
system/service_init.go:24:1: exported method ServiceInit.Service should have comment or be unexported
system/service_init.go:28:1: exported method ServiceInit.Exists should have comment or be unexported
system/service_init.go:38:1: exported method ServiceInit.Enabled should have comment or be unexported
system/service_init.go:44:9: if block ends with a return statement, so drop this else and outdent its block
system/service_init.go:49:1: exported method ServiceInit.Running should have comment or be unexported
system/service_systemd.go:10:6: exported type ServiceSystemd should have comment or be unexported
system/service_systemd.go:15:1: exported function NewServiceSystemd should have comment or be unexported
system/service_systemd.go:21:1: exported function NewServiceSystemdLegacy should have comment or be unexported
system/service_systemd.go:28:1: exported method ServiceSystemd.Service should have comment or be unexported
system/service_systemd.go:32:1: exported method ServiceSystemd.Exists should have comment or be unexported
system/service_systemd.go:51:1: exported method ServiceSystemd.Enabled should have comment or be unexported
system/service_systemd.go:70:1: exported method ServiceSystemd.Running should have comment or be unexported
system/service_upstart.go:13:6: exported type ServiceUpstart should have comment or be unexported
system/service_upstart.go:20:1: exported function NewServiceUpstart should have comment or be unexported
system/service_upstart.go:24:1: exported method ServiceUpstart.Service should have comment or be unexported
system/service_upstart.go:28:1: exported method ServiceUpstart.Exists should have comment or be unexported
system/service_upstart.go:41:1: exported method ServiceUpstart.Enabled should have comment or be unexported
system/service_upstart.go:71:1: exported method ServiceUpstart.Running should have comment or be unexported
system/system.go:18:6: exported type Resource should have comment or be unexported
system/system.go:22:6: exported type System should have comment or be unexported
system/system.go:44:1: exported method System.Ports should have comment or be unexported
system/system.go:51:1: exported method System.ProcMap should have comment or be unexported
system/system.go:61:1: exported function New should have comment or be unexported
system/system.go:85:1: receiver name sys should be consistent with previous receiver name s for System
system/system.go:102:1: receiver name sys should be consistent with previous receiver name s for System
system/user.go:11:6: exported type User should have comment or be unexported
system/user.go:21:6: exported type DefUser should have comment or be unexported
system/user.go:25:1: exported function NewDefUser should have comment or be unexported
system/user.go:29:1: exported method DefUser.Username should have comment or be unexported
system/user.go:33:1: exported method DefUser.Exists should have comment or be unexported
system/user.go:41:1: exported method DefUser.UID should have comment or be unexported
system/user.go:50:1: exported method DefUser.GID should have comment or be unexported
system/user.go:59:1: exported method DefUser.Home should have comment or be unexported
system/user.go:68:1: exported method DefUser.Shell should have comment or be unexported
system/user.go:77:1: exported method DefUser.Groups should have comment or be unexported
util/command.go:11:6: exported type Command should have comment or be unexported
util/command.go:19:1: exported function NewCommand should have comment or be unexported
util/command.go:28:1: exported method Command.Run should have comment or be unexported
util/config.go:239:6: exported type OutputConfig should have comment or be unexported
util/config.go:246:2: exported const JSON should have comment (or a comment on this block) or be unexported
util/config.go:250:1: exported function ValidateSections should have comment or be unexported
util/config.go:261:10: should omit 2nd value from range; this loop is equivalent to `for k := range ...`
util/config.go:271:1: exported function WhitelistAttrs should have comment or be unexported
util/config.go:283:1: exported function IsValueInList should have comment or be unexported
INFO: Starting build vet
go vet . ./cmd/... ./matchers/... ./outputs/... ./resource/... ./system/... ./util/... || true
INFO: Starting build test
./ci/go-test.sh . ./cmd/... ./matchers/... ./outputs/... ./resource/... ./system/... ./util/...
/usr/local/bin/go
ok      github.com/aelsabbahy/goss      0.242s  coverage: 55.7% of statements
./release-build.sh alpha-darwin-amd64
./release-build.sh linux-386
./release-build.sh linux-amd64
./release-build.sh linux-arm
./release-build.sh alpha-windows-amd64
./release-build.sh freebsd-amd64
INFO: Starting build centos7-32
cd integration-tests/ && ./test.sh centos7 386
+ os=centos7
+ arch=386
+ vars_inline='{inline: bar, overwrite: bar}'
+ cd integration-tests
+ cp ../release/goss-linux-386 goss/centos7/
+ md5sum -c Dockerfile_centos7.md5
./test.sh: line 26: md5sum: command not found
+ docker build -t aelsabbahy/goss_centos7:latest -
./test.sh: line 27: docker: command not found
++ _err_trap
++ local err=127
++ local 'cmd=docker build -t "aelsabbahy/goss_${os}:latest" - < "Dockerfile_$os"'
++ set +x
panic: uncaught error
Traceback (most recent call first):
  at ./test.sh:27 in main()
docker build -t "aelsabbahy/goss_${os}:latest" - < "Dockerfile_$os" exited 127
gmake: *** [Makefile:87: centos7-32] Error 127
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
