### PR TITLE
Install the correct binary for 32-bit and 64-bit arm machines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,8 +25,10 @@ touch "$INSTALL_LOC" || { echo "ERROR: Cannot write to $GOSS_DST set GOSS_DST el
 arch=""
 if [ "$(uname -m)" = "x86_64" ]; then
     arch="amd64"
-elif [ "$(uname -m)" = "aarch64" ]; then
+elif [ "$(uname -m)" = "aarch32" ]; then
     arch="arm"
+elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+    arch="arm64"
 else
     arch="386"
 fi


### PR DESCRIPTION
Following up on https://github.com/aelsabbahy/goss/pull/737#issuecomment-1030903417.

This change was split out from the original PR.

The `install.sh` in its current version didn't download the correct binary. If `"$(uname -m)" = "aarch64"` (meaning we are a 64-bit system) it would download `goss-linux-arm` (which is a 32-bit binary).

With this change it downloads the correct binaries:
* `aarch32` -> `goss-linux-arm`
* `aarch64` as well as `arm64 ` -> `goss-linux-arm64` (which will exist after merging https://github.com/aelsabbahy/goss/pull/737)

As mentioned in the other PR there might be more possible return values of `uname -m` for a 32-bit system (e.g. just `arm` or `armv7`) but I can't test it currently.