### PR TITLE
Prometheus output format

### DIFF
--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -30,6 +30,7 @@ var (
 		"json":          &Json{},
 		"junit":         &JUnit{},
 		"nagios":        &Nagios{},
+		"prometheus":    &Prometheus{},
 		"rspecish":      &Rspecish{},
 		"structured":    &Structured{},
 		"tap":           &Tap{},

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -1,0 +1,115 @@
+package outputs
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aelsabbahy/goss/resource"
+	"github.com/aelsabbahy/goss/util"
+	"github.com/fatih/color"
+)
+
+type Prometheus struct{}
+
+func (r Prometheus) ValidOptions() []*formatOption {
+	return []*formatOption{}
+}
+
+func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
+	startTime time.Time, outConfig util.OutputConfig) (exitCode int) {
+
+	color.NoColor = true
+	testCount := 0
+	var skipped, failed int
+
+	const resultName string = "goss_result"
+	const durationName string = "goss_duration_seconds"
+	const promType string = "gauge"
+
+	fmt.Fprintf(w, "# HELP %s goss result\n", resultName)
+	fmt.Fprintf(w, "# TYPE %s %s\n", resultName, promType)
+	fmt.Fprintf(w, "# HELP %s goss duration\n", durationName)
+	fmt.Fprintf(w, "# TYPE %s %s\n", durationName, promType)
+
+	for resultGroup := range results {
+		for _, testResult := range resultGroup {
+			labels := make(map[string]string)
+			labels["property"] = testResult.Property
+			labels["resource_id"] = testResult.ResourceId
+			labels["resource_type"] = testResult.ResourceType
+			switch testResult.Result {
+			case resource.SUCCESS:
+				labels["result"] = "success"
+			case resource.SKIP:
+				labels["result"] = "skipped"
+				skipped++
+			case resource.FAIL:
+				labels["result"] = "failure"
+				failed++
+			}
+			testCount++
+
+			if testResult.Title != "" {
+				labels["title"] = testResult.Title
+			}
+			if len(testResult.Meta) > 0 {
+				for k, v := range testResult.Meta {
+					labels[ToSnakeCase(k)] = v.(string)
+				}
+			}
+
+			fmt.Fprintf(w, "%s{%s} %d\n", resultName, KeysString(labels), testResult.Result)
+			fmt.Fprintf(w, "%s{%s} %f\n", durationName, KeysString(labels), float64(testResult.Duration.Nanoseconds())/1000000000)
+		}
+	}
+
+	fmt.Fprint(w, "\n\n")
+	fmt.Fprint(w, "# HELP goss_failed_total goss failed tests\n")
+	fmt.Fprint(w, "# TYPE goss_failed_total gauge\n")
+	fmt.Fprintf(w, "goss_failed_total %d\n", failed)
+	fmt.Fprint(w, "# HELP goss_successful_total goss successful tests\n")
+	fmt.Fprint(w, "# TYPE goss_successful_total gauge\n")
+	fmt.Fprintf(w, "goss_successful_total %d\n", testCount-failed-skipped)
+	fmt.Fprint(w, "# HELP goss_skipped_total goss skipped tests\n")
+	fmt.Fprint(w, "# TYPE goss_skipped_total gauge\n")
+	fmt.Fprintf(w, "goss_skipped_total %d\n", skipped)
+	fmt.Fprint(w, "# HELP goss_test_count goss test count\n")
+	fmt.Fprint(w, "# TYPE goss_test_count gauge\n")
+	fmt.Fprintf(w, "goss_test_count %d\n", testCount)
+	fmt.Fprint(w, "# HELP goss_duration_seconds_total goss total duration\n")
+	fmt.Fprint(w, "# TYPE goss_duration_seconds_total gauge\n")
+	fmt.Fprintf(w, "goss_duration_seconds_total %f\n", float64(time.Since(startTime).Nanoseconds())/1000000000)
+
+	if failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+func ToSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+func QuoteValue(s string) string {
+	var vs string = s
+	vs = strings.ReplaceAll(vs, "\\", "\\\\")
+	vs = strings.ReplaceAll(vs, "\n", "\\n")
+	vs = strings.ReplaceAll(vs, "\"", "\\\"")
+	return vs
+}
+
+func KeysString(m map[string]string) string {
+	l := make([]string, 0, len(m))
+	for k, v := range m {
+		l = append(l, fmt.Sprintf("%s=\"%s\"", k, QuoteValue(v)))
+	}
+	return strings.Join(l, ", ")
+}

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -83,9 +83,6 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 	fmt.Fprint(w, "# TYPE goss_duration_seconds_total gauge\n")
 	fmt.Fprintf(w, "goss_duration_seconds_total %f\n", float64(time.Since(startTime).Nanoseconds())/1000000000)
 
-	if failed > 0 {
-		return 1
-	}
 	return 0
 }
 
@@ -111,5 +108,5 @@ func KeysString(m map[string]string) string {
 	for k, v := range m {
 		l = append(l, fmt.Sprintf("%s=\"%s\"", k, QuoteValue(v)))
 	}
-	return strings.Join(l, ", ")
+	return strings.Join(l, ",")
 }

--- a/serve.go
+++ b/serve.go
@@ -164,6 +164,8 @@ func (h healthHandler) negotiateResponseContentType(r *http.Request) (string, ou
 func (h healthHandler) responseContentType(outputName string) string {
 	if outputName == "json" {
 		return "application/json"
+	} else if outputName == "prometheus" {
+		return "text/plain; version=0.0.4"
 	}
 	return fmt.Sprintf("%s%s", mediaTypePrefix, outputName)
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
Add a **prometheus** output format.

The format was copied from [DracoBlue](https://github.com/DracoBlue/goss-metrics-exporter).

Additions include:
**meta** are added to labels on the testoutput metric
**goss_test_count** metric added

There is no special negotiation (Accept Header) logic, so goss serve must be started with _-f prometheus_, or scraper must be configured to send Accept header as _application/vnd.goss-prometheus_.

Endpoint will respond with _text/plain; version=0.0.4_ as per Prometheus specification.
