### PR TITLE
Fixed kgoss kubectl cp issue

### DIFF
--- a/extras/kgoss/kgoss
+++ b/extras/kgoss/kgoss
@@ -220,7 +220,7 @@ get_pod_file() {
     if ${k} exec "$id" -- sh -c "test -e ${GOSS_CONTAINER_PATH}/$1" &> /dev/null; then
         mkdir -p "${GOSS_FILES_PATH}"
         info "Copied '$1' from pod/container to '${GOSS_FILES_PATH}'"
-        ${k} cp "${id}:${GOSS_CONTAINER_PATH}/$1" "${GOSS_FILES_PATH}"
+        ${k} cp "${id}:${GOSS_CONTAINER_PATH}/$1" "${GOSS_FILES_PATH}/$1"
     fi
 }
 


### PR DESCRIPTION
Fixed https://github.com/aelsabbahy/goss/issues/770 issue

`kubectl cp <file-spec-src> <file-spec-dest>` **file-spec-dest** should be filename with path(optional) but It cannot be directory.

Reference for `kubectl cp`
-  https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cp
- https://stackoverflow.com/questions/52407277/how-to-copy-files-from-kubernetes-pods-to-local-system