### PR TITLE
Skip by type

### DIFF
--- a/add.go
+++ b/add.go
@@ -47,35 +47,35 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 
 	// Need to figure out a good way to refactor this
 	switch resourceName {
-	case "Addr":
+	case resource.AddResourceName:
 		res, err = gossConfig.Addrs.AppendSysResource(key, sys, config)
-	case "Command":
+	case resource.CommandResourceName:
 		res, err = gossConfig.Commands.AppendSysResource(key, sys, config)
-	case "DNS":
+	case resource.DNSResourceName:
 		res, err = gossConfig.DNS.AppendSysResource(key, sys, config)
-	case "File":
+	case resource.FileResourceName:
 		res, err = gossConfig.Files.AppendSysResource(key, sys, config)
-	case "Group":
+	case resource.GroupFileResourceName:
 		res, err = gossConfig.Groups.AppendSysResource(key, sys, config)
-	case "Package":
+	case resource.PackageResourceName:
 		res, err = gossConfig.Packages.AppendSysResource(key, sys, config)
-	case "Port":
+	case resource.PortResourceName:
 		res, err = gossConfig.Ports.AppendSysResource(key, sys, config)
-	case "Process":
+	case resource.ProcessResourceName:
 		res, err = gossConfig.Processes.AppendSysResource(key, sys, config)
-	case "Service":
+	case resource.ServiceResourceName:
 		res, err = gossConfig.Services.AppendSysResource(key, sys, config)
-	case "User":
+	case resource.UserResourceName:
 		res, err = gossConfig.Users.AppendSysResource(key, sys, config)
-	case "Gossfile":
+	case resource.GossFileResourceName:
 		res, err = gossConfig.Gossfiles.AppendSysResource(key, sys, config)
-	case "KernelParam":
+	case resource.KernelParamResourceName:
 		res, err = gossConfig.KernelParams.AppendSysResource(key, sys, config)
-	case "Mount":
+	case resource.MountResourceName:
 		res, err = gossConfig.Mounts.AppendSysResource(key, sys, config)
-	case "Interface":
+	case resource.InterfaceResourceName:
 		res, err = gossConfig.Interfaces.AppendSysResource(key, sys, config)
-	case "HTTP":
+	case resource.HTTPResourceName:
 		res, err = gossConfig.HTTPs.AppendSysResource(key, sys, config)
 	default:
 		err = fmt.Errorf("undefined resource name: %s", resourceName)

--- a/add.go
+++ b/add.go
@@ -55,7 +55,7 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 		res, err = gossConfig.DNS.AppendSysResource(key, sys, config)
 	case resource.FileResourceName:
 		res, err = gossConfig.Files.AppendSysResource(key, sys, config)
-	case resource.GroupFileResourceName:
+	case resource.GroupResourceName:
 		res, err = gossConfig.Groups.AppendSysResource(key, sys, config)
 	case resource.PackageResourceName:
 		res, err = gossConfig.Packages.AppendSysResource(key, sys, config)

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aelsabbahy/goss"
 	"github.com/aelsabbahy/goss/outputs"
+	"github.com/aelsabbahy/goss/resource"
 	"github.com/aelsabbahy/goss/system"
 	"github.com/aelsabbahy/goss/util"
 
@@ -239,77 +240,77 @@ func main() {
 			},
 			Subcommands: []cli.Command{
 				{
-					Name:  "package",
+					Name:  resource.PackageResourceKey,
 					Usage: "add new package",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Package", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.PackageResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "file",
+					Name:  resource.FileResourceKey,
 					Usage: "add new file",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "File", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.FileResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "addr",
+					Name:  resource.AddrResourceKey,
 					Usage: "add new remote address:port - ex: google.com:80",
 					Flags: []cli.Flag{
 						timeoutFlag(500 * time.Millisecond),
 					},
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Addr", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.AddResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "port",
+					Name:  resource.PortResourceKey,
 					Usage: "add new listening [protocol]:port - ex: 80 or udp:123",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Port", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.PortResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "service",
+					Name:  resource.ServiceResourceKey,
 					Usage: "add new service",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Service", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.ServiceResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "user",
+					Name:  resource.UserResourceKey,
 					Usage: "add new user",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "User", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.UserResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "group",
+					Name:  resource.GroupFileResourceKey,
 					Usage: "add new group",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Group", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.GroupFileResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "command",
+					Name:  resource.CommandResourceKey,
 					Usage: "add new command",
 					Flags: []cli.Flag{
 						timeoutFlag(10 * time.Second),
 					},
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Command", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.CommandResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "dns",
+					Name:  resource.DNSResourceKey,
 					Usage: "add new dns",
 					Flags: []cli.Flag{
 						timeoutFlag(500 * time.Millisecond),
@@ -320,19 +321,19 @@ func main() {
 					},
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "DNS", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.DNSResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "process",
+					Name:  resource.ProcessResourceKey,
 					Usage: "add new process name",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Process", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.ProcessResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "http",
+					Name:  resource.HTTPResourceKey,
 					Usage: "add new http",
 					Flags: []cli.Flag{
 						cli.BoolFlag{
@@ -357,7 +358,7 @@ func main() {
 					},
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "HTTP", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.HTTPResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
@@ -365,32 +366,32 @@ func main() {
 					Usage: "add new goss file, it will be imported from this one",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Gossfile", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.GossFileResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 
 					},
 				},
 				{
-					Name:  "kernel-param",
+					Name:  resource.KernelParamResourceKey,
 					Usage: "add new goss kernel param",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "KernelParam", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.KernelParamResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "mount",
+					Name:  resource.MountResourceKey,
 					Usage: "add new mount",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Mount", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.MountResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{
-					Name:  "interface",
+					Name:  resource.InterfaceResourceKey,
 					Usage: "add new interface",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), "Interface", c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.InterfaceResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 			},

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -291,11 +291,11 @@ func main() {
 					},
 				},
 				{
-					Name:  resource.GroupFileResourceKey,
+					Name:  resource.GroupResourceKey,
 					Usage: "add new group",
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
-						return goss.AddResources(c.GlobalString("gossfile"), resource.GroupFileResourceName, c.Args(), newRuntimeConfigFromCLI(c))
+						return goss.AddResources(c.GlobalString("gossfile"), resource.GroupResourceName, c.Args(), newRuntimeConfigFromCLI(c))
 					},
 				},
 				{

--- a/goss_test.go
+++ b/goss_test.go
@@ -3,7 +3,6 @@ package goss
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -63,7 +62,7 @@ func TestUseAsPackage(t *testing.T) {
 	output := &bytes.Buffer{}
 
 	// temp spec file
-	fh, err := ioutil.TempFile("", "*.yaml")
+	fh, err := os.CreateTemp("", "*.yaml")
 	checkErr(t, err, "temp file failed")
 	fh.Close()
 
@@ -125,7 +124,7 @@ func TestSkipResourcesByType(t *testing.T) {
 	output := &bytes.Buffer{}
 
 	// temp spec file
-	fh, err := ioutil.TempFile("", "*.yaml")
+	fh, err := os.CreateTemp("", "*.yaml")
 	checkErr(t, err, "temp file failed")
 	fh.Close()
 

--- a/resource/addr.go
+++ b/resource/addr.go
@@ -14,6 +14,7 @@ type Addr struct {
 	LocalAddress string  `json:"local-address,omitempty" yaml:"local-address,omitempty"`
 	Reachable    matcher `json:"reachable" yaml:"reachable"`
 	Timeout      int     `json:"timeout" yaml:"timeout"`
+	Skip         bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
 const (
@@ -25,15 +26,18 @@ func init() {
 	registerResource(AddrResourceKey, &Addr{})
 }
 
-func (a *Addr) ID() string      { return a.Address }
-func (a *Addr) SetID(id string) { a.Address = id }
+func (a *Addr) ID() string       { return a.Address }
+func (a *Addr) SetID(id string)  { a.Address = id }
+func (a *Addr) SetSkip()         { a.Skip = true }
+func (a *Addr) TypeKey() string  { return AddrResourceKey }
+func (a *Addr) TypeName() string { return AddResourceName }
 
 // FIXME: Can this be refactored?
-func (r *Addr) GetTitle() string { return r.Title }
-func (r *Addr) GetMeta() meta    { return r.Meta }
+func (a *Addr) GetTitle() string { return a.Title }
+func (a *Addr) GetMeta() meta    { return a.Meta }
 
-func (a *Addr) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(AddrResourceKey, skipTypes)
+func (a *Addr) Validate(sys *system.System) []TestResult {
+	skip := a.Skip
 
 	if a.Timeout == 0 {
 		a.Timeout = 500

--- a/resource/addr.go
+++ b/resource/addr.go
@@ -16,6 +16,15 @@ type Addr struct {
 	Timeout      int     `json:"timeout" yaml:"timeout"`
 }
 
+const (
+	AddrResourceKey = "addr"
+	AddResourceName = "Addr"
+)
+
+func init() {
+	registerResource(AddrResourceKey, &Addr{})
+}
+
 func (a *Addr) ID() string      { return a.Address }
 func (a *Addr) SetID(id string) { a.Address = id }
 
@@ -23,8 +32,9 @@ func (a *Addr) SetID(id string) { a.Address = id }
 func (r *Addr) GetTitle() string { return r.Title }
 func (r *Addr) GetMeta() meta    { return r.Meta }
 
-func (a *Addr) Validate(sys *system.System) []TestResult {
-	skip := false
+func (a *Addr) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(AddrResourceKey, skipTypes)
+
 	if a.Timeout == 0 {
 		a.Timeout = 500
 	}

--- a/resource/command.go
+++ b/resource/command.go
@@ -32,8 +32,11 @@ func init() {
 	registerResource(CommandResourceKey, &Command{})
 }
 
-func (c *Command) ID() string      { return c.Command }
-func (c *Command) SetID(id string) { c.Command = id }
+func (c *Command) ID() string       { return c.Command }
+func (c *Command) SetID(id string)  { c.Command = id }
+func (c *Command) SetSkip()         { c.Skip = true }
+func (c *Command) TypeKey() string  { return CommandResourceKey }
+func (c *Command) TypeName() string { return CommandResourceName }
 
 func (c *Command) GetTitle() string { return c.Title }
 func (c *Command) GetMeta() meta    { return c.Meta }
@@ -44,14 +47,11 @@ func (c *Command) GetExec() string {
 	return c.Command
 }
 
-func (c *Command) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(CommandResourceKey, skipTypes)
+func (c *Command) Validate(sys *system.System) []TestResult {
+	skip := c.Skip
 
 	if c.Timeout == 0 {
 		c.Timeout = 10000
-	}
-	if c.Skip {
-		skip = true
 	}
 
 	var results []TestResult

--- a/resource/command.go
+++ b/resource/command.go
@@ -23,6 +23,15 @@ type Command struct {
 	Skip       bool     `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	CommandResourceKey  = "command"
+	CommandResourceName = "Command"
+)
+
+func init() {
+	registerResource(CommandResourceKey, &Command{})
+}
+
 func (c *Command) ID() string      { return c.Command }
 func (c *Command) SetID(id string) { c.Command = id }
 
@@ -35,8 +44,9 @@ func (c *Command) GetExec() string {
 	return c.Command
 }
 
-func (c *Command) Validate(sys *system.System) []TestResult {
-	skip := false
+func (c *Command) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(CommandResourceKey, skipTypes)
+
 	if c.Timeout == 0 {
 		c.Timeout = 10000
 	}

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -29,25 +29,24 @@ func init() {
 	registerResource(DNSResourceKey, &DNS{})
 }
 
-func (d *DNS) ID() string      { return d.Host }
-func (d *DNS) SetID(id string) { d.Host = id }
-
+func (d *DNS) ID() string       { return d.Host }
+func (d *DNS) SetID(id string)  { d.Host = id }
+func (d *DNS) SetSkip()         { d.Skip = true }
+func (d *DNS) TypeKey() string  { return DNSResourceKey }
+func (d *DNS) TypeName() string { return DNSResourceName }
 func (d *DNS) GetTitle() string { return d.Title }
 func (d *DNS) GetMeta() meta    { return d.Meta }
 
-func (d *DNS) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(DNSResourceKey, skipTypes)
+func (d *DNS) Validate(sys *system.System) []TestResult {
+	skip := d.Skip
 	if d.Timeout == 0 {
 		d.Timeout = 500
-	}
-	if d.Skip {
-		skip = true
 	}
 
 	sysDNS := sys.NewDNS(d.Host, sys, util.Config{Timeout: time.Duration(d.Timeout) * time.Millisecond, Server: d.Server})
 
 	var results []TestResult
-	// Backwards copatibility hack for now
+	// Backwards compatibility hack for now
 	if d.Resolvable == nil {
 		d.Resolvable = d.Resolveable
 	}

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -20,14 +20,23 @@ type DNS struct {
 	Skip        bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	DNSResourceKey  = "dns"
+	DNSResourceName = "DNS"
+)
+
+func init() {
+	registerResource(DNSResourceKey, &DNS{})
+}
+
 func (d *DNS) ID() string      { return d.Host }
 func (d *DNS) SetID(id string) { d.Host = id }
 
 func (d *DNS) GetTitle() string { return d.Title }
 func (d *DNS) GetMeta() meta    { return d.Meta }
 
-func (d *DNS) Validate(sys *system.System) []TestResult {
-	skip := false
+func (d *DNS) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(DNSResourceKey, skipTypes)
 	if d.Timeout == 0 {
 		d.Timeout = 500
 	}

--- a/resource/file.go
+++ b/resource/file.go
@@ -32,19 +32,18 @@ func init() {
 	registerResource(FileResourceKey, &File{})
 }
 
-func (f *File) ID() string      { return f.Path }
-func (f *File) SetID(id string) { f.Path = id }
+func (f *File) ID() string       { return f.Path }
+func (f *File) SetID(id string)  { f.Path = id }
+func (f *File) SetSkip()         { f.Skip = true }
+func (f *File) TypeKey() string  { return FileResourceKey }
+func (f *File) TypeName() string { return FileResourceName }
 
 func (f *File) GetTitle() string { return f.Title }
 func (f *File) GetMeta() meta    { return f.Meta }
 
-func (f *File) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(FileResourceKey, skipTypes)
+func (f *File) Validate(sys *system.System) []TestResult {
+	skip := f.Skip
 	sysFile := sys.NewFile(f.Path, sys, util.Config{})
-
-	if f.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(f, "exists", f.Exists, sysFile.Exists, skip))

--- a/resource/file.go
+++ b/resource/file.go
@@ -23,14 +23,23 @@ type File struct {
 	Skip     bool     `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	FileResourceKey  = "file"
+	FileResourceName = "File"
+)
+
+func init() {
+	registerResource(FileResourceKey, &File{})
+}
+
 func (f *File) ID() string      { return f.Path }
 func (f *File) SetID(id string) { f.Path = id }
 
 func (f *File) GetTitle() string { return f.Title }
 func (f *File) GetMeta() meta    { return f.Meta }
 
-func (f *File) Validate(sys *system.System) []TestResult {
-	skip := false
+func (f *File) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(FileResourceKey, skipTypes)
 	sysFile := sys.NewFile(f.Path, sys, util.Config{})
 
 	if f.Skip {

--- a/resource/gossfile.go
+++ b/resource/gossfile.go
@@ -20,13 +20,16 @@ func init() {
 	registerResource(GossFileResourceKey, &Gossfile{})
 }
 
-func (g *Gossfile) ID() string      { return g.Path }
-func (g *Gossfile) SetID(id string) { g.Path = id }
+func (g *Gossfile) ID() string       { return g.Path }
+func (g *Gossfile) SetID(id string)  { g.Path = id }
+func (g *Gossfile) SetSkip()         {}
+func (g *Gossfile) TypeKey() string  { return GossFileResourceKey }
+func (g *Gossfile) TypeName() string { return GossFileResourceName }
 
 func (g *Gossfile) GetTitle() string { return g.Title }
 func (g *Gossfile) GetMeta() meta    { return g.Meta }
 
-func (g *Gossfile) Validate(sys *system.System, skipTypes []string) []TestResult {
+func (g *Gossfile) Validate(sys *system.System) []TestResult {
 	return []TestResult{}
 }
 

--- a/resource/gossfile.go
+++ b/resource/gossfile.go
@@ -11,13 +11,22 @@ type Gossfile struct {
 	Path  string `json:"-" yaml:"-"`
 }
 
+const (
+	GossFileResourceKey  = "gossfile"
+	GossFileResourceName = "Gossfile"
+)
+
+func init() {
+	registerResource(GossFileResourceKey, &Gossfile{})
+}
+
 func (g *Gossfile) ID() string      { return g.Path }
 func (g *Gossfile) SetID(id string) { g.Path = id }
 
 func (g *Gossfile) GetTitle() string { return g.Title }
 func (g *Gossfile) GetMeta() meta    { return g.Meta }
 
-func (g *Gossfile) Validate(sys *system.System) []TestResult {
+func (g *Gossfile) Validate(sys *system.System, skipTypes []string) []TestResult {
 	return []TestResult{}
 }
 

--- a/resource/group.go
+++ b/resource/group.go
@@ -17,27 +17,25 @@ type Group struct {
 }
 
 const (
-	GroupFileResourceKey  = "group"
-	GroupFileResourceName = "Group"
+	GroupResourceKey  = "group"
+	GroupResourceName = "Group"
 )
 
 func init() {
-	registerResource(GroupFileResourceKey, &Group{})
+	registerResource(GroupResourceKey, &Group{})
 }
 
-func (g *Group) ID() string      { return g.Groupname }
-func (g *Group) SetID(id string) { g.Groupname = id }
-
+func (g *Group) ID() string       { return g.Groupname }
+func (g *Group) SetID(id string)  { g.Groupname = id }
+func (g *Group) SetSkip()         { g.Skip = true }
+func (g *Group) TypeKey() string  { return GroupResourceKey }
+func (g *Group) TypeName() string { return GroupResourceName }
 func (g *Group) GetTitle() string { return g.Title }
 func (g *Group) GetMeta() meta    { return g.Meta }
 
-func (g *Group) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(GroupFileResourceKey, skipTypes)
+func (g *Group) Validate(sys *system.System) []TestResult {
+	skip := g.Skip
 	sysgroup := sys.NewGroup(g.Groupname, sys, util.Config{})
-
-	if g.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(g, "exists", g.Exists, sysgroup.Exists, skip))

--- a/resource/group.go
+++ b/resource/group.go
@@ -16,14 +16,23 @@ type Group struct {
 	Skip      bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	GroupFileResourceKey  = "group"
+	GroupFileResourceName = "Group"
+)
+
+func init() {
+	registerResource(GroupFileResourceKey, &Group{})
+}
+
 func (g *Group) ID() string      { return g.Groupname }
 func (g *Group) SetID(id string) { g.Groupname = id }
 
 func (g *Group) GetTitle() string { return g.Title }
 func (g *Group) GetMeta() meta    { return g.Meta }
 
-func (g *Group) Validate(sys *system.System) []TestResult {
-	skip := false
+func (g *Group) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(GroupFileResourceKey, skipTypes)
 	sysgroup := sys.NewGroup(g.Groupname, sys, util.Config{})
 
 	if g.Skip {

--- a/resource/http.go
+++ b/resource/http.go
@@ -41,21 +41,24 @@ func init() {
 
 func (u *HTTP) ID() string { return u.HTTP }
 
-func (u *HTTP) SetID(id string) { u.HTTP = id }
+func (u *HTTP) SetID(id string)  { u.HTTP = id }
+func (u *HTTP) SetSkip()         { u.Skip = true }
+func (u *HTTP) TypeKey() string  { return HTTPResourceKey }
+func (u *HTTP) TypeName() string { return HTTPResourceName }
 
 // FIXME: Can this be refactored?
-func (r *HTTP) GetTitle() string { return r.Title }
-func (r *HTTP) GetMeta() meta    { return r.Meta }
+func (u *HTTP) GetTitle() string { return u.Title }
+func (u *HTTP) GetMeta() meta    { return u.Meta }
 
-func (r *HTTP) getURL() string {
-	if r.URL != "" {
-		return r.URL
+func (u *HTTP) getURL() string {
+	if u.URL != "" {
+		return u.URL
 	}
-	return r.HTTP
+	return u.HTTP
 }
 
-func (u *HTTP) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(HTTPResourceKey, skipTypes)
+func (u *HTTP) Validate(sys *system.System) []TestResult {
+	skip := u.Skip
 	if u.Timeout == 0 {
 		u.Timeout = 5000
 	}
@@ -69,10 +72,6 @@ func (u *HTTP) Validate(sys *system.System, skipTypes []string) []TestResult {
 		RequestHeader: u.RequestHeader, RequestBody: u.RequestBody, Method: u.Method})
 	sysHTTP.SetAllowInsecure(u.AllowInsecure)
 	sysHTTP.SetNoFollowRedirects(u.NoFollowRedirects)
-
-	if u.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(u, "status", u.Status, sysHTTP.Status, skip))

--- a/resource/http.go
+++ b/resource/http.go
@@ -30,6 +30,15 @@ type HTTP struct {
 	Proxy             string   `json:"proxy,omitempty" yaml:"proxy,omitempty"`
 }
 
+const (
+	HTTPResourceKey  = "http"
+	HTTPResourceName = "HTTP"
+)
+
+func init() {
+	registerResource(HTTPResourceKey, &HTTP{})
+}
+
 func (u *HTTP) ID() string { return u.HTTP }
 
 func (u *HTTP) SetID(id string) { u.HTTP = id }
@@ -45,8 +54,8 @@ func (r *HTTP) getURL() string {
 	return r.HTTP
 }
 
-func (u *HTTP) Validate(sys *system.System) []TestResult {
-	skip := false
+func (u *HTTP) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(HTTPResourceKey, skipTypes)
 	if u.Timeout == 0 {
 		u.Timeout = 5000
 	}

--- a/resource/interface.go
+++ b/resource/interface.go
@@ -24,20 +24,19 @@ func init() {
 	registerResource(InterfaceResourceKey, &Interface{})
 }
 
-func (i *Interface) ID() string      { return i.Name }
-func (i *Interface) SetID(id string) { i.Name = id }
+func (i *Interface) ID() string       { return i.Name }
+func (i *Interface) SetID(id string)  { i.Name = id }
+func (i *Interface) SetSkip()         { i.Skip = true }
+func (i *Interface) TypeKey() string  { return InterfaceResourceKey }
+func (i *Interface) TypeName() string { return InterfaceResourceName }
 
 // FIXME: Can this be refactored?
 func (i *Interface) GetTitle() string { return i.Title }
 func (i *Interface) GetMeta() meta    { return i.Meta }
 
-func (i *Interface) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(InterfaceResourceKey, skipTypes)
+func (i *Interface) Validate(sys *system.System) []TestResult {
+	skip := i.Skip
 	sysInterface := sys.NewInterface(i.Name, sys, util.Config{})
-
-	if i.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(i, "exists", i.Exists, sysInterface.Exists, skip))

--- a/resource/interface.go
+++ b/resource/interface.go
@@ -15,6 +15,15 @@ type Interface struct {
 	Skip   bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	InterfaceResourceKey  = "interface"
+	InterfaceResourceName = "Interface"
+)
+
+func init() {
+	registerResource(InterfaceResourceKey, &Interface{})
+}
+
 func (i *Interface) ID() string      { return i.Name }
 func (i *Interface) SetID(id string) { i.Name = id }
 
@@ -22,8 +31,8 @@ func (i *Interface) SetID(id string) { i.Name = id }
 func (i *Interface) GetTitle() string { return i.Title }
 func (i *Interface) GetMeta() meta    { return i.Meta }
 
-func (i *Interface) Validate(sys *system.System) []TestResult {
-	skip := false
+func (i *Interface) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(InterfaceResourceKey, skipTypes)
 	sysInterface := sys.NewInterface(i.Name, sys, util.Config{})
 
 	if i.Skip {

--- a/resource/kernel_param.go
+++ b/resource/kernel_param.go
@@ -12,6 +12,15 @@ type KernelParam struct {
 	Value matcher `json:"value" yaml:"value"`
 }
 
+const (
+	KernelParamResourceKey  = "kernel-param"
+	KernelParamResourceName = "KernelParam"
+)
+
+func init() {
+	registerResource(KernelParamResourceKey, &KernelParam{})
+}
+
 func (a *KernelParam) ID() string      { return a.Key }
 func (a *KernelParam) SetID(id string) { a.Key = id }
 
@@ -19,8 +28,8 @@ func (a *KernelParam) SetID(id string) { a.Key = id }
 func (r *KernelParam) GetTitle() string { return r.Title }
 func (r *KernelParam) GetMeta() meta    { return r.Meta }
 
-func (a *KernelParam) Validate(sys *system.System) []TestResult {
-	skip := false
+func (a *KernelParam) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(KernelParamResourceKey, skipTypes)
 	sysKernelParam := sys.NewKernelParam(a.Key, sys, util.Config{})
 
 	var results []TestResult

--- a/resource/kernel_param.go
+++ b/resource/kernel_param.go
@@ -10,6 +10,7 @@ type KernelParam struct {
 	Meta  meta    `json:"meta,omitempty" yaml:"meta,omitempty"`
 	Key   string  `json:"-" yaml:"-"`
 	Value matcher `json:"value" yaml:"value"`
+	Skip  bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
 const (
@@ -21,15 +22,18 @@ func init() {
 	registerResource(KernelParamResourceKey, &KernelParam{})
 }
 
-func (a *KernelParam) ID() string      { return a.Key }
-func (a *KernelParam) SetID(id string) { a.Key = id }
+func (a *KernelParam) ID() string       { return a.Key }
+func (a *KernelParam) SetID(id string)  { a.Key = id }
+func (a *KernelParam) SetSkip()         { a.Skip = true }
+func (a *KernelParam) TypeKey() string  { return KernelParamResourceKey }
+func (a *KernelParam) TypeName() string { return KernelParamResourceName }
 
 // FIXME: Can this be refactored?
-func (r *KernelParam) GetTitle() string { return r.Title }
-func (r *KernelParam) GetMeta() meta    { return r.Meta }
+func (a *KernelParam) GetTitle() string { return a.Title }
+func (a *KernelParam) GetMeta() meta    { return a.Meta }
 
-func (a *KernelParam) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(KernelParamResourceKey, skipTypes)
+func (a *KernelParam) Validate(sys *system.System) []TestResult {
+	skip := a.Skip
 	sysKernelParam := sys.NewKernelParam(a.Key, sys, util.Config{})
 
 	var results []TestResult

--- a/resource/matching.go
+++ b/resource/matching.go
@@ -27,7 +27,7 @@ func (a *Matching) SetID(id string) { a.Id = id }
 func (r *Matching) GetTitle() string { return r.Title }
 func (r *Matching) GetMeta() meta    { return r.Meta }
 
-func (a *Matching) Validate(sys *system.System) []TestResult {
+func (a *Matching) Validate(sys *system.System, skipTypes []string) []TestResult {
 	skip := false
 
 	// ValidateValue expects a function

--- a/resource/matching.go
+++ b/resource/matching.go
@@ -18,16 +18,24 @@ type Matching struct {
 	Matches matcher     `json:"matches" yaml:"matches"`
 }
 
+const (
+	MatchingResourceKey  = "mount"
+	MatchingResourceName = "Mount"
+)
+
 type MatchingMap map[string]*Matching
 
-func (a *Matching) ID() string      { return a.Id }
-func (a *Matching) SetID(id string) { a.Id = id }
+func (a *Matching) ID() string       { return a.Id }
+func (a *Matching) SetID(id string)  { a.Id = id }
+func (a *Matching) SetSkip()         {}
+func (a *Matching) TypeKey() string  { return MatchingResourceKey }
+func (a *Matching) TypeName() string { return MatchingResourceName }
 
 // FIXME: Can this be refactored?
 func (r *Matching) GetTitle() string { return r.Title }
 func (r *Matching) GetMeta() meta    { return r.Meta }
 
-func (a *Matching) Validate(sys *system.System, skipTypes []string) []TestResult {
+func (a *Matching) Validate(sys *system.System) []TestResult {
 	skip := false
 
 	// ValidateValue expects a function

--- a/resource/mount.go
+++ b/resource/mount.go
@@ -17,6 +17,15 @@ type Mount struct {
 	Usage      matcher `json:"usage,omitempty" yaml:"usage,omitempty"`
 }
 
+const (
+	MountResourceKey  = "mount"
+	MountResourceName = "Mount"
+)
+
+func init() {
+	registerResource(MountResourceKey, &Mount{})
+}
+
 func (m *Mount) ID() string      { return m.MountPoint }
 func (m *Mount) SetID(id string) { m.MountPoint = id }
 
@@ -24,8 +33,8 @@ func (m *Mount) SetID(id string) { m.MountPoint = id }
 func (m *Mount) GetTitle() string { return m.Title }
 func (m *Mount) GetMeta() meta    { return m.Meta }
 
-func (m *Mount) Validate(sys *system.System) []TestResult {
-	skip := false
+func (m *Mount) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(MountResourceKey, skipTypes)
 	sysMount := sys.NewMount(m.MountPoint, sys, util.Config{})
 
 	if m.Skip {

--- a/resource/mount.go
+++ b/resource/mount.go
@@ -26,20 +26,19 @@ func init() {
 	registerResource(MountResourceKey, &Mount{})
 }
 
-func (m *Mount) ID() string      { return m.MountPoint }
-func (m *Mount) SetID(id string) { m.MountPoint = id }
+func (m *Mount) ID() string       { return m.MountPoint }
+func (m *Mount) SetID(id string)  { m.MountPoint = id }
+func (m *Mount) SetSkip()         { m.Skip = true }
+func (m *Mount) TypeKey() string  { return MountResourceKey }
+func (m *Mount) TypeName() string { return MountResourceName }
 
 // FIXME: Can this be refactored?
 func (m *Mount) GetTitle() string { return m.Title }
 func (m *Mount) GetMeta() meta    { return m.Meta }
 
-func (m *Mount) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(MountResourceKey, skipTypes)
+func (m *Mount) Validate(sys *system.System) []TestResult {
+	skip := m.Skip
 	sysMount := sys.NewMount(m.MountPoint, sys, util.Config{})
-
-	if m.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(m, "exists", m.Exists, sysMount.Exists, skip))

--- a/resource/package.go
+++ b/resource/package.go
@@ -23,19 +23,17 @@ func init() {
 	registerResource(PackageResourceKey, &Package{})
 }
 
-func (p *Package) ID() string      { return p.Name }
-func (p *Package) SetID(id string) { p.Name = id }
-
+func (p *Package) ID() string       { return p.Name }
+func (p *Package) SetID(id string)  { p.Name = id }
+func (p *Package) SetSkip()         { p.Skip = true }
+func (p *Package) TypeKey() string  { return PackageResourceKey }
+func (p *Package) TypeName() string { return PackageResourceName }
 func (p *Package) GetTitle() string { return p.Title }
 func (p *Package) GetMeta() meta    { return p.Meta }
 
-func (p *Package) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(PackageResourceKey, skipTypes)
+func (p *Package) Validate(sys *system.System) []TestResult {
+	skip := p.Skip
 	sysPkg := sys.NewPackage(p.Name, sys, util.Config{})
-
-	if p.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(p, "installed", p.Installed, sysPkg.Installed, skip))

--- a/resource/package.go
+++ b/resource/package.go
@@ -14,14 +14,23 @@ type Package struct {
 	Skip      bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	PackageResourceKey  = "package"
+	PackageResourceName = "Package"
+)
+
+func init() {
+	registerResource(PackageResourceKey, &Package{})
+}
+
 func (p *Package) ID() string      { return p.Name }
 func (p *Package) SetID(id string) { p.Name = id }
 
 func (p *Package) GetTitle() string { return p.Title }
 func (p *Package) GetMeta() meta    { return p.Meta }
 
-func (p *Package) Validate(sys *system.System) []TestResult {
-	skip := false
+func (p *Package) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(PackageResourceKey, skipTypes)
 	sysPkg := sys.NewPackage(p.Name, sys, util.Config{})
 
 	if p.Skip {

--- a/resource/port.go
+++ b/resource/port.go
@@ -23,19 +23,17 @@ func init() {
 	registerResource(PortResourceKey, &Port{})
 }
 
-func (p *Port) ID() string      { return p.Port }
-func (p *Port) SetID(id string) { p.Port = id }
-
+func (p *Port) ID() string       { return p.Port }
+func (p *Port) SetID(id string)  { p.Port = id }
+func (p *Port) SetSkip()         { p.Skip = true }
+func (p *Port) TypeKey() string  { return PortResourceKey }
+func (p *Port) TypeName() string { return PortResourceName }
 func (p *Port) GetTitle() string { return p.Title }
 func (p *Port) GetMeta() meta    { return p.Meta }
 
-func (p *Port) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(PortResourceKey, skipTypes)
+func (p *Port) Validate(sys *system.System) []TestResult {
+	skip := p.Skip
 	sysPort := sys.NewPort(p.Port, sys, util.Config{})
-
-	if p.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(p, "listening", p.Listening, sysPort.Listening, skip))

--- a/resource/port.go
+++ b/resource/port.go
@@ -14,14 +14,23 @@ type Port struct {
 	Skip      bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	PortResourceKey  = "port"
+	PortResourceName = "Port"
+)
+
+func init() {
+	registerResource(PortResourceKey, &Port{})
+}
+
 func (p *Port) ID() string      { return p.Port }
 func (p *Port) SetID(id string) { p.Port = id }
 
 func (p *Port) GetTitle() string { return p.Title }
 func (p *Port) GetMeta() meta    { return p.Meta }
 
-func (p *Port) Validate(sys *system.System) []TestResult {
-	skip := false
+func (p *Port) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(PortResourceKey, skipTypes)
 	sysPort := sys.NewPort(p.Port, sys, util.Config{})
 
 	if p.Skip {

--- a/resource/process.go
+++ b/resource/process.go
@@ -13,14 +13,23 @@ type Process struct {
 	Skip       bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	ProcessResourceKey  = "process"
+	ProcessResourceName = "Process"
+)
+
+func init() {
+	registerResource(ProcessResourceKey, &Process{})
+}
+
 func (p *Process) ID() string      { return p.Executable }
 func (p *Process) SetID(id string) { p.Executable = id }
 
 func (p *Process) GetTitle() string { return p.Title }
 func (p *Process) GetMeta() meta    { return p.Meta }
 
-func (p *Process) Validate(sys *system.System) []TestResult {
-	skip := false
+func (p *Process) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(PortResourceKey, skipTypes)
 	sysProcess := sys.NewProcess(p.Executable, sys, util.Config{})
 
 	if p.Skip {

--- a/resource/process.go
+++ b/resource/process.go
@@ -22,19 +22,17 @@ func init() {
 	registerResource(ProcessResourceKey, &Process{})
 }
 
-func (p *Process) ID() string      { return p.Executable }
-func (p *Process) SetID(id string) { p.Executable = id }
-
+func (p *Process) ID() string       { return p.Executable }
+func (p *Process) SetID(id string)  { p.Executable = id }
+func (p *Process) SetSkip()         { p.Skip = true }
+func (p *Process) TypeKey() string  { return ProcessResourceKey }
+func (p *Process) TypeName() string { return ProcessResourceName }
 func (p *Process) GetTitle() string { return p.Title }
 func (p *Process) GetMeta() meta    { return p.Meta }
 
-func (p *Process) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(PortResourceKey, skipTypes)
+func (p *Process) Validate(sys *system.System) []TestResult {
+	skip := p.Skip
 	sysProcess := sys.NewProcess(p.Executable, sys, util.Config{})
-
-	if p.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(p, "running", p.Running, sysProcess.Running, skip))

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -12,8 +12,11 @@ import (
 )
 
 type Resource interface {
-	Validate(sys *system.System, skipTypes []string) []TestResult
+	Validate(sys *system.System) []TestResult
 	SetID(string)
+	SetSkip()
+	TypeKey() string
+	TypeName() string
 }
 
 var (

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -12,30 +12,20 @@ import (
 )
 
 type Resource interface {
-	Validate(*system.System) []TestResult
+	Validate(sys *system.System, skipTypes []string) []TestResult
 	SetID(string)
 }
 
 var (
 	resourcesMu sync.Mutex
-	resources   = map[string]Resource{
-		"addr":         &Addr{},
-		"command":      &Command{},
-		"dns":          &DNS{},
-		"file":         &File{},
-		"gossfile":     &Gossfile{},
-		"group":        &Group{},
-		"http":         &HTTP{},
-		"interface":    &Interface{},
-		"kernel-param": &KernelParam{},
-		"mount":        &Mount{},
-		"package":      &Package{},
-		"port":         &Port{},
-		"process":      &Process{},
-		"service":      &Service{},
-		"user":         &User{},
-	}
+	resources   = map[string]Resource{}
 )
+
+func registerResource(key string, resource Resource) {
+	resourcesMu.Lock()
+	resources[key] = resource
+	resourcesMu.Unlock()
+}
 
 func Resources() map[string]Resource {
 	return resources

--- a/resource/service.go
+++ b/resource/service.go
@@ -23,19 +23,17 @@ func init() {
 	registerResource(ServiceResourceKey, &Service{})
 }
 
-func (s *Service) ID() string      { return s.Service }
-func (s *Service) SetID(id string) { s.Service = id }
-
+func (s *Service) ID() string       { return s.Service }
+func (s *Service) SetID(id string)  { s.Service = id }
+func (s *Service) SetSkip()         { s.Skip = true }
+func (s *Service) TypeKey() string  { return ServiceResourceKey }
+func (s *Service) TypeName() string { return ServiceResourceName }
 func (s *Service) GetTitle() string { return s.Title }
 func (s *Service) GetMeta() meta    { return s.Meta }
 
-func (s *Service) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(ServiceResourceKey, skipTypes)
+func (s *Service) Validate(sys *system.System) []TestResult {
+	skip := s.Skip
 	sysservice := sys.NewService(s.Service, sys, util.Config{})
-
-	if s.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(s, "enabled", s.Enabled, sysservice.Enabled, skip))

--- a/resource/service.go
+++ b/resource/service.go
@@ -14,14 +14,23 @@ type Service struct {
 	Skip    bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	ServiceResourceKey  = "service"
+	ServiceResourceName = "Service"
+)
+
+func init() {
+	registerResource(ServiceResourceKey, &Service{})
+}
+
 func (s *Service) ID() string      { return s.Service }
 func (s *Service) SetID(id string) { s.Service = id }
 
 func (s *Service) GetTitle() string { return s.Title }
 func (s *Service) GetMeta() meta    { return s.Meta }
 
-func (s *Service) Validate(sys *system.System) []TestResult {
-	skip := false
+func (s *Service) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(ServiceResourceKey, skipTypes)
 	sysservice := sys.NewService(s.Service, sys, util.Config{})
 
 	if s.Skip {

--- a/resource/user.go
+++ b/resource/user.go
@@ -29,19 +29,17 @@ func init() {
 	registerResource(UserResourceKey, &User{})
 }
 
-func (u *User) ID() string      { return u.Username }
-func (u *User) SetID(id string) { u.Username = id }
-
+func (u *User) ID() string       { return u.Username }
+func (u *User) SetID(id string)  { u.Username = id }
+func (u *User) SetSkip()         { u.Skip = true }
+func (u *User) TypeKey() string  { return UserResourceKey }
+func (u *User) TypeName() string { return UserResourceName }
 func (u *User) GetTitle() string { return u.Title }
 func (u *User) GetMeta() meta    { return u.Meta }
 
-func (u *User) Validate(sys *system.System, skipTypes []string) []TestResult {
-	skip := util.IsValueInList(UserResourceKey, skipTypes)
+func (u *User) Validate(sys *system.System) []TestResult {
+	skip := u.Skip
 	sysuser := sys.NewUser(u.Username, sys, util.Config{})
-
-	if u.Skip {
-		skip = true
-	}
 
 	var results []TestResult
 	results = append(results, ValidateValue(u, "exists", u.Exists, sysuser.Exists, skip))

--- a/resource/user.go
+++ b/resource/user.go
@@ -20,14 +20,23 @@ type User struct {
 	Skip     bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 }
 
+const (
+	UserResourceKey  = "user"
+	UserResourceName = "User"
+)
+
+func init() {
+	registerResource(UserResourceKey, &User{})
+}
+
 func (u *User) ID() string      { return u.Username }
 func (u *User) SetID(id string) { u.Username = id }
 
 func (u *User) GetTitle() string { return u.Title }
 func (u *User) GetMeta() meta    { return u.Meta }
 
-func (u *User) Validate(sys *system.System) []TestResult {
-	skip := false
+func (u *User) Validate(sys *system.System, skipTypes []string) []TestResult {
+	skip := util.IsValueInList(UserResourceKey, skipTypes)
 	sysuser := sys.NewUser(u.Username, sys, util.Config{})
 
 	if u.Skip {

--- a/resource/validate.go
+++ b/resource/validate.go
@@ -50,6 +50,7 @@ const (
 
 type TestResult struct {
 	Successful   bool          `json:"successful" yaml:"successful"`
+	Skipped      bool          `json:"skipped" yaml:"skipped"`
 	ResourceId   string        `json:"resource-id" yaml:"resource-id"`
 	ResourceType string        `json:"resource-type" yaml:"resource-type"`
 	Title        string        `json:"title" yaml:"title"`
@@ -82,6 +83,7 @@ func skipResult(typeS string, testType int, id string, title string, meta meta, 
 	return TestResult{
 		Successful:   true,
 		Result:       SKIP,
+		Skipped:      true,
 		ResourceType: typeS,
 		TestType:     testType,
 		ResourceId:   id,
@@ -336,7 +338,7 @@ func ValidateContains(res ResourceRead, property string, expectedValues []string
 	}
 
 	defer func() {
-		//Do we need to close the stream?
+		// Do we need to close the stream?
 		if rc, ok := fh.(io.ReadCloser); ok {
 			rc.Close()
 		}

--- a/serve.go
+++ b/serve.go
@@ -115,7 +115,7 @@ func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outp
 func (h healthHandler) runValidate(outputer outputs.Outputer) res {
 	h.sys = system.New(h.c.PackageManager)
 	iStartTime := time.Now()
-	out := validate(h.sys, h.gossConfig, h.maxConcurrent)
+	out := validate(h.sys, h.gossConfig, h.c.DisabledResourceTypes, h.maxConcurrent)
 	var b bytes.Buffer
 	outputConfig := util.OutputConfig{
 		FormatOptions: h.c.FormatOptions,

--- a/store.go
+++ b/store.go
@@ -3,7 +3,6 @@ package goss
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -53,7 +52,7 @@ func getStoreFormatFromData(data []byte) (int, error) {
 
 // ReadJSON Reads json file returning GossConfig
 func ReadJSON(filePath string) (GossConfig, error) {
-	file, err := ioutil.ReadFile(filePath)
+	file, err := os.ReadFile(filePath)
 	if err != nil {
 		return GossConfig{}, fmt.Errorf("file error: %v", err)
 	}
@@ -97,7 +96,7 @@ func varsFromFile(varsFile string) (map[string]interface{}, error) {
 	if varsFile == "" {
 		return vars, nil
 	}
-	data, err := ioutil.ReadFile(varsFile)
+	data, err := os.ReadFile(varsFile)
 	if err != nil {
 		return vars, err
 	}
@@ -257,7 +256,7 @@ func WriteJSON(filePath string, gossConfig GossConfig) error {
 		return nil
 	}
 
-	if err := ioutil.WriteFile(filePath, jsonData, 0644); err != nil {
+	if err := os.WriteFile(filePath, jsonData, 0644); err != nil {
 		return fmt.Errorf("failed to write %s: %s", filePath, err)
 	}
 

--- a/store_test.go
+++ b/store_test.go
@@ -1,8 +1,8 @@
 package goss
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -220,7 +220,7 @@ func Test_loadVars(t *testing.T) {
 func fileMaker(content string) (string, func()) {
 	bytes := []byte(content)
 
-	f, err := ioutil.TempFile("", "*")
+	f, err := os.CreateTemp("", "*")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/system/system.go
+++ b/system/system.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -182,7 +181,7 @@ func DetectService() string {
 // using. One of "ubuntu", "redhat" (including Centos), "alpine", "arch", or
 // "debian". If it can't decide, it returns an empty string.
 func DetectDistro() string {
-	if b, e := ioutil.ReadFile("/etc/lsb-release"); e == nil && bytes.Contains(b, []byte("Ubuntu")) {
+	if b, e := os.ReadFile("/etc/lsb-release"); e == nil && bytes.Contains(b, []byte("Ubuntu")) {
 		return "ubuntu"
 	} else if isRedhat() {
 		return "redhat"
@@ -205,7 +204,7 @@ func HasCommand(cmd string) bool {
 }
 
 func isLegacySystemd() bool {
-	if b, err := ioutil.ReadFile("/etc/debian_version"); err == nil {
+	if b, err := os.ReadFile("/etc/debian_version"); err == nil {
 		i := bytes.Index(b, []byte("."))
 		if i < 0 {
 			return false

--- a/template.go
+++ b/template.go
@@ -3,7 +3,6 @@ package goss
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -51,7 +50,7 @@ func mkSlice(args ...interface{}) []interface{} {
 }
 
 func readFile(f string) (string, error) {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return "", err
 

--- a/util/config.go
+++ b/util/config.go
@@ -21,37 +21,38 @@ type ConfigOption func(c *Config) error
 // NewConfig can be used to create this which will default to what the CLI assumes
 // and allow manipulation via ConfigOption functions
 type Config struct {
-	AllowInsecure     bool
-	AnnounceToCLI     bool
-	Cache             time.Duration
-	Debug             bool
-	Endpoint          string
-	FormatOptions     []string
-	IgnoreList        []string
-	ListenAddress     string
-	LocalAddress      string
-	MaxConcurrent     int
-	Method            string
-	NoColor           *bool
-	NoFollowRedirects bool
-	OutputFormat      string
-	OutputWriter      io.Writer
-	PackageManager    string
-	Password          string
-	RequestBody       string
-	Proxy             string
-	RequestHeader     []string
-	RetryTimeout      time.Duration
-	Server            string
-	Sleep             time.Duration
-	Spec              string
-	Timeout           time.Duration
-	Username          string
-	CAFile            string
-	CertFile          string
-	KeyFile           string
-	Vars              string
-	VarsInline        string
+	AllowInsecure         bool
+	AnnounceToCLI         bool
+	Cache                 time.Duration
+	Debug                 bool
+	Endpoint              string
+	FormatOptions         []string
+	IgnoreList            []string
+	ListenAddress         string
+	LocalAddress          string
+	MaxConcurrent         int
+	Method                string
+	NoColor               *bool
+	NoFollowRedirects     bool
+	OutputFormat          string
+	OutputWriter          io.Writer
+	PackageManager        string
+	Password              string
+	RequestBody           string
+	Proxy                 string
+	RequestHeader         []string
+	RetryTimeout          time.Duration
+	Server                string
+	Sleep                 time.Duration
+	Spec                  string
+	Timeout               time.Duration
+	Username              string
+	CAFile                string
+	CertFile              string
+	KeyFile               string
+	Vars                  string
+	VarsInline            string
+	DisabledResourceTypes []string
 }
 
 // TimeOutMilliSeconds is the timeout as milliseconds
@@ -62,31 +63,32 @@ func (c *Config) TimeOutMilliSeconds() int {
 // NewConfig creates a default configuration modeled on the defaults the CLI sets, modified using opts
 func NewConfig(opts ...ConfigOption) (rc *Config, err error) {
 	rc = &Config{
-		AllowInsecure:     false,
-		AnnounceToCLI:     false,
-		Cache:             5 * time.Second,
-		Debug:             false,
-		Endpoint:          "/healthz",
-		FormatOptions:     []string{},
-		IgnoreList:        []string{},
-		ListenAddress:     ":8080",
-		LocalAddress:      "",
-		MaxConcurrent:     50,
-		NoColor:           nil,
-		NoFollowRedirects: false,
-		OutputFormat:      "structured", // most appropriate for package usage
-		PackageManager:    "",
-		Password:          "",
-		Proxy:             "",
-		RequestHeader:     nil,
-		RetryTimeout:      0,
-		Server:            "",
-		Sleep:             time.Second,
-		Spec:              "",
-		Timeout:           0,
-		Username:          "",
-		Vars:              "",
-		VarsInline:        "",
+		AllowInsecure:         false,
+		AnnounceToCLI:         false,
+		Cache:                 5 * time.Second,
+		Debug:                 false,
+		Endpoint:              "/healthz",
+		FormatOptions:         []string{},
+		IgnoreList:            []string{},
+		DisabledResourceTypes: []string{},
+		ListenAddress:         ":8080",
+		LocalAddress:          "",
+		MaxConcurrent:         50,
+		NoColor:               nil,
+		NoFollowRedirects:     false,
+		OutputFormat:          "structured", // most appropriate for package usage
+		PackageManager:        "",
+		Password:              "",
+		Proxy:                 "",
+		RequestHeader:         nil,
+		RetryTimeout:          0,
+		Server:                "",
+		Sleep:                 time.Second,
+		Spec:                  "",
+		Timeout:               0,
+		Username:              "",
+		Vars:                  "",
+		VarsInline:            "",
 	}
 
 	// NewConfig() is likely to be used when embedding goss or using as a package
@@ -235,6 +237,14 @@ func WithVarsBytes(v []byte) ConfigOption {
 func WithVarsString(v string) ConfigOption {
 	return func(c *Config) error {
 		c.VarsInline = v
+		return nil
+	}
+}
+
+// WithDisabledResourceTypes ensures that any resource matching types listed will be skipped when validating
+func WithDisabledResourceTypes(t ...string) ConfigOption {
+	return func(c *Config) error {
+		c.DisabledResourceTypes = append(c.DisabledResourceTypes, t...)
 		return nil
 	}
 }

--- a/validate.go
+++ b/validate.go
@@ -3,7 +3,6 @@ package goss
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,7 +31,7 @@ func getGossConfig(vars string, varsInline string, specFile string) (cfg *GossCo
 	if specFile == "-" {
 		source = "STDIN"
 		fh = os.Stdin
-		data, err := ioutil.ReadAll(fh)
+		data, err := io.ReadAll(fh)
 		if err != nil {
 			return nil, err
 		}

--- a/validate.go
+++ b/validate.go
@@ -150,6 +150,10 @@ func validate(sys *system.System, gossConfig GossConfig, skipList []string, maxC
 
 	go func() {
 		for _, t := range gossConfig.Resources() {
+			if util.IsValueInList(t.TypeName(), skipList) || util.IsValueInList(t.TypeKey(), skipList) {
+				t.SetSkip()
+			}
+
 			in <- t
 		}
 		close(in)
@@ -165,7 +169,7 @@ func validate(sys *system.System, gossConfig GossConfig, skipList []string, maxC
 		go func() {
 			defer wg.Done()
 			for f := range in {
-				out <- f.Validate(sys, skipList)
+				out <- f.Validate(sys)
 			}
 		}()
 	}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change

When using Goss as a package it might be desirable to disable a certain resource type - mainly Command - so this adds a new utility `util.WithDisabledResourceTypes()` that can be used to disable a resource type.

Might not be desirable to change the `Validate()` signature but was best I could come up with, let me know if you have alternatives in mind.

Also deals with `ioutil` deprecation.

