### PR TITLE
improve handling of errors in encoded TestResults

### DIFF
--- a/resource/validate.go
+++ b/resource/validate.go
@@ -48,21 +48,32 @@ const (
 	maxScanTokenSize = 10 * 1024 * 1024
 )
 
+type ValidateError string
+
+func (g ValidateError) Error() string { return string(g) }
+func toValidateError(err error) *ValidateError {
+	if err == nil {
+		return nil
+	}
+	ve := ValidateError(err.Error())
+	return &ve
+}
+
 type TestResult struct {
-	Successful   bool          `json:"successful" yaml:"successful"`
-	Skipped      bool          `json:"skipped" yaml:"skipped"`
-	ResourceId   string        `json:"resource-id" yaml:"resource-id"`
-	ResourceType string        `json:"resource-type" yaml:"resource-type"`
-	Title        string        `json:"title" yaml:"title"`
-	Meta         meta          `json:"meta" yaml:"meta"`
-	TestType     int           `json:"test-type" yaml:"test-type"`
-	Result       int           `json:"result" yaml:"result"`
-	Property     string        `json:"property" yaml:"property"`
-	Err          error         `json:"err" yaml:"err"`
-	Expected     []string      `json:"expected" yaml:"expected"`
-	Found        []string      `json:"found" yaml:"found"`
-	Human        string        `json:"human" yaml:"human"`
-	Duration     time.Duration `json:"duration" yaml:"duration"`
+	Successful   bool           `json:"successful" yaml:"successful"`
+	Skipped      bool           `json:"skipped" yaml:"skipped"`
+	ResourceId   string         `json:"resource-id" yaml:"resource-id"`
+	ResourceType string         `json:"resource-type" yaml:"resource-type"`
+	Title        string         `json:"title" yaml:"title"`
+	Meta         meta           `json:"meta" yaml:"meta"`
+	TestType     int            `json:"test-type" yaml:"test-type"`
+	Result       int            `json:"result" yaml:"result"`
+	Property     string         `json:"property" yaml:"property"`
+	Err          *ValidateError `json:"err" yaml:"err"`
+	Expected     []string       `json:"expected" yaml:"expected"`
+	Found        []string       `json:"found" yaml:"found"`
+	Human        string         `json:"human" yaml:"human"`
+	Duration     time.Duration  `json:"duration" yaml:"duration"`
 }
 
 // ToOutcome converts the enum to a human-friendly string.
@@ -149,7 +160,7 @@ func ValidateValue(res ResourceRead, property string, expectedValue interface{},
 			Title:        title,
 			Meta:         meta,
 			Property:     property,
-			Err:          err,
+			Err:          toValidateError(err),
 			Duration:     time.Now().Sub(startTime),
 		}
 	}
@@ -176,7 +187,6 @@ func ValidateValue(res ResourceRead, property string, expectedValue interface{},
 		Expected:     []string{string(expected)},
 		Found:        []string{string(found)},
 		Human:        failMessage,
-		Err:          err,
 		Duration:     time.Now().Sub(startTime),
 	}
 }
@@ -332,7 +342,7 @@ func ValidateContains(res ResourceRead, property string, expectedValues []string
 			Title:        title,
 			Meta:         meta,
 			Property:     property,
-			Err:          err,
+			Err:          toValidateError(err),
 			Duration:     time.Now().Sub(startTime),
 		}
 	}
@@ -377,7 +387,7 @@ func ValidateContains(res ResourceRead, property string, expectedValues []string
 			Title:        title,
 			Meta:         meta,
 			Property:     property,
-			Err:          err,
+			Err:          toValidateError(err),
 			Duration:     time.Now().Sub(startTime),
 		}
 	}

--- a/resource/validate_test.go
+++ b/resource/validate_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -137,5 +138,32 @@ func TestValidateContainsSkip(t *testing.T) {
 		if got.Result != SKIP {
 			t.Errorf("%+v: got %v, want %v", c, got.Result, SKIP)
 		}
+	}
+}
+
+func TestResultMarshaling(t *testing.T) {
+	inFunc := func() (io.Reader, error) {
+		return nil, fmt.Errorf("dummy error")
+	}
+	res := ValidateContains(&FakeResource{}, "", []string{"x"}, inFunc, false)
+	if res.Err == nil {
+		t.Fatalf("Expected to receive an error")
+	}
+	if res.Err.Error() != "dummy error" {
+		t.Fatalf("expected to receive 'dummy error', got: %v", res.Err.Error())
+	}
+
+	rj, _ := json.Marshal(res)
+	res = TestResult{}
+	err := json.Unmarshal(rj, &res)
+	if err != nil {
+		t.Fatalf("could not unmarshal result: %v", err)
+	}
+
+	if res.Err == nil {
+		t.Fatalf("Expected to receive an error")
+	}
+	if res.Err.Error() != "dummy error" {
+		t.Fatalf("expected to receive 'dummy error', got: %v", res.Err.Error())
 	}
 }


### PR DESCRIPTION
Go error does not marshal to a string and cannot be unmarshalled but the TestResult has a error in it and is being marshalled by StructuredResult.

Here we create a basic string based error implementation that goes to json and back cleanly but we make sure tests for err==nil continues to work.

Signed-off-by: R.I.Pienaar <rip@devco.net>
