### PR TITLE
Added: goss-linux-ppc64le binary to release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ script:
 #     - release/goss-linux-arm64.sha256
 #     - release/goss-linux-s390x
 #     - release/goss-linux-s390x.sha256
+#     - release/goss-linux-ppc64le
+#     - release/goss-linux-ppc64le.sha256
 #     - release/goss-windows-amd64.exe
 #     - release/goss-windows-amd64.exe.sha256
 #     - extras/dgoss/dgoss

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-darwin-amd64 release/goss-darwin-arm64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-linux-arm64 release/goss-linux-s390x release/goss-windows-amd64
+build: release/goss-darwin-amd64 release/goss-darwin-arm64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-linux-arm64 release/goss-linux-s390x release/goss-linux-ppc64le release/goss-windows-amd64
 
 gen:
 	$(info INFO: Starting build $@)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
Add goss-linux-ppc64le build

This is based on https://github.com/goss-org/goss/pull/835

I'm not sure if the build system has changed since then.

The ARM64 build has been invaluable and now we also need PPC64LE. I can run the test suite on a PPC64LE machine once I create a build locally. IIRC, there is no CI running tests on anything other than AMD64. For now, here is an PR.