### PR TITLE
feat: Add support for specifying URL Query params in HTTP resource

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -335,6 +335,8 @@ http:
     timeout: 1000
     request-headers: # Set request header values
        - "Content-Type: text/html"
+    request-query-params:
+       foo: 'bar'
     headers: [] # Check http response headers for these patterns (e.g. "Content-Type: text/html")
     request-body: '{"key": "value"}' # request body
     body: [] # Check http response content for these patterns

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -336,7 +336,8 @@ http:
     request-headers: # Set request header values
        - "Content-Type: text/html"
     request-query-params:
-       foo: 'bar'
+       foo:
+          - 'bar'
     headers: [] # Check http response headers for these patterns (e.g. "Content-Type: text/html")
     request-body: '{"key": "value"}' # request body
     body: [] # Check http response content for these patterns

--- a/resource/http.go
+++ b/resource/http.go
@@ -10,26 +10,27 @@ import (
 )
 
 type HTTP struct {
-	Title             string   `json:"title,omitempty" yaml:"title,omitempty"`
-	Meta              meta     `json:"meta,omitempty" yaml:"meta,omitempty"`
-	id                string   `json:"-" yaml:"-"`
-	URL               string   `json:"url,omitempty" yaml:"url,omitempty"`
-	Method            string   `json:"method,omitempty" yaml:"method,omitempty"`
-	Status            matcher  `json:"status" yaml:"status"`
-	AllowInsecure     bool     `json:"allow-insecure" yaml:"allow-insecure"`
-	NoFollowRedirects bool     `json:"no-follow-redirects" yaml:"no-follow-redirects"`
-	Timeout           int      `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	RequestHeader     []string `json:"request-headers,omitempty" yaml:"request-headers,omitempty"`
-	RequestBody       string   `json:"request-body,omitempty" yaml:"request-body,omitempty"`
-	Headers           matcher  `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Body              matcher  `json:"body,omitempty" yaml:"body,omitempty"`
-	Username          string   `json:"username,omitempty" yaml:"username,omitempty"`
-	Password          string   `json:"password,omitempty" yaml:"password,omitempty"`
-	CAFile            string   `json:"ca-file,omitempty" yaml:"ca-file,omitempty"`
-	CertFile          string   `json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
-	KeyFile           string   `json:"key-file,omitempty" yaml:"key-file,omitempty"`
-	Skip              bool     `json:"skip,omitempty" yaml:"skip,omitempty"`
-	Proxy             string   `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	Title              string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta               meta              `json:"meta,omitempty" yaml:"meta,omitempty"`
+	id                 string            `json:"-" yaml:"-"`
+	URL                string            `json:"url,omitempty" yaml:"url,omitempty"`
+	Method             string            `json:"method,omitempty" yaml:"method,omitempty"`
+	Status             matcher           `json:"status" yaml:"status"`
+	AllowInsecure      bool              `json:"allow-insecure" yaml:"allow-insecure"`
+	NoFollowRedirects  bool              `json:"no-follow-redirects" yaml:"no-follow-redirects"`
+	Timeout            int               `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	RequestHeader      []string          `json:"request-headers,omitempty" yaml:"request-headers,omitempty"`
+	RequestBody        string            `json:"request-body,omitempty" yaml:"request-body,omitempty"`
+	RequestQueryParams map[string]string `json:"request-query-params,omitempty" yaml:"request-query-params,omitempty"`
+	Headers            matcher           `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Body               matcher           `json:"body,omitempty" yaml:"body,omitempty"`
+	Username           string            `json:"username,omitempty" yaml:"username,omitempty"`
+	Password           string            `json:"password,omitempty" yaml:"password,omitempty"`
+	CAFile             string            `json:"ca-file,omitempty" yaml:"ca-file,omitempty"`
+	CertFile           string            `json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
+	KeyFile            string            `json:"key-file,omitempty" yaml:"key-file,omitempty"`
+	Skip               bool              `json:"skip,omitempty" yaml:"skip,omitempty"`
+	Proxy              string            `json:"proxy,omitempty" yaml:"proxy,omitempty"`
 }
 
 const (
@@ -75,7 +76,7 @@ func (u *HTTP) Validate(sys *system.System) []TestResult {
 		KeyFile:           u.KeyFile,
 		NoFollowRedirects: u.NoFollowRedirects,
 		Timeout:           time.Duration(u.Timeout) * time.Millisecond, Username: u.Username, Password: u.Password, Proxy: u.Proxy,
-		RequestHeader: u.RequestHeader, RequestBody: u.RequestBody, Method: u.Method})
+		RequestHeader: u.RequestHeader, RequestBody: u.RequestBody, RequestQueryParams: u.RequestQueryParams, Method: u.Method})
 	sysHTTP.SetAllowInsecure(u.AllowInsecure)
 	sysHTTP.SetNoFollowRedirects(u.NoFollowRedirects)
 
@@ -98,17 +99,18 @@ func NewHTTP(sysHTTP system.HTTP, config util.Config) (*HTTP, error) {
 	http := sysHTTP.HTTP()
 	status, err := sysHTTP.Status()
 	u := &HTTP{
-		id:                http,
-		Status:            status,
-		RequestHeader:     []string{},
-		Headers:           nil,
-		Body:              []string{},
-		AllowInsecure:     config.AllowInsecure,
-		NoFollowRedirects: config.NoFollowRedirects,
-		Timeout:           config.TimeOutMilliSeconds(),
-		Username:          config.Username,
-		Password:          config.Password,
-		Proxy:             config.Proxy,
+		id:                 http,
+		Status:             status,
+		RequestHeader:      []string{},
+		RequestQueryParams: nil,
+		Headers:            nil,
+		Body:               []string{},
+		AllowInsecure:      config.AllowInsecure,
+		NoFollowRedirects:  config.NoFollowRedirects,
+		Timeout:            config.TimeOutMilliSeconds(),
+		Username:           config.Username,
+		Password:           config.Password,
+		Proxy:              config.Proxy,
 	}
 	return u, err
 }

--- a/resource/http.go
+++ b/resource/http.go
@@ -10,27 +10,27 @@ import (
 )
 
 type HTTP struct {
-	Title              string            `json:"title,omitempty" yaml:"title,omitempty"`
-	Meta               meta              `json:"meta,omitempty" yaml:"meta,omitempty"`
-	id                 string            `json:"-" yaml:"-"`
-	URL                string            `json:"url,omitempty" yaml:"url,omitempty"`
-	Method             string            `json:"method,omitempty" yaml:"method,omitempty"`
-	Status             matcher           `json:"status" yaml:"status"`
-	AllowInsecure      bool              `json:"allow-insecure" yaml:"allow-insecure"`
-	NoFollowRedirects  bool              `json:"no-follow-redirects" yaml:"no-follow-redirects"`
-	Timeout            int               `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	RequestHeader      []string          `json:"request-headers,omitempty" yaml:"request-headers,omitempty"`
-	RequestBody        string            `json:"request-body,omitempty" yaml:"request-body,omitempty"`
-	RequestQueryParams map[string]string `json:"request-query-params,omitempty" yaml:"request-query-params,omitempty"`
-	Headers            matcher           `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Body               matcher           `json:"body,omitempty" yaml:"body,omitempty"`
-	Username           string            `json:"username,omitempty" yaml:"username,omitempty"`
-	Password           string            `json:"password,omitempty" yaml:"password,omitempty"`
-	CAFile             string            `json:"ca-file,omitempty" yaml:"ca-file,omitempty"`
-	CertFile           string            `json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
-	KeyFile            string            `json:"key-file,omitempty" yaml:"key-file,omitempty"`
-	Skip               bool              `json:"skip,omitempty" yaml:"skip,omitempty"`
-	Proxy              string            `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	Title              string              `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta               meta                `json:"meta,omitempty" yaml:"meta,omitempty"`
+	id                 string              `json:"-" yaml:"-"`
+	URL                string              `json:"url,omitempty" yaml:"url,omitempty"`
+	Method             string              `json:"method,omitempty" yaml:"method,omitempty"`
+	Status             matcher             `json:"status" yaml:"status"`
+	AllowInsecure      bool                `json:"allow-insecure" yaml:"allow-insecure"`
+	NoFollowRedirects  bool                `json:"no-follow-redirects" yaml:"no-follow-redirects"`
+	Timeout            int                 `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	RequestHeader      []string            `json:"request-headers,omitempty" yaml:"request-headers,omitempty"`
+	RequestBody        string              `json:"request-body,omitempty" yaml:"request-body,omitempty"`
+	RequestQueryParams map[string][]string `json:"request-query-params,omitempty" yaml:"request-query-params,omitempty"`
+	Headers            matcher             `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Body               matcher             `json:"body,omitempty" yaml:"body,omitempty"`
+	Username           string              `json:"username,omitempty" yaml:"username,omitempty"`
+	Password           string              `json:"password,omitempty" yaml:"password,omitempty"`
+	CAFile             string              `json:"ca-file,omitempty" yaml:"ca-file,omitempty"`
+	CertFile           string              `json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
+	KeyFile            string              `json:"key-file,omitempty" yaml:"key-file,omitempty"`
+	Skip               bool                `json:"skip,omitempty" yaml:"skip,omitempty"`
+	Proxy              string              `json:"proxy,omitempty" yaml:"proxy,omitempty"`
 }
 
 const (

--- a/system/http.go
+++ b/system/http.go
@@ -30,22 +30,23 @@ type HTTP interface {
 }
 
 type DefHTTP struct {
-	http              string
-	allowInsecure     bool
-	noFollowRedirects bool
-	resp              *http.Response
-	RequestHeader     http.Header
-	RequestBody       string
-	Timeout           int
-	loaded            bool
-	err               error
-	Username          string
-	Password          string
-	CAFile            string
-	CertFile          string
-	KeyFile           string
-	Method            string
-	Proxy             string
+	http               string
+	allowInsecure      bool
+	noFollowRedirects  bool
+	resp               *http.Response
+	RequestHeader      http.Header
+	RequestBody        string
+	RequestQueryParams map[string]string
+	Timeout            int
+	loaded             bool
+	err                error
+	Username           string
+	Password           string
+	CAFile             string
+	CertFile           string
+	KeyFile            string
+	Method             string
+	Proxy              string
 }
 
 func NewDefHTTP(_ context.Context, httpStr string, system *System, config util.Config) HTTP {
@@ -60,19 +61,20 @@ func NewDefHTTP(_ context.Context, httpStr string, system *System, config util.C
 		headers.Add(str[0], str[1])
 	}
 	return &DefHTTP{
-		http:              httpStr,
-		allowInsecure:     config.AllowInsecure,
-		Method:            config.Method,
-		noFollowRedirects: config.NoFollowRedirects,
-		RequestHeader:     headers,
-		RequestBody:       config.RequestBody,
-		Timeout:           config.TimeOutMilliSeconds(),
-		Username:          config.Username,
-		Password:          config.Password,
-		CAFile:            config.CAFile,
-		CertFile:          config.CertFile,
-		KeyFile:           config.KeyFile,
-		Proxy:             config.Proxy,
+		http:               httpStr,
+		allowInsecure:      config.AllowInsecure,
+		Method:             config.Method,
+		noFollowRedirects:  config.NoFollowRedirects,
+		RequestHeader:      headers,
+		RequestBody:        config.RequestBody,
+		RequestQueryParams: config.RequestQueryParams,
+		Timeout:            config.TimeOutMilliSeconds(),
+		Username:           config.Username,
+		Password:           config.Password,
+		CAFile:             config.CAFile,
+		CertFile:           config.CertFile,
+		KeyFile:            config.KeyFile,
+		Proxy:              config.Proxy,
 	}
 }
 
@@ -160,6 +162,14 @@ func (u *DefHTTP) setupReal() error {
 
 	if host := req.Header.Get("Host"); host != "" {
 		req.Host = host
+	}
+
+	if u.RequestQueryParams != nil {
+		qParams := req.URL.Query()
+		for k, v := range u.RequestQueryParams {
+			qParams.Add(k, v)
+		}
+		req.URL.RawQuery = qParams.Encode()
 	}
 
 	if u.Username != "" || u.Password != "" {

--- a/system/http.go
+++ b/system/http.go
@@ -36,7 +36,7 @@ type DefHTTP struct {
 	resp               *http.Response
 	RequestHeader      http.Header
 	RequestBody        string
-	RequestQueryParams map[string]string
+	RequestQueryParams map[string][]string
 	Timeout            int
 	loaded             bool
 	err                error
@@ -166,8 +166,10 @@ func (u *DefHTTP) setupReal() error {
 
 	if u.RequestQueryParams != nil {
 		qParams := req.URL.Query()
-		for k, v := range u.RequestQueryParams {
-			qParams.Add(k, v)
+		for k, params := range u.RequestQueryParams {
+			for _, param := range params {
+				qParams.Add(k, param)
+			}
 		}
 		req.URL.RawQuery = qParams.Encode()
 	}

--- a/util/config.go
+++ b/util/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	RequestBody           string
 	Proxy                 string
 	RequestHeader         []string
+	RequestQueryParams    map[string]string
 	RetryTimeout          time.Duration
 	RunLevel              string
 	Server                string

--- a/util/config.go
+++ b/util/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	RequestBody           string
 	Proxy                 string
 	RequestHeader         []string
-	RequestQueryParams    map[string]string
+	RequestQueryParams    map[string][]string
 	RetryTimeout          time.Duration
 	RunLevel              string
 	Server                string


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [X] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

This P.R adds support for specifying _URL query params_ in the `http` resource.

This will properly handle _URL encoding_ as opposed to specifying _raw query params_ directly in the `url`.


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1013.org.readthedocs.build/en/1013/

<!-- readthedocs-preview goss end -->