### PR TITLE
fix: Use Prometheus standard content-type

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -186,5 +186,9 @@ func (h healthHandler) responseContentType(outputName string) string {
 	if outputName == "json" {
 		return "application/json"
 	}
+	if outputName == "prometheus" {
+		return "text/plain; version=0.0.4"
+	}
+
 	return fmt.Sprintf("%s%s", mediaTypePrefix, outputName)
 }

--- a/serve_test.go
+++ b/serve_test.go
@@ -117,6 +117,15 @@ func TestServeNegotiatingContent(t *testing.T) {
 			expectedHTTPStatus:  http.StatusOK,
 			expectedContentType: "application/json",
 		},
+		"accept prometheus": {
+			acceptHeader: []string{
+				"text/plain; version=0.0.4",
+			},
+			outputFormat:        "prometheus",
+			specFile:            filepath.Join("testdata", "passing.goss.yaml"),
+			expectedHTTPStatus:  http.StatusOK,
+			expectedContentType: "text/plain; version=0.0.4",
+		},
 		"accept header contains vendor-specific output format different from process-level": {
 			acceptHeader: []string{
 				"application/vnd.goss-rspecish",


### PR DESCRIPTION
> Contributors guide: ./CONTRIBUTING.md

Looks like this is missing...?


##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)

### Description of change

fixes #1010 
Use Prometheus standard content-type
https://prometheus.io/docs/instrumenting/exposition_formats/
