### PR TITLE
Update dead link to json schema validators in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ rendered_goss.yaml: fail: process.chrome: skip is required
 rendered_goss.yaml: fail: service.sshd: skip is required
 ```
 
-Full list of available Json schema validators can be found in <https://json-schema.org/implementations.html#validator-command%20line>
+JSON Schema maintains a [table of validators](https://json-schema.org/tools?query=&sortBy=name&sortOrder=ascending&groupBy=toolingTypes&licenses=&languages=&drafts=&toolingTypes=validator&environments=Command+Line&showObsolete=false).
 
 <!-- --8<-- [end:quickstart] -->
 <!-- --8<-- [start:about] -->


### PR DESCRIPTION
No functional changes.
The link to CLI validators was 404'ing.

dead link: https://json-schema.org/implementations.html#validator-command%20line

new link: https://json-schema.org/tools?query=&sortBy=name&sortOrder=ascending&groupBy=toolingTypes&licenses=&languages=&drafts=&toolingTypes=validator&environments=Command+Line&showObsolete=false

<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1025.org.readthedocs.build/en/1025/

<!-- readthedocs-preview goss end -->