### PR TITLE
Set loglevel for the Stale cache logs

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -103,7 +103,7 @@ func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outp
 		log.Printf("[TRACE] Returning cached[%s].", cacheKey)
 		tra = tmp.([][]resource.TestResult)
 	} else {
-		log.Printf("Stale cache[%s], running tests", cacheKey)
+		log.Printf("[INFO] Stale cache[%s], running tests", cacheKey)
 		h.sys = system.New(h.c.PackageManager)
 		tra = h.validate()
 		h.cache.SetDefault(cacheKey, tra)


### PR DESCRIPTION
When the loglevel for a log is not set, the loglevel filter will ignore that and it will be printed regardless of the loglevel.
This will allow the loglevel filter to filter those out when using WARN or ERROR.

More information : https://github.com/goss-org/goss/issues/991

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test` (UNIX) passes. CI will also test this

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
When the loglevel for a log is not set, the loglevel filter will ignore that and it will be printed regardless of the loglevel.
This will allow the loglevel filter to filter those out when using WARN or ERROR.

More information : https://github.com/goss-org/goss/issues/991
