### PR TITLE
Update golang-lint CI to final v1 release: v1.64.8

### DIFF
--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.64.8
 
   coverage:
     needs: [lint]

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ htmlcov:
 
 lint:
 	$(info INFO: Starting build $@)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 	golangci-lint run --timeout 5m $(pkgs) || true
 
 vet:

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -231,7 +231,7 @@ func IsValidFormat(f string) bool {
 
 func GetOutputer(name string) (Outputer, error) {
 	if _, ok := outputers[name]; !ok {
-		return nil, fmt.Errorf("bad output format: " + name)
+		return nil, fmt.Errorf("bad output format: %v", name)
 	}
 	return outputers[name], nil
 }

--- a/outputs/prometheus_test.go
+++ b/outputs/prometheus_test.go
@@ -512,7 +512,7 @@ func TestPrometheusOutput(t *testing.T) {
 			assert.Equal(t, 0, exitCode)
 
 			output := buf.String()
-			t.Logf(output)
+			t.Log(output)
 			for _, metric := range testCase.expectedMetrics {
 				assert.Contains(t, output, metric)
 			}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
This update is needed to cover some spurious failing typecheck golangci-lint tests that start being flagged if the dependencies are upgraded.

Additionally, fix up a few minor issues caught by it.

Just to note, but when I ran `make test-linux-all`  on the master branch, the integration tests aren't working as expected because there have been some changes in the packages in RockyLinux, issues with DNS records exposed by `dnstest.io`, and a few other such issues. I get the same set of issues running on either the master branch or on the PR. It looks like some work is needed to fix the integration tests separately from all this.