### PR TITLE
Normalise whitespace in testcases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[testdata/*]
+trim_trailing_whitespace = false
+
 [*.md]
 indent_size = 4
 

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -62,7 +62,7 @@ func TestMatchers(t *testing.T) {
 				t.Fatal(err)
 			}
 			actualOut := output.String()
-			actualOut = sanitizeOutput(actualOut)
+			actualOut = sanitizeTrailingWhitespace(sanitizeOutput(actualOut))
 
 			if *update {
 				os.WriteFile(outFile, []byte(actualOut), 0644)
@@ -71,7 +71,7 @@ func TestMatchers(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			wantOut := string(wantOutB)
+			wantOut := sanitizeTrailingWhitespace(string(wantOutB))
 			if actualOut != wantOut {
 				assert.Equal(t, wantOut, actualOut)
 			}
@@ -86,4 +86,9 @@ func sanitizeOutput(s string) string {
 	// Remove duration time
 	re := regexp.MustCompile(`\d\.\d\d\ds`)
 	return re.ReplaceAllString(s, "")
+}
+
+func sanitizeTrailingWhitespace(s string) string {
+	re := regexp.MustCompile(` +\n`)
+	return re.ReplaceAllString(s, "\n")
 }

--- a/testdata/out_matching_basic_failing.1.documentation
+++ b/testdata/out_matching_basic_failing.1.documentation
@@ -109,7 +109,7 @@ diff
     @@ -1,2 +1,2 @@
     -this is a test9
     +this is a test1
-     
+
 Matching: basic_string_regexp: matches:
 Expected
     "this is a test"
@@ -156,7 +156,7 @@ Error
     ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:
         <string>: foo bar
         moo cow
-        
+
 Matching: negated_basic_string: matches:
 Expected
     "this is a test"
@@ -338,7 +338,7 @@ diff
     @@ -1,2 +1,2 @@
     -this is a test9
     +this is a test1
-     
+
 
 Matching: basic_string_regexp: matches:
 Expected
@@ -393,7 +393,7 @@ Error
     ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:
         <string>: foo bar
         moo cow
-        
+
 
 Matching: negated_basic_string: matches:
 Expected
@@ -455,5 +455,5 @@ diff
     -^this
     +this is a test
 
-Total Duration: 
+Total Duration:
 Count: 27, Failed: 27, Skipped: 0

--- a/testdata/out_matching_basic_failing.1.rspecish
+++ b/testdata/out_matching_basic_failing.1.rspecish
@@ -125,7 +125,7 @@ diff
     @@ -1,2 +1,2 @@
     -this is a test9
     +this is a test1
-     
+
 
 Matching: basic_string_regexp: matches:
 Expected
@@ -180,7 +180,7 @@ Error
     ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:
         <string>: foo bar
         moo cow
-        
+
 
 Matching: negated_basic_string: matches:
 Expected
@@ -242,5 +242,5 @@ diff
     -^this
     +this is a test
 
-Total Duration: 
+Total Duration:
 Count: 27, Failed: 27, Skipped: 0

--- a/testdata/out_matching_basic_failing.1.tap
+++ b/testdata/out_matching_basic_failing.1.tap
@@ -19,7 +19,7 @@ not ok 17 - Matching: negated_basic_array_consists_of: matches: Expected ["foo",
 not ok 18 - Matching: negated_basic_array_contain_element: matches: Expected ["foo","bar","moo"] not to contain element matching "foo"
 not ok 19 - Matching: negated_basic_array_matchers: matches: Expected ["foo","bar","moo"] to satisfy at least one of these matchers [{"not":{"contain-elements":["foo","bar"]}},{"not":{"contain-elements":["foo","bar"]}},{"not":["foo","bar","moo"]},{"not":{"consist-of":["foo",{"have-prefix":"m"},"bar"]}},{"not":{"contain-element":{"have-prefix":"b"}}}]
 not ok 20 - Matching: negated_basic_int: matches: Expected 42 not to be numerically eq 42
-not ok 21 - Matching: negated_basic_reader: matches: Error ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2. Got: <string>: foo bar moo cow 
+not ok 21 - Matching: negated_basic_reader: matches: Error ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2. Got: <string>: foo bar moo cow
 not ok 22 - Matching: negated_basic_string: matches: Expected "this is a test" not to equal "this is a test"
 not ok 23 - Matching: negatedbasic_len: matches: Expected "123" not to have length 3
 not ok 24 - Matching: negatedbasic_string_contain_substring: matches: Expected "foo" not to contain substring "oo"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

The .editorconfig file leads to trailing whitespace being removed. It's a bit of a coin-toss as to whether the right solution here is to override whitespace trimming for just the `testcase` directory or to instead perform some normalization of the expected and actual strings to trim this whitespace, so I did both.