### PR TITLE
fix: schema description for file type

### DIFF
--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -125,6 +125,10 @@ definitions:
           - file
           - symlink
           - directory
+          - socket
+          - character-device
+          - block-device
+          - pipe
       contains:
         type: array
         description: Check file content for these patterns. can be a string or a pattern
@@ -585,7 +589,7 @@ properties:
 
   file:
     type: object
-    description: "Validates the state of a file, directory, or symbolic link"
+    description: "Validates the state of a file, directory, socket, symbolic link, character-device, block-device, or pipe"
     additionalProperties:
       $ref: "#/definitions/fileTest"
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (not applicable: schema-only change, no code path altered)
- [x] documentation is changed or added (schema description updated)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

This PR updates `docs/schema.yaml` so that the `fileTest.filetype` enum fully reflects all file types that the runtime (`system/file.go`) can return. Previously, the schema only listed `file`, `symlink`, and `directory`. It now includes:

- `file`
- `symlink`
- `directory`
- `socket`
- `character-device`
- `block-device`
- `pipe`

Additionally, the description of the `file` resource was expanded to enumerate these types.

**Motivation:**
Tools (IDEs, schema validators, autocomplete) relying on `docs/schema.yaml` were unaware of valid values like `socket`, causing false validation errors and poorer authoring experience. Aligning the schema with the runtime improves correctness and usability.

**Evidence:**
Supported types are returned by `DefFile.Filetype()` in `system/file.go`:
```go
	switch {
	case fi.Mode()&os.ModeSymlink == os.ModeSymlink:
		return "symlink", nil
	case fi.Mode()&os.ModeDevice == os.ModeDevice:
		if fi.Mode()&os.ModeCharDevice == os.ModeCharDevice {
			return "character-device", nil
		}
		return "block-device", nil
	case fi.Mode()&os.ModeNamedPipe == os.ModeNamedPipe:
		return "pipe", nil
	case fi.Mode()&os.ModeSocket == os.ModeSocket:
		return "socket", nil
	case fi.IsDir():
		return "directory", nil
	case fi.Mode().IsRegular():
		return "file", nil
	}
```


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1041.org.readthedocs.build/en/1041/

<!-- readthedocs-preview goss end -->