### PR TITLE
fix: close HTTP response bodies to prevent OOM with many checks

### DIFF
--- a/resource/http.go
+++ b/resource/http.go
@@ -78,6 +78,7 @@ func (u *HTTP) Validate(sys *system.System) []TestResult {
 		RequestHeader: u.RequestHeader, RequestBody: u.RequestBody, Method: u.Method})
 	sysHTTP.SetAllowInsecure(u.AllowInsecure)
 	sysHTTP.SetNoFollowRedirects(u.NoFollowRedirects)
+	defer sysHTTP.Close()
 
 	var results []TestResult
 	results = append(results, ValidateValue(u, "status", u.Status, sysHTTP.Status, skip))

--- a/system/http.go
+++ b/system/http.go
@@ -27,6 +27,7 @@ type HTTP interface {
 	Exists() (bool, error)
 	SetAllowInsecure(bool)
 	SetNoFollowRedirects(bool)
+	Close() error
 }
 
 type DefHTTP struct {
@@ -216,6 +217,13 @@ func (u *DefHTTP) Body() (io.Reader, error) {
 	}
 
 	return u.resp.Body, nil
+}
+
+func (u *DefHTTP) Close() error {
+	if u.resp != nil && u.resp.Body != nil {
+		return u.resp.Body.Close()
+	}
+	return nil
 }
 
 func hasUserAgentHeader(headers []string) bool {

--- a/system/http_test.go
+++ b/system/http_test.go
@@ -1,0 +1,42 @@
+package system
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestDefHTTPCloseClosesBodyAfterBodyRead(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("ok")}
+	httpResource := &DefHTTP{
+		loaded: true,
+		resp: &http.Response{
+			Body: body,
+		},
+	}
+
+	reader, err := httpResource.Body()
+	if err != nil {
+		t.Fatalf("Body() returned error: %v", err)
+	}
+	if _, err := io.ReadAll(reader); err != nil {
+		t.Fatalf("ReadAll() returned error: %v", err)
+	}
+	if err := httpResource.Close(); err != nil {
+		t.Fatalf("Close() returned error: %v", err)
+	}
+	if !body.closed {
+		t.Fatal("Close() did not close the response body")
+	}
+}


### PR DESCRIPTION
When running 100+ HTTP checks concurrently, response bodies were not always closed after validation. This caused unclosed TCP connections to accumulate, holding TLS state and transport buffers until the client timeout expired, leading to OOM kills under memory limits.

##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

### Description of change
Fixes OOM when goss is configured with many HTTP checks and limited RAM.

- Add `Close()` to the `system.HTTP` interface and `DefHTTP`
- Defer `sysHTTP.Close()` from HTTP resource validation for guaranteed cleanup
- Always close `resp.Body` when `Close()` is called, including after a body matcher reads it
- Add a unit test covering close-after-body-read behavior