### PR TITLE
Restore old error messages for the ContainElements matcher

### DIFF
--- a/matchers/contain_elements_matcher.go
+++ b/matchers/contain_elements_matcher.go
@@ -2,7 +2,10 @@ package matchers
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 
+	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/matchers"
 	"github.com/samber/lo"
 )
@@ -18,6 +21,14 @@ func ContainElements(elements ...interface{}) GossMatcher {
 		},
 	}
 }
+
+func (m *ContainElementsMatcher) Match(actual any) (success bool, err error) {
+	if !isArrayOrSlice(actual) && !isMap(actual) {
+		return false, fmt.Errorf("ContainElements matcher expects an array/slice/map.  Got:\n%s", format.Object(actual, 1))
+	}
+	return m.ContainElementsMatcher.Match(actual)
+}
+
 func (m *ContainElementsMatcher) FailureResult(actual interface{}) MatcherResult {
 	missingElements := getUnexported(m, "missingElements")
 	missingEl, ok := missingElements.([]interface{})
@@ -32,19 +43,37 @@ func (m *ContainElementsMatcher) FailureResult(actual interface{}) MatcherResult
 		MissingElements: missingElements,
 		FoundElements:   foundElements,
 	}
-
 }
+
 func (m *ContainElementsMatcher) NegatedFailureResult(actual interface{}) MatcherResult {
 	return MatcherResult{
 		Actual:   actual,
 		Message:  "not to contain elements matching",
 		Expected: m.Elements,
 	}
-
 }
 
 func (m *ContainElementsMatcher) MarshalJSON() ([]byte, error) {
 	j := make(map[string]interface{})
 	j["contain-elements"] = m.Elements
 	return json.Marshal(j)
+}
+
+func isMap(a any) bool {
+	if a == nil {
+		return false
+	}
+	return reflect.TypeOf(a).Kind() == reflect.Map
+}
+
+func isArrayOrSlice(a any) bool {
+	if a == nil {
+		return false
+	}
+	switch reflect.TypeOf(a).Kind() {
+	case reflect.Array, reflect.Slice:
+		return true
+	default:
+		return false
+	}
 }

--- a/testdata/out_matching_basic_failing.1.documentation
+++ b/testdata/out_matching_basic_failing.1.documentation
@@ -153,7 +153,7 @@ not to be numerically eq
     42
 Matching: negated_basic_reader: matches:
 Error
-    ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:
+    ContainElements matcher expects an array/slice/map.  Got:
         <string>: foo bar
         moo cow
         
@@ -390,7 +390,7 @@ not to be numerically eq
 
 Matching: negated_basic_reader: matches:
 Error
-    ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:
+    ContainElements matcher expects an array/slice/map.  Got:
         <string>: foo bar
         moo cow
         

--- a/testdata/out_matching_basic_failing.1.rspecish
+++ b/testdata/out_matching_basic_failing.1.rspecish
@@ -177,7 +177,7 @@ not to be numerically eq
 
 Matching: negated_basic_reader: matches:
 Error
-    ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:
+    ContainElements matcher expects an array/slice/map.  Got:
         <string>: foo bar
         moo cow
         

--- a/testdata/out_matching_basic_failing.1.tap
+++ b/testdata/out_matching_basic_failing.1.tap
@@ -19,7 +19,7 @@ not ok 17 - Matching: negated_basic_array_consists_of: matches: Expected ["foo",
 not ok 18 - Matching: negated_basic_array_contain_element: matches: Expected ["foo","bar","moo"] not to contain element matching "foo"
 not ok 19 - Matching: negated_basic_array_matchers: matches: Expected ["foo","bar","moo"] to satisfy at least one of these matchers [{"not":{"contain-elements":["foo","bar"]}},{"not":{"contain-elements":["foo","bar"]}},{"not":["foo","bar","moo"]},{"not":{"consist-of":["foo",{"have-prefix":"m"},"bar"]}},{"not":{"contain-element":{"have-prefix":"b"}}}]
 not ok 20 - Matching: negated_basic_int: matches: Expected 42 not to be numerically eq 42
-not ok 21 - Matching: negated_basic_reader: matches: Error ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2. Got: <string>: foo bar moo cow 
+not ok 21 - Matching: negated_basic_reader: matches: Error ContainElements matcher expects an array/slice/map. Got: <string>: foo bar moo cow 
 not ok 22 - Matching: negated_basic_string: matches: Expected "this is a test" not to equal "this is a test"
 not ok 23 - Matching: negatedbasic_len: matches: Expected "123" not to have length 3
 not ok 24 - Matching: negatedbasic_string_contain_substring: matches: Expected "foo" not to contain substring "oo"


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change

Before delegating to the gomega matcher, it checks for whether its argument is a map, array, or slice, which is a subset of the checks done by gomega. As the configuration file won't have an iterator, this precheck means we can deal with the error a bit more appropriately.