### PR TITLE
Decouple the build of the Trivy image from the release image

### DIFF
--- a/.github/workflows/docker-goss.yaml
+++ b/.github/workflows/docker-goss.yaml
@@ -8,9 +8,6 @@ on:
       - "v*"
   workflow_dispatch:
 
-env:
-  PLATFORMS: "linux/amd64,linux/arm64"
-
 jobs:
   goss:
     name: Build and push Docker image
@@ -75,27 +72,13 @@ jobs:
           build-args: |
             GO_VERSION=${{ env.GO_VERSION_FROM_PROJECT }}
             GOSS_VERSION=${{ steps.get-latest-tag.outputs.tag }}-${{ github.ref_name }}+${{ env.COMMIT_SHORT_SHA }}
+          file: ./Dockerfile_trivy
           context: .
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/goss:master
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.PLATFORMS }}
-
-      - name: Build release goss image
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: docker/build-push-action@v7
-        with:
-          build-args: |
-            GO_VERSION=${{ env.GO_VERSION_FROM_PROJECT }}
-            GOSS_VERSION=${{ github.ref_name }}
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/goss:latest
-            ghcr.io/${{ github.repository_owner }}/goss:${{ github.ref_name }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/amd64
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23
+FROM alpine:3.24
 
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/goss /usr/bin/

--- a/Dockerfile_trivy
+++ b/Dockerfile_trivy
@@ -1,0 +1,19 @@
+ARG GO_VERSION
+FROM docker.io/golang:${GO_VERSION}-alpine AS base
+
+ARG GOSS_VERSION=v0.0.0
+WORKDIR /build
+
+RUN --mount=target=. \
+    CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VERSION} -s -w" \
+    -o "/release/goss" \
+    ./cmd/goss
+
+FROM alpine:3.24
+
+COPY --from=base /release/* /usr/bin/
+
+RUN mkdir /goss
+VOLUME /goss


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change

After #1052 was merged, I noticed some build failures with `docker-goss.yaml`. It turned out to have a few problems, some prexisting, and mostly caused by that PR, as I hadn't anticipated some of that pipeline's behaviours.

It had logic for building the release image, but really shouldn't still have. I ought to have removed that as part of the #1052. I've trimmed it back to be just enough to handle pushing the image for Trivy to scan, which necessitated creating a dockerfile specifically for Trivy so it could be solved quickly.

I'm in two minds when it comes to this pipeline. I think the weekly run of the most recent release image with `trivy-schedule.yaml` is probably enough, but I can see the value that also comes from scanning the HEAD of the master branch.

This should make sure that merges to master no longer have any failing workflows.

Incidental changes:

 * It now only builds `linux/amd64`, though if this is an issue, I can partially revert it. This ought to be enough for Trivy though. In testing, I found `docker buildx` would hang during the image build, which is why I made the change.

 * Bump the version of Alpine: Trivy started flagging issues with the base image, so I figure there's no harm in getting both updated.