### PR TITLE
Update the docs to refer to archives and add guidance for using goss in a CI job

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ This will install goss and [dgoss](https://github.com/goss-org/goss/tree/master/
 # Install latest version to /usr/local/bin
 curl -fsSL https://goss.rocks/install | sh
 
-# Install v0.4.8 version to ~/bin
-curl -fsSL https://goss.rocks/install | GOSS_VER=v0.4.8 GOSS_DST=~/bin sh
+# Install v0.4.10 version to ~/bin
+curl -fsSL https://goss.rocks/install | GOSS_VER=v0.4.10 GOSS_DST=~/bin sh
 ```
 
 <!-- --8<-- [end:intro] -->
@@ -56,28 +56,22 @@ curl -fsSL https://goss.rocks/install | GOSS_VER=v0.4.8 GOSS_DST=~/bin sh
 
 ### Manual installation
 
-#### Latest
+!!! warning
 
-```bash
-curl -L https://github.com/goss-org/goss/releases/latest/download/goss-linux-amd64 -o /usr/local/bin/goss
-chmod +rx /usr/local/bin/goss
-
-curl -L https://github.com/goss-org/goss/releases/latest/download/dgoss -o /usr/local/bin/dgoss
-# Alternatively, using the latest master
-# curl -L https://raw.githubusercontent.com/goss-org/goss/master/extras/dgoss/dgoss -o /usr/local/bin/dgoss
-chmod +rx /usr/local/bin/dgoss
-```
+    If you're using goss in a CI pipeline, it's recommended that you don't
+    download the `latest` and instead use a specific release tag. Using the
+    latest release may lead to unexpected behaviour.
 
 #### Specific Version
 
 ```bash
 # See https://github.com/goss-org/goss/releases for release versions
-VERSION=v0.4.8
-curl -L "https://github.com/goss-org/goss/releases/download/${VERSION}/goss-linux-amd64" -o /usr/local/bin/goss
+VERSION=v0.4.10
+curl -L "https://github.com/goss-org/goss/releases/download/${VERSION}/goss_${VERSION#v}_linux_x86_64.tar.gz" | tar xz -C /usr/local/bin goss
 chmod +rx /usr/local/bin/goss
 
 # (optional) dgoss docker wrapper (use 'master' for latest version)
-VERSION=v0.4.8
+VERSION=v0.4.10
 curl -L "https://github.com/goss-org/goss/releases/download/${VERSION}/dgoss" -o /usr/local/bin/dgoss
 chmod +rx /usr/local/bin/dgoss
 ```

--- a/extras/dcgoss/README.md
+++ b/extras/dcgoss/README.md
@@ -5,7 +5,9 @@ containers. It is based on `dgoss`.
 
 ## Usage
 
-`dcgoss [run|edit] <docker_run_params>`
+```plain
+dcgoss [run|edit] <docker_run_params>
+```
 
 ### Run
 
@@ -21,11 +23,15 @@ Container configuration is used from the compose file, for example:
 
 **run:**
 
-`docker-compose up db`
+```sh
+docker-compose up db
+```
 
 **test:**
 
-`dcgoss run db`
+```sh
+dcgoss run db
+```
 
 `dcgoss run` will do the following:
 
@@ -43,7 +49,9 @@ This allows the user to leverage the `goss add|autoadd` commands to write tests 
 
 **Example:**
 
-`dcgoss edit db`
+```sh
+dcgoss edit db
+```
 
 ### Environment vars and defaults
 
@@ -59,7 +67,9 @@ When running in debug mode, the tmp dir with the container output will not be cl
 
 **Example:**
 
-`DEBUG=true dcgoss edit db`
+```sh
+DEBUG=true dcgoss edit db
+```
 
 #### GOSS_PATH
 
@@ -91,7 +101,9 @@ Location of the goss yaml files.
 
 **Example:**
 
-`GOSS_FILES_PATH=db dcgoss edit db`
+```sh
+GOSS_FILES_PATH=db dcgoss edit db
+```
 
 #### GOSS_FILE
 
@@ -99,7 +111,9 @@ Allows to specify a differing name for `goss.yaml`. Useful when the same image i
 
 **Example:**
 
-`GOSS_FILE=goss_config1.yaml dcgoss run db`
+```sh
+GOSS_FILE=goss_config1.yaml dcgoss run db
+```
 
 #### GOSS_VARS
 
@@ -129,4 +143,6 @@ When debugging test execution its beneficual to set both `DEBUG=true` and `GOSS_
 
 **Example:**
 
-`DEBUG=true GOSS_FILES_PATH=db GOSS_WAIT_OPTS="-r 60s -s 5s" dcgoss run db`
+```sh
+DEBUG=true GOSS_FILES_PATH=db GOSS_WAIT_OPTS="-r 60s -s 5s" dcgoss run db
+```

--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -41,7 +41,7 @@ dgoss run ...
 
 ## Usage
 
-```
+```plain
 dgoss [run|edit] <docker_run_params>
 ```
 
@@ -60,11 +60,15 @@ for the dgoss command, for example:
 
 **run:**
 
-`docker run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine`
+```sh
+docker run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine
+```
 
 **test:**
 
-`dgoss run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine`
+```sh
+dgoss run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine
+```
 
 `dgoss run` will do the following:
 
@@ -82,7 +86,9 @@ This allows the user to leverage the `goss add|autoadd` commands to write tests 
 
 **Example:**
 
-`dgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine`
+```sh
+dgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" jenkins:alpine
+```
 
 ### Environment vars and defaults
 
@@ -101,7 +107,9 @@ Note: Debug output of `dgoss` is from `dgoss` shell script and not debug output 
 
 **Example:**
 
-`DEBUG=true dgoss run jenkins:alpine`
+```sh
+DEBUG=true dgoss run jenkins:alpine
+```
 
 #### GOSS_PATH
 

--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -25,7 +25,7 @@ Since goss runs on the target container, dgoss can be used on a Mac OSX system b
 curl -L https://raw.githubusercontent.com/goss-org/goss/master/extras/dgoss/dgoss -o /usr/local/bin/dgoss
 chmod +rx /usr/local/bin/dgoss
 
-# Download desired goss version to your preferred location (e.g. v0.4.8)
+# Download desired goss version to your preferred location (e.g. v0.4.10)
 curl -L "https://github.com/goss-org/goss/releases/download/v0.4.10/goss_0.4.10_linux_x86_64.tar.gz" | tar xz -C ~/Downloads goss
 
 # Set your GOSS_PATH to the above location

--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -26,10 +26,10 @@ curl -L https://raw.githubusercontent.com/goss-org/goss/master/extras/dgoss/dgos
 chmod +rx /usr/local/bin/dgoss
 
 # Download desired goss version to your preferred location (e.g. v0.4.8)
-curl -L https://github.com/goss-org/goss/releases/download/v0.4.8/goss-linux-amd64 -o ~/Downloads/goss-linux-amd64
+curl -L "https://github.com/goss-org/goss/releases/download/v0.4.10/goss_0.4.10_linux_x86_64.tar.gz" | tar xz -C ~/Downloads goss
 
 # Set your GOSS_PATH to the above location
-export GOSS_PATH=~/Downloads/goss-linux-amd64
+export GOSS_PATH=~/Downloads/goss
 
 # Set DGOSS_TEMP_DIR to the tmp directory in your home, since /tmp is private on Mac OSX
 export DGOSS_TEMP_DIR=~/tmp
@@ -41,7 +41,9 @@ dgoss run ...
 
 ## Usage
 
-`dgoss [run|edit] <docker_run_params>`
+```
+dgoss [run|edit] <docker_run_params>
+```
 
 ### Run
 

--- a/extras/kgoss/README.md
+++ b/extras/kgoss/README.md
@@ -102,7 +102,7 @@ on a regular machine.
 
 **Example:**
 
-```
+```sh
 kgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine
 ```
 

--- a/extras/kgoss/README.md
+++ b/extras/kgoss/README.md
@@ -24,53 +24,27 @@ the files and putting them in the right path. To get each of them:
 
 * **kgoss**: Run `curl -sSLO
   https://raw.githubusercontent.com/goss-org/goss/master/extras/kgoss/kgoss`.
-* **goss**: Download the `goss-linux-amd64` asset from
-  <https://github.com/goss-org/goss/releases> and rename it `goss`. Place it
-  in your HOME directory, e.g. `C:\Users\<username>` on Windows; or set the
+* **goss**: Download the `goss_<VERSION>_linux_x86_64.tar.gz` archive from
+  <https://github.com/goss-org/goss/releases> and extract the binary from it
+  with `tar xzf goss_<VERSION>_linux_x86_64.tar.gz goss`. Place it in your
+  HOME directory, e.g. `C:\Users\<username>` on Windows; or set the
   environment variable `GOSS_PATH` to its path.
 
 ### Automatic / CLI
 
 To install from the command line or automatically, use the following commands.
-[jq][] is required to parse the API response and find the release asset's
-download URL.
-
-[jq]: https://stedolan.github.io/jq
-
-First get a GitHub personal access token for accessing the GitHub API from
-<https://github.com/settings/tokens>. Input it in the first
-line below. Set `dest_dir` to a directory in your `PATH` env var.
+Set `GOSS_DST` to a directory in your `PATH` env var.
 
 ```shell
-token=<personal_access_token>
-username=$(whoami)
-dest_dir=${HOME}/bin
+GOSS_VER=v0.4.10
+GOSS_DST=$HOME/bin
 
-host=raw.githubusercontent.com
-repo=goss-org/goss
-# for private repos, replace:
-# host=github.yourcompany.com
-# repo=org-name/goss
-
-## install kgoss
-curl -sSL -u "${username}:${token}" -H 'Accept: application/vnd.github.v3.raw' -o "${dest_dir}/kgoss" \
-  https://${host}/api/v3/repos/${repo}/contents/extras/kgoss/kgoss
-chmod a+rx "${dest_dir}/kgoss"
-
-## install goss
-if [[ ! $(which jq) ]]; then echo "jq is required, get from https://stedolan.github.io/jq"; fi
-version=v0.4.8
-arch=amd64
-host=github.com
-# for private repos, leave `host` blank or same as above:
-# host=github.yourcompany.com
-dl_url=$(curl -sSL -u "${username}:${token}" https://${host}/api/v3/repos/${repo}/releases \
-  | jq -r ".[] | select (.name == \"${version}\") | .assets[] | select (.name == \"goss-linux-${arch}\") | .url")
-curl -sSL -u "${username}:${token}" -H 'Accept: application/octet-stream' -o "${dest_dir}/goss" $dl_url
-chmod a+rx "${dest_dir}/goss"
+curl -L "https://github.com/goss-org/goss/releases/download/$GOSS_VER/dgoss" -o $GOSS_DST/kgoss
+chmod a+rx "$GOSS_DST/kgoss"
+curl -fsSL https://goss.rocks/install | sh
 
 # If `goss` is not in your path, export a GOSS_PATH variable:
-export GOSS_PATH=${dest_dir}/goss
+export GOSS_PATH="$GOSS_DST/goss"
 
 # Now you can use kgoss as described below:
 # kgoss edit ...
@@ -79,7 +53,9 @@ export GOSS_PATH=${dest_dir}/goss
 
 ## Use
 
-`kgoss [run|edit] -i <image_url> [-p | -c "command to run" | -a "args to pass"] [-d "directory to include"]* [-e "k=v"]*`
+```sh
+kgoss [run|edit] -i <image_url> [-p | -c "command to run" | -a "args to pass"] [-d "directory to include"]* [-e "k=v"]*
+```
 
 If none of `-p|-c|-a` are specified the container is run with its configured entry point.
 
@@ -106,7 +82,9 @@ until a certain port is open before executing the tests.
 
 **Example:**
 
-`kgoss run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine`
+```sh
+kgoss run -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine
+```
 
 `kgoss run` will do the following:
 
@@ -124,7 +102,9 @@ on a regular machine.
 
 **Example:**
 
-`kgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine`
+```
+kgoss edit -e JENKINS_OPTS="--httpPort=8080 --httpsPort=-1" -e JAVA_OPTS="-Xmx1048m" -i jenkins:alpine
+```
 
 ## Environment variables
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change

With the change over to GoReleaser for builds, I forgot to update the documentation to refer to archives rather than uncompressed binaries. This corrects that omission, and also adds guidance for the use of goss in CI jobs.

I've also updated any references to `0.4.8` to `0.4.10` so as people aren't testing out an older version, and switched some of the code examples from using inline code to code fences so the documentation renders a little better.

Closes #1088.