### PR TITLE
Fix data races in goss serve and mute the cache-miss log by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 	./ci/go-test.sh
 
 cov:
-	go test -coverpkg=./... -coverprofile=c.out ./...
+	go test -race -coverpkg=./... -coverprofile=c.out ./...
 	# go tool cover -func ./c.out
 
 funcov:

--- a/add.go
+++ b/add.go
@@ -13,15 +13,14 @@ import (
 
 // AddResources is a simple wrapper to add multiple resources
 func AddResources(fileName, resourceName string, keys []string, c *util.Config) error {
-	var err error
-	err = setLogLevel(c)
+	if err := setLogLevel(c); err != nil {
+		return err
+	}
+	format, err := getStoreFormatFromFileName(fileName)
 	if err != nil {
 		return err
 	}
-	outStoreFormat, err = getStoreFormatFromFileName(fileName)
-	if err != nil {
-		return err
-	}
+	setStoreFormat(format)
 
 	var gossConfig GossConfig
 	if _, err := os.Stat(fileName); err == nil {
@@ -96,11 +95,11 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 
 // AutoAddResources is a simple wrapper to add multiple resources
 func AutoAddResources(fileName string, keys []string, c *util.Config) error {
-	var err error
-	outStoreFormat, err = getStoreFormatFromFileName(fileName)
+	format, err := getStoreFormatFromFileName(fileName)
 	if err != nil {
 		return err
 	}
+	setStoreFormat(format)
 
 	var gossConfig GossConfig
 	if _, err = os.Stat(fileName); err == nil {

--- a/ci/go-test.sh
+++ b/ci/go-test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 command -v go
 
-go test -coverpkg=./... ./... -coverprofile="c.out"
+go test -race -coverpkg=./... ./... -coverprofile="c.out"
 
 sed 's|github.com/goss-org/goss/||' <"c.out" >"c.out.tmp"
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,6 +62,23 @@ GLOBAL OPTIONS:
     * `pacman`
     * `rpm`
 
+`--loglevel <level>`, `-L <level>`
+:   Goss logging verbosity level (default: `INFO`).
+    This is a global option: it applies to every command, and may be given either
+    before or after the command name.
+    Lower levels of tracing include all upper levels traces also
+    (ie. `INFO` includes `WARN` and `ERROR`).
+    `level` can be one of:
+
+    * `ERROR` - Critical errors that halt goss or significantly affect its functionality,
+        requiring immediate intervention.
+    * `WARN` - Non-critical issues that may require attention, such as overwritten keys
+        or deprecated features.
+    * `INFO` - General operational messages, useful for tasks where a more structured
+        output is needed (e.g. goss serve).
+    * `DEBUG` - Information useful for the goss user to debug.
+    * `TRACE` - Detailed internal system activities useful for goss developers to debug.
+
 ## Commands
 
 Commands are the actions goss can run.
@@ -266,17 +283,6 @@ The end-point will return the stest results in the format requested and an http 
 `--listen-addr [ip]:port`, `-l [ip]:port`
 :   Address to listen on (default: `:8080`)
 
-`--loglevel <level>`, `-L <level>`
-:   Goss logging verbosity level (default: `INFO`).
-    Lower levels of tracing include all upper levels traces also (ie. `INFO` include `WARN` and `ERROR`).
-    `level` can be one of:
-
-    - `ERROR` - Critical errors that halt goss or significantly affect its functionality, requiring immediate intervention.
-    - `WARN` - Non-critical issues that may require attention, such as overwritten keys or deprecated features.
-    - `INFO` - General operational messages, useful for tasks where a more structured output is needed (e.g. goss serve).
-    - `DEBUG` - Information useful for the goss user to debug.
-    - `TRACE` - Detailed internal system activities useful for goss developers to debug.
-
 `--max-concurrent <num>`
 :   Max number of tests to run concurrently
 
@@ -326,18 +332,6 @@ Exits with status 0 on success, non-0 otherwise.
     - `verbose`  - Gives verbose output. Applies to `nagios` and `prometheus` output
     - `pretty`   - Pretty printing for the `json` output
     - `sort`     - Sorts the results
-
-`--loglevel <level>`, `-L <level>`
-:   Goss logging verbosity level (default: `INFO`).
-    Lower levels of tracing include all upper levels traces also (ie. `INFO` includes `WARN`, `ERROR` and `FATAL` outputs).
-    `level` can be one of:
-
-    - `TRACE` - Print details for each check, successful or not and all incoming healthchecks
-    - `DEBUG` - Print details of summary response to healthchecks including remote IP address, return code and full body
-    - `INFO` - Print summary when all checks run OK
-    - `WARN` - Print summary and corresponding checks when encountering some failures
-    - `ERROR` - Not used for now (will not print anything)
-    - `FATAL` - Not used for now (will not print anything)
 
 `--max-concurrent <num>`
 :   Max number of tests to run concurrently

--- a/logs.go
+++ b/logs.go
@@ -13,22 +13,33 @@ import (
 )
 
 func setLogLevel(c *util.Config) error {
-	filter := &logutils.LevelFilter{
-		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},
-		MinLevel: logutils.LogLevel("INFO"),
-		Writer:   os.Stderr,
+	filter, err := newLogFilter(c.LogLevel, os.Stderr)
+	if err != nil {
+		return err
 	}
 	log.SetFlags(0) // Turn off standard timestamp flags
 	log.SetOutput(&timestampedWriter{filter})
+	log.Printf("[DEBUG] Setting log level to %v", strings.ToUpper(c.LogLevel))
+	return nil
+}
+
+// newLogFilter builds the level filter used to gate goss's log output. Levels
+// are expressed as a prefix on each message (for example "[DEBUG] ..."), so any
+// message logged without one is emitted regardless of the configured level.
+func newLogFilter(level string, w io.Writer) (*logutils.LevelFilter, error) {
+	filter := &logutils.LevelFilter{
+		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},
+		MinLevel: logutils.LogLevel("INFO"),
+		Writer:   w,
+	}
+	want := strings.ToUpper(level)
 	for _, lvl := range filter.Levels {
-		cLvl := strings.ToUpper(c.LogLevel)
-		if string(lvl) == cLvl {
+		if string(lvl) == want {
 			filter.MinLevel = lvl
-			log.Printf("[DEBUG] Setting log level to %v", cLvl)
-			return nil
+			return filter, nil
 		}
 	}
-	return fmt.Errorf("Unsupported log level: %s", c.LogLevel)
+	return nil, fmt.Errorf("Unsupported log level: %s", level)
 }
 
 type timestampedWriter struct {

--- a/logs_test.go
+++ b/logs_test.go
@@ -1,0 +1,105 @@
+package goss
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCacheMissLogIsGatedByLogLevel is the regression test for
+// https://github.com/goss-org/goss/issues/991: the cache-miss message emitted
+// on every health probe could not be muted at any --loglevel, because it was
+// logged without a level prefix for logutils to match on.
+func TestCacheMissLogIsGatedByLogLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		level   string
+		visible bool
+	}{
+		"default INFO mutes it": {level: "INFO", visible: false},
+		"WARN mutes it":         {level: "WARN", visible: false},
+		"ERROR mutes it":        {level: "ERROR", visible: false},
+		"DEBUG shows it":        {level: "DEBUG", visible: true},
+		"TRACE shows it":        {level: "TRACE", visible: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			filter, err := newLogFilter(tc.level, &buf)
+			require.NoError(t, err)
+
+			// Deliberately a local logger: the message must be gated by the
+			// filter itself, not by anything the global logger happens to do.
+			log.New(filter, "", 0).Printf(cacheMissLogFormat, "res")
+
+			if tc.visible {
+				require.Contains(t, buf.String(), "Stale cache[res], running tests",
+					"message should be emitted at level %s", tc.level)
+			} else {
+				require.Empty(t, buf.String(),
+					"message should be muted at level %s", tc.level)
+			}
+		})
+	}
+}
+
+// TestNewLogFilterRejectsUnknownLevel pins the error path, and documents that
+// FATAL is not among the supported levels.
+func TestNewLogFilterRejectsUnknownLevel(t *testing.T) {
+	t.Parallel()
+
+	for _, level := range []string{"FATAL", "", "verbose"} {
+		_, err := newLogFilter(level, &bytes.Buffer{})
+		require.Error(t, err, "level %q should be rejected", level)
+	}
+}
+
+// TestNewLogFilterAcceptsSupportedLevels guards the level list documented in
+// docs/cli.md against drift, and pins both the case-insensitive handling and
+// the "lower levels include the upper ones" contract that docs/cli.md promises.
+//
+// This asserts on what actually reaches the writer rather than on the filter's
+// own fields, so it keeps its meaning if the logging backend is ever swapped
+// out for something that models levels differently.
+func TestNewLogFilterAcceptsSupportedLevels(t *testing.T) {
+	t.Parallel()
+
+	// Ordered most to least verbose: configuring levels[i] must emit exactly
+	// levels[i:] and mute everything before it.
+	levels := []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+
+	for i, configured := range levels {
+		for _, spelling := range []string{configured, strings.ToLower(configured)} {
+			t.Run(spelling, func(t *testing.T) {
+				t.Parallel()
+
+				var buf bytes.Buffer
+				filter, err := newLogFilter(spelling, &buf)
+				require.NoError(t, err, "level %q should be accepted", spelling)
+
+				logger := log.New(filter, "", 0)
+				for _, emitted := range levels {
+					logger.Printf("[%s] %s-message", emitted, emitted)
+				}
+
+				got := buf.String()
+				for j, emitted := range levels {
+					if j >= i {
+						require.Contains(t, got, emitted+"-message",
+							"%s should be emitted when configured at %s", emitted, configured)
+					} else {
+						require.NotContains(t, got, emitted+"-message",
+							"%s should be muted when configured at %s", emitted, configured)
+					}
+				}
+			})
+		}
+	}
+}

--- a/outputs/color.go
+++ b/outputs/color.go
@@ -1,0 +1,52 @@
+package outputs
+
+import (
+	"sync"
+
+	"github.com/fatih/color"
+)
+
+// color.NoColor is a package-level variable in github.com/fatih/color that is
+// read every time one of the colorizing helpers below formats a string.
+//
+// Under `goss serve` the output formatters run concurrently, once per in-flight
+// request, and the machine-readable formatters assign to color.NoColor on every
+// invocation. That combination is a data race: unsynchronised writes from one
+// request against reads from another.
+//
+// Guarding the assignment and the reads with a single RWMutex removes the race
+// while preserving the existing last-writer-wins behaviour.
+var colorMu sync.RWMutex
+
+var (
+	greenFn  = color.New(color.FgGreen).SprintfFunc()
+	redFn    = color.New(color.FgRed).SprintfFunc()
+	yellowFn = color.New(color.FgYellow).SprintfFunc()
+)
+
+// SetNoColor enables or disables ANSI colorization for all goss output. It is
+// safe to call concurrently, and callers outside this package should use it in
+// preference to assigning to color.NoColor directly.
+func SetNoColor(disable bool) {
+	colorMu.Lock()
+	defer colorMu.Unlock()
+	color.NoColor = disable
+}
+
+func green(format string, a ...any) string {
+	return colorize(greenFn, format, a...)
+}
+
+func red(format string, a ...any) string {
+	return colorize(redFn, format, a...)
+}
+
+func yellow(format string, a ...any) string {
+	return colorize(yellowFn, format, a...)
+}
+
+func colorize(f func(string, ...any) string, format string, a ...any) string {
+	colorMu.RLock()
+	defer colorMu.RUnlock()
+	return f(format, a...)
+}

--- a/outputs/color_test.go
+++ b/outputs/color_test.go
@@ -1,0 +1,70 @@
+package outputs
+
+import (
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goss-org/goss/resource"
+	"github.com/goss-org/goss/util"
+)
+
+// TestOutputersAreConcurrencySafe is the regression test for the data race on
+// github.com/fatih/color's package-level NoColor variable.
+//
+// `goss serve` runs an Outputer once per in-flight health probe, and the
+// machine-readable formatters disable colorization on every invocation. Before
+// SetNoColor existed those assignments raced against the colorizing helpers
+// reading the same variable from another request. Run this under -race.
+func TestOutputersAreConcurrencySafe(t *testing.T) {
+	outputers := map[string]Outputer{
+		"json":          Json{},
+		"junit":         JUnit{},
+		"rspecish":      Rspecish{},
+		"documentation": Documentation{},
+		"tap":           Tap{},
+		"nagios":        Nagios{},
+	}
+
+	for name, outputer := range outputers {
+		t.Run(name, func(t *testing.T) {
+			const n = 16
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for range n {
+				go func() {
+					defer wg.Done()
+					outputer.Output(io.Discard, mixedResults(), util.OutputConfig{})
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
+
+// mixedResults returns a closed channel carrying one result of each outcome, so
+// that every colorizing branch of humanizeResult is exercised.
+func mixedResults() <-chan []resource.TestResult {
+	now := time.Now()
+	c := make(chan []resource.TestResult, 1)
+	c <- []resource.TestResult{
+		{
+			Successful: true, Result: resource.SUCCESS, ResourceType: "File",
+			ResourceId: "/tmp", Property: "exists",
+			StartTime: now, EndTime: now,
+		},
+		{
+			Successful: false, Result: resource.FAIL, ResourceType: "File",
+			ResourceId: "/nope", Property: "exists",
+			StartTime: now, EndTime: now,
+		},
+		{
+			Successful: true, Result: resource.SKIP, ResourceType: "File",
+			ResourceId: "/skip", Property: "exists", Skipped: true,
+			StartTime: now, EndTime: now,
+		},
+	}
+	close(c)
+	return c
+}

--- a/outputs/json.go
+++ b/outputs/json.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/goss-org/goss/resource"
 	"github.com/goss-org/goss/util"
 )
@@ -32,7 +31,7 @@ func (r Json) Output(w io.Writer, results <-chan []resource.TestResult,
 
 	var startTime time.Time
 	var endTime time.Time
-	color.NoColor = true
+	SetNoColor(true)
 	testCount := 0
 	failed := 0
 	skipped := 0

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/goss-org/goss/resource"
 	"github.com/goss-org/goss/util"
 )
@@ -28,7 +27,7 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
 	sort := util.IsValueInList(foSort, outConfig.FormatOptions)
 	results = getResults(results, sort)
 
-	color.NoColor = true
+	SetNoColor(true)
 	var testCount, failed, skipped int
 
 	// ISO8601 timeformat

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -13,7 +13,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/fatih/color"
 	"github.com/goss-org/goss/resource"
 	"github.com/goss-org/goss/util"
 	"github.com/pmezard/go-difflib/difflib"
@@ -48,9 +47,6 @@ var (
 	foSort       = "sort"
 )
 
-var green = color.New(color.FgGreen).SprintfFunc()
-var red = color.New(color.FgRed).SprintfFunc()
-var yellow = color.New(color.FgYellow).SprintfFunc()
 var multiple_space = regexp.MustCompile(`\s+`)
 
 func humanizeResult(r resource.TestResult, compact bool, includeRaw bool) string {

--- a/serve.go
+++ b/serve.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/goss-org/goss/outputs"
 	"github.com/goss-org/goss/resource"
 	"github.com/goss-org/goss/system"
@@ -35,7 +34,8 @@ func Serve(c *util.Config) error {
 }
 
 func newHealthHandler(c *util.Config) (*healthHandler, error) {
-	color.NoColor = true
+	// The health endpoint always emits machine-readable output.
+	outputs.SetNoColor(true)
 	cache := cache.New(c.Cache, 30*time.Second)
 
 	cfg, err := getGossConfig(c.VarsFiles, c.VarsInline, c.Spec)

--- a/serve.go
+++ b/serve.go
@@ -17,6 +17,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// cacheMissLogFormat is logged whenever a health probe finds the result cache
+// cold and has to run the test suite. It carries a level prefix so that it can
+// be muted via --loglevel; without one it was emitted unconditionally and
+// flooded the logs of any container being polled by a load balancer.
+const cacheMissLogFormat = "[DEBUG] Stale cache[%s], running tests"
+
 func Serve(c *util.Config) error {
 	err := setLogLevel(c)
 	if err != nil {
@@ -103,7 +109,7 @@ func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outp
 		log.Printf("[TRACE] Returning cached[%s].", cacheKey)
 		tra = tmp.([][]resource.TestResult)
 	} else {
-		log.Printf("Stale cache[%s], running tests", cacheKey)
+		log.Printf(cacheMissLogFormat, cacheKey)
 		h.sys = system.New(h.c.PackageManager)
 		tra = h.validate()
 		h.cache.SetDefault(cacheKey, tra)

--- a/serve_concurrency_test.go
+++ b/serve_concurrency_test.go
@@ -1,0 +1,47 @@
+package goss
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServeHandlesConcurrentRequests drives a single healthHandler from many
+// goroutines, which is what net/http does for every `goss serve` deployment.
+// Its value is under -race: it covers the whole per-request path, so a future
+// change that reaches for process-wide mutable state from a request will be
+// caught here rather than in production.
+func TestServeHandlesConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	// A spec with no subprocesses, so the test stays fast when every goroutine
+	// misses the cache at once.
+	config, err := util.NewConfig(
+		util.WithSpecFile(filepath.Join("testdata", "matching_basic.yaml")),
+		util.WithOutputFormat("json"),
+	)
+	require.NoError(t, err)
+
+	handler, err := newHealthHandler(config)
+	require.NoError(t, err)
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+			if rr.Code != http.StatusOK {
+				t.Errorf("got status %d, want %d", rr.Code, http.StatusOK)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/store.go
+++ b/store.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 
 	"dario.cat/mergo"
 	"gopkg.in/yaml.v3"
@@ -24,9 +25,52 @@ const (
 	YAML
 )
 
-var outStoreFormat = UNSET
-var currentTemplateFilter TemplateFilter
-var debug = false
+// These package-level variables hold state derived from the gossfile currently
+// being processed. `goss serve` and library consumers can drive the load path
+// from more than one goroutine, so every access goes through storeStateMu via
+// the helpers below rather than touching the variables directly.
+var (
+	storeStateMu          sync.RWMutex
+	outStoreFormat        = UNSET
+	currentTemplateFilter TemplateFilter
+	debug                 bool
+)
+
+func setStoreFormat(f int) {
+	storeStateMu.Lock()
+	defer storeStateMu.Unlock()
+	outStoreFormat = f
+}
+
+func storeFormat() int {
+	storeStateMu.RLock()
+	defer storeStateMu.RUnlock()
+	return outStoreFormat
+}
+
+func setTemplateFilter(tf TemplateFilter) {
+	storeStateMu.Lock()
+	defer storeStateMu.Unlock()
+	currentTemplateFilter = tf
+}
+
+func templateFilter() TemplateFilter {
+	storeStateMu.RLock()
+	defer storeStateMu.RUnlock()
+	return currentTemplateFilter
+}
+
+func setDebug(d bool) {
+	storeStateMu.Lock()
+	defer storeStateMu.Unlock()
+	debug = d
+}
+
+func debugEnabled() bool {
+	storeStateMu.RLock()
+	defer storeStateMu.RUnlock()
+	return debug
+}
 
 var (
 	errCannotDetermineFormat = errors.New("unable to determine format from content")
@@ -146,18 +190,18 @@ func varsFromString(varsString string) (map[string]any, error) {
 // ReadJSONData Reads json byte array returning GossConfig
 func ReadJSONData(data []byte, detectFormat bool) (GossConfig, error) {
 	var err error
-	if currentTemplateFilter != nil {
-		data, err = currentTemplateFilter(data)
+	if tf := templateFilter(); tf != nil {
+		data, err = tf(data)
 		if err != nil {
 			return GossConfig{}, err
 		}
-		if debug {
+		if debugEnabled() {
 			fmt.Println("DEBUG: file after text/template render")
 			fmt.Println(string(data))
 		}
 	}
 
-	format := outStoreFormat
+	format := storeFormat()
 	if detectFormat {
 		format, err = getStoreFormatFromData(data)
 		if err != nil {
@@ -176,17 +220,18 @@ func ReadJSONData(data []byte, detectFormat bool) (GossConfig, error) {
 
 // RenderJSON reads json file recursively returning string
 func RenderJSON(c *util.Config) (string, error) {
-	var err error
-	debug = c.Debug
-	currentTemplateFilter, err = NewTemplateFilter(c.VarsFiles, c.VarsInline)
+	setDebug(c.Debug)
+	tf, err := NewTemplateFilter(c.VarsFiles, c.VarsInline)
 	if err != nil {
 		return "", err
 	}
+	setTemplateFilter(tf)
 
-	outStoreFormat, err = getStoreFormatFromFileName(c.Spec)
+	format, err := getStoreFormatFromFileName(c.Spec)
 	if err != nil {
 		return "", err
 	}
+	setStoreFormat(format)
 
 	j, err := ReadJSON(c.Spec)
 	if err != nil {
@@ -296,7 +341,7 @@ func resourcePrint(fileName string, res resource.ResourceRead, announce bool) {
 }
 
 func marshal(gossConfig any) ([]byte, error) {
-	switch outStoreFormat {
+	switch storeFormat() {
 	case JSON:
 		return marshalJSON(gossConfig)
 	case YAML:

--- a/validate.go
+++ b/validate.go
@@ -24,10 +24,11 @@ func getGossConfig(varsFiles []string, varsInline string, specFile string) (cfg 
 	var path, source string
 	var gossConfig GossConfig
 
-	currentTemplateFilter, err = NewTemplateFilter(varsFiles, varsInline)
+	tf, err := NewTemplateFilter(varsFiles, varsInline)
 	if err != nil {
 		return nil, err
 	}
+	setTemplateFilter(tf)
 
 	if specFile == "-" {
 		source = "STDIN"
@@ -36,10 +37,11 @@ func getGossConfig(varsFiles []string, varsInline string, specFile string) (cfg 
 		if err != nil {
 			return nil, err
 		}
-		outStoreFormat, err = getStoreFormatFromData(data)
+		format, err := getStoreFormatFromData(data)
 		if err != nil {
 			return nil, err
 		}
+		setStoreFormat(format)
 
 		gossConfig, err = ReadJSONData(data, true)
 		if err != nil {
@@ -48,10 +50,11 @@ func getGossConfig(varsFiles []string, varsInline string, specFile string) (cfg 
 	} else {
 		source = specFile
 		path = filepath.Dir(specFile)
-		outStoreFormat, err = getStoreFormatFromFileName(specFile)
+		format, err := getStoreFormatFromFileName(specFile)
 		if err != nil {
 			return nil, err
 		}
+		setStoreFormat(format)
 
 		gossConfig, err = ReadJSON(specFile)
 		if err != nil {
@@ -73,10 +76,10 @@ func getGossConfig(varsFiles []string, varsInline string, specFile string) (cfg 
 
 func getOutputer(c *bool, format string) (outputs.Outputer, error) {
 	if c != nil && *c {
-		color.NoColor = true
+		outputs.SetNoColor(true)
 	}
 	if c != nil && !*c {
-		color.NoColor = false
+		outputs.SetNoColor(false)
 	}
 
 	return outputs.GetOutputer(format)


### PR DESCRIPTION
First piece split out of #1054. Self-contained and depends on nothing else.

## Data races in the serve request path

`goss serve` handles each request in its own goroutine, but three pieces of
process-wide state were mutated from the request path with no synchronisation:

- `color.NoColor`, written by `newHealthHandler`, `getOutputer` and the JSON and
  JUnit outputers, read by the color helpers in `outputs`
- `outStoreFormat` and `currentTemplateFilter` in `store.go`, written while
  loading a gossfile and read while rendering one
- `debug` in `store.go`

Two concurrent probes are enough to trip this. `go test -race ./...` fails on a
clean checkout of `master` today:

```
WARNING: DATA RACE
  github.com/goss-org/goss.newHealthHandler()
WARNING: DATA RACE
  github.com/goss-org/goss.getGossConfig()
  github.com/goss-org/goss.newHealthHandler()
WARNING: DATA RACE
  github.com/goss-org/goss.getOutputer()
  github.com/goss-org/goss.newHealthHandler()
FAIL	github.com/goss-org/goss	9.695s
```

The color state moves behind an accessor pair in the new `outputs/color.go`, so
the `fatih/color` global is touched in one place, and the `store.go` globals get
a mutex. Both keep their existing last-writer-wins behaviour. This makes the
hand-off safe; giving each request its own configuration would be a much larger
change and is not attempted here.

## The cache-miss log line could not be muted (#991)

Every cache miss logged `Stale cache[...], running tests` with no level prefix,
so `logutils` let it through at any `--loglevel`. Anything polling the health
endpoint more often than the cache TTL, a load balancer or a Kubernetes probe
for instance, got a line per request with no way to turn it off.

It now carries `[DEBUG]`, so it shows at `DEBUG` and `TRACE` and stays quiet at
the `INFO` default. The cache-hit line beside it has always been `[TRACE]`.

`--loglevel` was also documented twice, under `serve` and under `validate`, with
two different and partly wrong descriptions of the levels, including a `FATAL`
that goss actually rejects. It is a global option and works before or after the
command name, so it is now documented once under "Global options".

Closes #991

## The -race commit

`Run the unit tests with -race` is last so it can be dropped on its own. These
races survived this long because nothing in CI would have caught them: neither
`make cov`, which the coverage job runs, nor `ci/go-test.sh` passed `-race`.

The suite is clean under `-race -count=2` and `make cov` with `-race` takes
about 24s, but that is only verified on darwin. If it goes red elsewhere for
reasons unrelated to this branch, dropping that commit unblocks the rest.

## For anyone looking at log/slog later

`logutils` is confined to `logs.go`, and there are 14 level-prefixed
`log.Printf` calls across 6 files. That is the whole surface.

A slog migration would replace `newLogFilter`'s body and drop the `[DEBUG]`
prefix constant, since slog carries the level as a value rather than as text
inside the message. The signature maps over cleanly though: `(level string, w
io.Writer) (slog.Handler, error)`, and the `error` return stays earned because
`slog.Level.UnmarshalText` does not know `TRACE`.

The tests here are meant to help rather than get in the way. Their tables say
which levels emit what, which is a statement about behaviour and not about
logutils, so they port as-is with a few lines of plumbing changed per test.
Nothing pinned that contract before, so a migration that quietly broke level
gating had nothing to fail against.

Worth knowing before starting: slog has no `TRACE` level, so goss would need a
custom `slog.Level(-8)`, and the level list in `docs/cli.md` wants another pass
at the same time.

## Testing

Each new test was run against the pre-fix code and fails there:

- `outputs/color_test.go` exercises every outputer concurrently
- `serve_concurrency_test.go` drives the health handler from 16 goroutines
- `logs_test.go` pins which levels mute the cache-miss line, and checks the
  documented levels behave the way `docs/cli.md` says they do

Also run: `gofmt`, `go vet`, `golangci-lint v2.12.2` (0 issues),
`markdownlint-cli2`, `go test -race -count=2 ./...`.

<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1092.org.readthedocs.build/en/1092/

<!-- readthedocs-preview goss end -->