### PR TITLE
docs: explain that an empty matcher list asserts nothing

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -173,6 +173,20 @@ command:
 
 `stdout` and `stderr` can be a string or [pattern](#patterns)
 
+!!! warning "An empty list asserts nothing"
+
+    A list of patterns is a list of conditions that must all be satisfied. An
+    empty list is therefore zero conditions, and always passes:
+
+    ```yaml
+    stderr: []   # asserts nothing; passes even when stderr has output
+    stderr: ""   # asserts stderr is empty
+    ```
+
+    This is why `goss add` writes `stderr: ""` rather than `stderr: []` when a
+    command produced no error output. Use `[]` only where you deliberately want
+    no assertion at all.
+
 The `exec` attribute is the command to run; this defaults to the name of
 the hash for backwards compatibility
 
@@ -277,6 +291,14 @@ file:
 ```
 
 `contents` can be a string or a [pattern](#patterns)
+
+!!! warning "An empty list asserts nothing"
+
+    As with [`stdout` and `stderr`](#command), `contents: []` is a list of zero
+    conditions and always passes. `goss add file` writes it to record that it
+    captured no content expectation, so it is normal in generated gossfiles —
+    but it does not check that the file is empty. To assert emptiness, use
+    `contents: ""`.
 
 ### gossfile
 


### PR DESCRIPTION
Refs #1095

## Why docs rather than a behaviour change

#1095 is a real trap and the report is accurate: `stderr: []` looks like "assert stderr is empty" and asserts nothing. `isSet` in `resource/resource.go` returns false for a zero-length list, so the property is treated as absent and no check is ever created — the run reports `Count: 1` where you would expect 2.

The issue proposes making it an error instead. I started down that path and stopped, because an empty matcher list is **generated by goss itself** and is load-bearing in this repo:

```console
$ goss add file /etc/hosts
file:
    /etc/hosts:
        exists: true
        ...
        contents: []
```

`resource/file.go:125` sets `Contents: []string{}` for exactly this reason, and the generated form is checked in as expected output at `integration-tests/goss/rockylinux9/goss-expected-q.yaml`. `stderr: []` and friends also appear in `testdata/passing.goss.yaml`, `testdata/failing.goss.yaml`, `integration-tests/goss/goss-shared.yaml`, `goss-dummy.yaml`, and `goss-serve.yaml`.

So rejecting `[]` would make `goss add file` emit an immediately-invalid gossfile, break goss's own fixtures and integration tests, and break every user config produced by `goss add`. `[]` is not a mistake in this design — it is how "no expectation recorded" is written.

Worth noting that `goss add command` already writes `stderr: ""` when a command produced no error output, which is the assert-empty form. The two generators disagree, and that inconsistency is most of why the distinction is easy to miss.

That leaves the actual gap: the docs never say any of this. The `command` example uses `stderr: []` with no explanation, and neither `stdout`/`stderr` nor `contents` mentions that `""` and `[]` mean different things.

## What this adds

Two admonitions in `docs/gossfile.md`, one under `command` and one under `file`, stating that an empty list is zero conditions and always passes, and pointing at `""` for asserting emptiness. Both use the existing `!!! warning` style already used elsewhere in that file.

## Verified

Everything asserted above was run locally against `master` at `056389c`:

| Config | Result |
| --- | --- |
| `stderr: []` against a command writing to stderr | `Count: 1, Failed: 0` — passes, no check created |
| `stderr: ""` against the same command | `Count: 2, Failed: 1` — fails correctly |
| `contents: []` against a non-empty file | `Count: 1, Failed: 0` — passes |
| `contents: ""` against the same file | `Count: 2, Failed: 1` — fails correctly |

`npx markdownlint-cli2 "docs/**/*.md"` reports 0 issues in 14 files, matching the `DavidAnson/markdownlint-cli2-action` step in `.github/workflows/docs.yaml`.

## If you would rather change the behaviour

Happy to follow up if you want code as well. The least disruptive option I can see is a warning rather than an error, but it would fire on every `goss add`-generated file until the generator changed too, so it needs a decision about `goss add file` first. Your call — I did not want to guess at that in a first PR.

## AI assistance

This contribution was prepared with AI assistance. Every command and result quoted above was run locally.


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1096.org.readthedocs.build/en/1096/

<!-- readthedocs-preview goss end -->